### PR TITLE
Improvements to baseload analysis presentation

### DIFF
--- a/lib/dashboard/advice/advice_baseload.rb
+++ b/lib/dashboard/advice/advice_baseload.rb
@@ -43,7 +43,7 @@ class AdviceBaseload < AdviceElectricityBase
 
     # ap analysis_of_baseload(@school.aggregated_electricity_meters).flatten
 
-    charts_and_html += analysis_of_baseload(@school.aggregated_electricity_meters).flatten
+    # charts_and_html += analysis_of_baseload(@school.aggregated_electricity_meters).flatten
 
     charts_and_html += baseload_charts_for_real_meters if @school.electricity_meters.length > 1
 

--- a/lib/dashboard/advice/advice_baseload_commentary.rb
+++ b/lib/dashboard/advice/advice_baseload_commentary.rb
@@ -32,7 +32,7 @@ class AdviceBaseloadCommentary
         start_ratings_html(alert.rating)
       ]
     end
-    HtmlTableFormatting.new(header, rows).html(right_justified_columns: [2])
+    HtmlTableFormatting.new(header, rows).html(right_justified_columns: [2], widths: [nil, nil, nil, '"15%"'])
   end
 
   private
@@ -125,7 +125,7 @@ class AdviceBaseloadCommentary
       <p>
         A more detailed explanation of how to interpret the charts and the analysis,
         and what to do next is available
-        <a href="https://docs.google.com/document/d/1MvhMHdWaSrzmvjp4TaHJPWfDcw37xMEjFufn_kR6j-A/edit?usp=sharing" target ="_blank">here</a>.
+        <a href="http://blog.energysparks.uk/wp-content/uploads/2021/07/Baseload-User-Documentation.pdf" target ="_blank">here</a>.
       </p>
     )
     ERB.new(text).result(binding)

--- a/lib/dashboard/alerts/alert_change_in_electricity_baseload_short_term.rb
+++ b/lib/dashboard/alerts/alert_change_in_electricity_baseload_short_term.rb
@@ -123,7 +123,7 @@ class AlertChangeInElectricityBaseloadShortTerm < AlertBaseloadBase
                 You have been doing well recently, your baseload last week was <%= format_kw(average_baseload_last_week_kw) %>
                 compared with <%= format_kw(average_baseload_last_year_kw) %> on average over the last year.
               <% else %>
-              You baseload has increase, last week it was <%= format_kw(average_baseload_last_week_kw) %>
+              Your baseload has increased, last week it was <%= format_kw(average_baseload_last_week_kw) %>
               compared with <%= format_kw(average_baseload_last_year_kw) %> on average over the last year.
               <% end %>
             )

--- a/lib/dashboard/alerts/alert_electricity_baseload_versus_benchmark.rb
+++ b/lib/dashboard/alerts/alert_electricity_baseload_versus_benchmark.rb
@@ -151,7 +151,7 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
   def evaluation_html
     text = %(
               <% if average_baseload_last_year_kw < benchmark_per_pupil_kw %>
-                You are doing well your average annual baseload is
+                You are doing well, your average annual baseload is
                 <%= format_kw(average_baseload_last_year_kw) %> compared with a
                 well managed school of a similar size's
                 <%= format_kw(benchmark_per_pupil_kw) %> and

--- a/lib/dashboard/alerts/alert_intraweek_baseload_variation.rb
+++ b/lib/dashboard/alerts/alert_intraweek_baseload_variation.rb
@@ -93,7 +93,7 @@ class AlertIntraweekBaseloadVariation < AlertBaseloadBase
   def evaluation_html
     text = %(
               <% if rating > 4 %>
-                You are doing <%= adjective %> there is limited variation between weekday and weekend usage.
+                You are doing <%= adjective %>, there is limited variation between weekday and weekend usage.
                 You highest average daily usage occurs on <%= max_day_str %> of <%= format_kw(max_day_kw) %>,
                 and your lowest on <%= min_day_str %> of <%= format_kw(min_day_kw) %>.
               <% else %>

--- a/lib/dashboard/alerts/alert_seasonal_baseload_variation.rb
+++ b/lib/dashboard/alerts/alert_seasonal_baseload_variation.rb
@@ -74,7 +74,7 @@ class AlertSeasonalBaseloadVariation < AlertBaseloadBase
   def evaluation_html
     text = %(
               <% if rating > 4 %>
-                You are doing <%= adjective %> there is limited variation between seasons.
+                You are doing <%= adjective %>, there is limited variation between seasons.
                 Your average usage in the winter is <%= format_kw(winter_kw) %> and
                 <%= format_kw(summer_kw) %> in the summer.
               <% else %>

--- a/lib/dashboard/charting_and_reports/html_table_formatting.rb
+++ b/lib/dashboard/charting_and_reports/html_table_formatting.rb
@@ -9,14 +9,14 @@ class HtmlTableFormatting
     @precision = precision
   end
 
-  def html(right_justified_columns: [1..1000])
+  def html(right_justified_columns: [1..1000], widths: nil)
     template = %{
       <table class="table table-striped table-sm">
         <% unless @header.nil? %>
           <thead>
             <tr class="thead-dark">
-              <% @header.each do |header_titles| %>
-                <th scope="col" class="text-center"> <%= header_titles.to_s %> </th>
+              <% @header.each_with_index do |header_titles, column_number| %>
+                <th scope="col" class="text-center" <%= width(widths, column_number) %>> <%= header_titles.to_s %> </th>
               <% end %>
             </tr>
           </thead>
@@ -48,6 +48,11 @@ class HtmlTableFormatting
       <%= column_td(column_number, right_justified_columns) %><%= format_value(val, column_number) %> </td>
     }.gsub(/^  /, '')
     generate_html(template, binding)
+  end
+
+  private def width(widths, column_number)
+    return '' if widths.nil? || widths[column_number].nil?
+    "width=#{widths[column_number]}"
   end
 
   private def format_value(val, column_number)


### PR DESCRIPTION
Could you pull and integrate this branch, mainly cosmetic changes so low risk, and should be largely isolated to baseload analysis files, so should merge ok, and not impact other analysis.
- fixed % column width for ***** column - needs reviewing once in the front end
- improved advice text, typos
- removed spurious duplicate advice table
- advice as pdf, rather than gdoc