### PR TITLE
Meter tariff manager error logging bug fix

### DIFF
--- a/app/models/meter_attributes.rb
+++ b/app/models/meter_attributes.rb
@@ -321,7 +321,7 @@ class MeterAttributes
   end
 
   class SolarPVMeterMapping < MeterAttributeTypes::AttributeBase
-  
+
     id                  :solar_pv_mpan_meter_mapping
     aggregate_over      :solar_pv_mpan_meter_mapping
     name                'Solar PV MPAN Meter mapping'
@@ -640,7 +640,7 @@ class MeterAttributes
       }
     )
   end
-  
+
   def self.default_flat_rate
     MeterAttributeTypes::Hash.define(
       required: false,

--- a/app/models/tariffs/max_monthly_demand_charges_base.rb
+++ b/app/models/tariffs/max_monthly_demand_charges_base.rb
@@ -6,8 +6,8 @@ class MaxMonthlyDemandChargesBase
   end
 
   def max_demand_for_month_kw(date, amr_data)
-    start_of_month = DateTimeHelper.first_day_of_month(date)
-    end_of_month = DateTimeHelper.last_day_of_month(date)
+    start_of_month = [@amr_data.start_date, DateTimeHelper.first_day_of_month(date)].max
+    end_of_month =  [@amr_data.end_date, DateTimeHelper.last_day_of_month(date)].min
     @month_max_demand_kw_cache[start_of_month] ||= calculate_max_demand_kw(amr_data, start_of_month, end_of_month)
   end
 

--- a/app/models/tariffs/max_monthly_demand_charges_base.rb
+++ b/app/models/tariffs/max_monthly_demand_charges_base.rb
@@ -6,8 +6,8 @@ class MaxMonthlyDemandChargesBase
   end
 
   def max_demand_for_month_kw(date, amr_data)
-    start_of_month = [@amr_data.start_date, DateTimeHelper.first_day_of_month(date)].max
-    end_of_month =  [@amr_data.end_date, DateTimeHelper.last_day_of_month(date)].min
+    start_of_month = DateTimeHelper.first_day_of_month(date)
+    end_of_month = DateTimeHelper.last_day_of_month(date)
     @month_max_demand_kw_cache[start_of_month] ||= calculate_max_demand_kw(amr_data, start_of_month, end_of_month)
   end
 

--- a/app/models/tariffs/meter_tariff_manager.rb
+++ b/app/models/tariffs/meter_tariff_manager.rb
@@ -282,10 +282,9 @@ class MeterTariffManager
     date.saturday? || date.sunday?
   end
 
-  def raise_and_log_error(exception, message, data)
+  def raise_and_log_error(exception, message)
     logger.info message
     logger.info data
-    # TODO(PH, 3May2021) - uncomment once system wide accounting tariffs are released
-    # raise exception, message
+    raise exception, message
   end
 end

--- a/app/models/tariffs/transmission_network_use_of_system_demand_changes.rb
+++ b/app/models/tariffs/transmission_network_use_of_system_demand_changes.rb
@@ -139,7 +139,6 @@ class TNUOSCharges < MaxMonthlyDemandChargesBase
     triads = TRIAD_DATETIMES[year(date)]
     kws = triads.map do |dt|
       d, hh_index = DateTimeHelper.date_and_half_hour_index(dt)
-      puts "Got here #{d} #{hh_index} #{amr_data.kw(d, hh_index)}"
       amr_data.kw(d, hh_index)
     end
     kws.sum / 3.0

--- a/lib/dashboard/advice/activity_lists.rb
+++ b/lib/dashboard/advice/activity_lists.rb
@@ -32,7 +32,6 @@ class ActivityLists
   end
 
   def self.activity_reference_html(activity)
-    puts "Got herev #{activity}"
     link = %(
       <a href="https://energysparks.uk/activity_types/<%= activity[:number] %>" target ="_blank"><%= activity[:name] %></a>
     )

--- a/lib/dashboard/advice/advice_baseload.rb
+++ b/lib/dashboard/advice/advice_baseload.rb
@@ -41,7 +41,7 @@ class AdviceBaseload < AdviceElectricityBase
       charts_and_html.push( { type: :html,  content: longterm_chart_trend_should_be_downwards } )
     end
 
-    ap analysis_of_baseload(@school.aggregated_electricity_meters).flatten
+    # ap analysis_of_baseload(@school.aggregated_electricity_meters).flatten
 
     charts_and_html += analysis_of_baseload(@school.aggregated_electricity_meters).flatten
 

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -9,7 +9,7 @@ script = {
                               'combe*', 'catsfield', 'miller*','tomnac*',
                               'king-e*'
                             ],
-  schools: ['*'],
+  schools: ['king-james-3*'],
   source:                   :unvalidated_meter_data,
   logger2:                  { name: "./log/pupil dashboard %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
   adult_dashboard:          {

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -9,7 +9,7 @@ script = {
                               'combe*', 'catsfield', 'miller*','tomnac*',
                               'king-e*'
                             ],
-  schools: ['bath*'],
+  schools: ['*'],
   source:                   :unvalidated_meter_data,
   logger2:                  { name: "./log/pupil dashboard %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
   adult_dashboard:          {

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -20,8 +20,7 @@ script = {
                                 summarise_differences: true,
                                 report_failed_charts:   :summary, # :detailed
                                 user: { user_role: :analytics, staff_role: nil },
-                                pages: %i[baseload],
-                                no_pages: %i[electricity_profit_loss gas_profit_loss],
+                                pages: %i[electricity_profit_loss gas_profit_loss baseload],
                                 no_pages1: %i[gas_out_of_hours],
                                 compare_results: [
                                   { comparison_directory: 'C:\Users\phili\Documents\TestResultsDontBackup\AdultDashboard\Base' },

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -9,7 +9,7 @@ script = {
                               'combe*', 'catsfield', 'miller*','tomnac*',
                               'king-e*'
                             ],
-  schools: ['all-sain*'],
+  schools: ['bath*'],
   source:                   :unvalidated_meter_data,
   logger2:                  { name: "./log/pupil dashboard %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
   adult_dashboard:          {

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -9,7 +9,7 @@ script = {
                               'combe*', 'catsfield', 'miller*','tomnac*',
                               'king-e*'
                             ],
-  schools: ['king-james-3*'],
+  schools: ['all-sain*'],
   source:                   :unvalidated_meter_data,
   logger2:                  { name: "./log/pupil dashboard %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
   adult_dashboard:          {


### PR DESCRIPTION
This is derived from aws-eb-test. includes the meter_tariff_manager argument error bug fix, plus removal of debugging.

There is a persistent github merge failure with excess_availability_charge which keeps getting duplicated its hash, will fix once all of the analytics charges have migrated to master.

Keep getting 'Analysis page raised error: wrong number of arguments (given 3, expected 2)' when selecting an analysis baseload page e.g. https://test.energysparks.uk/schools/bathampton-primary-school/analysis/904609 - which I think is an issue for all schools, which I can't replicate  for any school in my analytics test environment using aws-eb-test, so I am confused?

Could you integrate this branch into test, please?