### PR TITLE
Billing tooltips v3

### DIFF
--- a/app/models/tariffs/meter_tariff_description.rb
+++ b/app/models/tariffs/meter_tariff_description.rb
@@ -5,6 +5,8 @@ class MeterTariffDescription
       rate(attribute_type)
     when /^Duos.*$/
       duos(attribute_type, school, meter)
+    when /^Climate.*$/
+      'Climate change levy - reflecting your carbon emissions'
     else
       nil
     end

--- a/app/models/tariffs/meter_tariff_manager.rb
+++ b/app/models/tariffs/meter_tariff_manager.rb
@@ -15,6 +15,7 @@
 # Summary: the manager selects the most relevant tariff for a given date
 #
 class MeterTariffManager
+  include Logging
   attr_reader :accounting_tariffs
 
   class MissingAccountingTariff                                   < StandardError; end
@@ -284,7 +285,6 @@ class MeterTariffManager
 
   def raise_and_log_error(exception, message)
     logger.info message
-    logger.info data
     raise exception, message
   end
 end

--- a/lib/dashboard/advice/costs/format_meter_tariffs.rb
+++ b/lib/dashboard/advice/costs/format_meter_tariffs.rb
@@ -249,9 +249,8 @@ class FormatMeterTariffs < DashboardChartAdviceBase
   
   def add_tooltips_to_table(table)
     table.map do |(tariff_type, rate)|
-      tooltip = MeterTariffDescription.description_html(@school, meter, tariff_type)
       [
-        tooltip.nil? ? tariff_type : info_button(tariff_type, tooltip),
+        MeterTariffDescription.short_description_html(@school, meter, tariff_type),
         rate
       ]
     end
@@ -270,14 +269,6 @@ class FormatMeterTariffs < DashboardChartAdviceBase
         FormatEnergyUnit.format(:£, rate, :html, false, false, :accountant) + '/kWh'
       ]
     end
-  end
-
-  # TODO(PH, 13Jul2021) - merge with idetnical version in meter_monthly_costs_advice once ok
-  def info_button(text, tooltip)
-    html = %(
-      <i class="fas fa-info-circle" data-toggle="tooltip" data-placement="top" title="<%= tooltip %>"><%= text %></i>
-    )
-    ERB.new(html).result(binding)
   end
 
   def if_not_full_tariff_coverage_html(tariff_info)

--- a/lib/dashboard/advice/costs/format_meter_tariffs.rb
+++ b/lib/dashboard/advice/costs/format_meter_tariffs.rb
@@ -241,8 +241,25 @@ class FormatMeterTariffs < DashboardChartAdviceBase
     rates.push(['', 'at weekends'    ]) if tariff.tariff[:weekend]
     rates.push(['', 'during weekdays']) if tariff.tariff[:weekday]
 
+    puts "Got here before"
+    ap rates
+    table = add_tooltips_to_table(rates)
+
+    puts "Got here after"
+    ap table
+
     header = ['Tariff type', 'Rate']
-    html_table(header, rates)
+    html_table(header, table)
+  end
+  
+  def add_tooltips_to_table(table)
+    table.map do |(tariff_type, rate)|
+      tooltip = MeterTariffDescription.description_html(@school, meter, tariff_type)
+      [
+        tooltip.nil? ? tariff_type : info_button(tariff_type, tooltip),
+        rate
+      ]
+    end
   end
 
   def climate_change_levy?(tariff)
@@ -258,6 +275,14 @@ class FormatMeterTariffs < DashboardChartAdviceBase
         FormatEnergyUnit.format(:£, rate, :html, false, false, :accountant) + '/kWh'
       ]
     end
+  end
+
+  # TODO(PH, 13Jul2021) - merge with idetnical version in meter_monthly_costs_advice once ok
+  def info_button(text, tooltip)
+    html = %(
+      <i class="fas fa-info-circle" data-toggle="tooltip" data-placement="top" title="<%= tooltip %>"><%= text %></i>
+    )
+    ERB.new(html).result(binding)
   end
 
   def if_not_full_tariff_coverage_html(tariff_info)

--- a/lib/dashboard/advice/costs/format_meter_tariffs.rb
+++ b/lib/dashboard/advice/costs/format_meter_tariffs.rb
@@ -241,12 +241,7 @@ class FormatMeterTariffs < DashboardChartAdviceBase
     rates.push(['', 'at weekends'    ]) if tariff.tariff[:weekend]
     rates.push(['', 'during weekdays']) if tariff.tariff[:weekday]
 
-    puts "Got here before"
-    ap rates
     table = add_tooltips_to_table(rates)
-
-    puts "Got here after"
-    ap table
 
     header = ['Tariff type', 'Rate']
     html_table(header, table)

--- a/lib/dashboard/advice/costs/meter_cost.rb
+++ b/lib/dashboard/advice/costs/meter_cost.rb
@@ -149,12 +149,12 @@ class MeterCost
 
   def intro_to_chart_2_year_comparison
     text = %{
-      <h2>Comparison of last 2 years costs for this meter</h2>
+      <h2>Comparison of last 2 years costs for this <%= @meter.fuel_type.to_s %> meter</h2>
       <p>
         This first chart compares your monthly consumption over the last 2 years
       </p>
     }
-    { type: :html, content: text }
+    { type: :html, content: ERB.new(text).result(binding) }
   end
 
   def intro_to_1_year_brokendown_chart

--- a/lib/dashboard/advice/costs/meter_cost.rb
+++ b/lib/dashboard/advice/costs/meter_cost.rb
@@ -137,8 +137,10 @@ class MeterCost
                 <p>          
                   Energy Sparks currently doesn't have a record of your real tariffs
                   and is using default tariffs between <%= group_missing_tariffs_text %>, 
-                  which means your billing won't be accurate. If you would like to help
-                  us setup your billing correctly, please get in touch by mailing
+                  which means your billing won't be accurate. To edit your tariffs go to the
+                  'Manage School' drop down menu above and select 'Manage tariffs'.
+                  If you would like to help us setup your billing correctly,
+                  please get in touch by mailing
                   <a href="mailto:hello@energysparks.uk?subject=Meter%20tariff%20information%20for%20<%= @school.name %>">mailto:hello@energysparks.uk</a>.                    
                 </p>
               }

--- a/lib/dashboard/advice/costs/meter_monthly_costs_advice.rb
+++ b/lib/dashboard/advice/costs/meter_monthly_costs_advice.rb
@@ -18,48 +18,8 @@ class MeterMonthlyCostsAdvice
 
   def add_tool_tips(header, school, meter)
     header.map do |column_heading|
-      tooltip = MeterTariffDescription.description_html(school, meter, column_heading)
-      # tooltip.nil? ? column_heading : to_tooltip_html(column_heading, tooltip)
-      tooltip.nil? ? column_heading : info_button(column_heading, tooltip)
+      MeterTariffDescription.short_description_html(school, meter, column_heading)
     end
-  end
-
-  # doesn't seem to work with front end bootstrap CSS
-  def to_tooltip_html_deprecated(column_heading_name, text)
-    "<button class=\"btn btn-secondary\" data-toggle=\"popover\" data-container=\"body\" data-placement=\"top\" data-title=\"Explanation\" data-content=\"#{text}\">#{column_heading_name}</button>"
-  end
-
-  # doesn't seem to work with front end bootstrap CSS
-  def to_tooltip_html(column_heading_name, text)
-    html = %(
-      <div class="tooltip"><%= column_heading_name %>
-        <span class="tooltiptext"><%= text %></span>
-      </div>
-    )
-    ERB.new(html).result(binding)
-  end
-
-  def info_button(text, tooltip)
-    html = %(
-      <i class="fas fa-info-circle" data-toggle="tooltip" data-placement="top" title="<%= tooltip %>"><%= text %></i>
-    )
-    ERB.new(html).result(binding)
-  end
-
-  def info_button_deprecated(text, tooltip)
-    html = %(
-      <span><%= text %><link href="https://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">
-      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
-      <div class="col-md-12">
-          <div class="info">
-            <i class="icon-info-sign"></i>
-            <span class="extra-info">
-              <%= tooltip %>
-            </span>
-          </div>
-      </div>
-    )
-    ERB.new(html).result(binding)
   end
 
   def row_to_£(row)
@@ -84,6 +44,10 @@ class MeterMonthlyCostsAdvice
   end
 
   private def reorder_columns(components)
+    sorted_list = components.sort_by { |column| column_order(column) }
+=begin
+    ap sorted_list
+
     # move to last 3 columns, in this order
     [:standing_charge, "vat@20%".to_sym, "vat@5%".to_sym, :variance_versus_last_year, :total].each do |column_type|
       if components.include?(column_type)
@@ -103,6 +67,48 @@ class MeterMonthlyCostsAdvice
     end
 
     components
+=end
+  end
+
+  # eccentrically sort columns logically for human consumption
+  def column_order(column)
+    return 0 if column == :flat_rate || column == "Flat Rate"
+    return 1 if column.match(/^\d\d:\d\d to \d\d:\d\d$/)
+    return 10 if column.to_s.downcase.match(/^climate.*$/)
+    
+    ordered_columns = {
+      'Feed in tariff levy' => 20,
+      :duos_green => 40,
+      :duos_amber => 50,
+      :duos_red => 60,
+
+      :tnuos => 90,
+
+      :agreed_availability_charge => 100,
+      :excess_availability_charge => 100,
+
+      :fixed_charge => 150,
+      :standing_charge => 160,
+      :site_fee => 165,
+
+      :settlement_agency_fee => 170,
+      :reactive_power_charge => 180,
+      
+      :nhh_automatic_meter_reading_charge => 200,
+      :data_collection_dcda_agent_charge => 210,
+      :nhh_metering_agent_charge => 220,
+      :meter_asset_provider_charge => 230,
+
+      'vat@5%'.to_sym => 300,
+      'vat@20%'.to_sym => 310,
+
+      :variance_versus_last_year => 400,
+      :total => 410
+    }
+
+    return ordered_columns[column] if ordered_columns.key?(column)
+
+    2000 # missing from list so put at end for the moment
   end
 
   def data_rows(up_to_13_most_recent_months, bill_components)

--- a/lib/dashboard/advice/costs/meter_monthly_costs_advice.rb
+++ b/lib/dashboard/advice/costs/meter_monthly_costs_advice.rb
@@ -41,6 +41,13 @@ class MeterMonthlyCostsAdvice
 
   def info_button(text, tooltip)
     html = %(
+      <i class="fas fa-info-circle" data-toggle="tooltip" data-placement="top" title="<%= tooltip %>"><%= text %></i>
+    )
+    ERB.new(html).result(binding)
+  end
+
+  def info_button_deprecated(text, tooltip)
+    html = %(
       <span><%= text %><link href="https://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">
       <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
       <div class="col-md-12">
@@ -56,9 +63,7 @@ class MeterMonthlyCostsAdvice
   end
 
   def row_to_£(row)
-    # Julian JH this is the problematic code indicative of BigDecimal leaking into the analytics
-    # row.map{ |value| value.is_a?(Numeric) ? format_£(value) : value }
-    row.map{ |value| value.is_a?(Float) ? format_£(value) : value }
+    row.map{ |value| value.is_a?(Numeric) ? format_£(value) : value }
   end
 
   def format_£(value)

--- a/lib/dashboard/advice/costs/meter_monthly_costs_advice.rb
+++ b/lib/dashboard/advice/costs/meter_monthly_costs_advice.rb
@@ -11,7 +11,7 @@ class MeterMonthlyCostsAdvice
     formatted_totals = row_to_£(totals)
     header = add_tool_tips(header, @school, @meter)
     html_table = HtmlTableFormatting.new(header, formatted_rows, formatted_totals)
-    html_table.html
+    html_table.html(scrollable: true)
   end
 
   private

--- a/lib/dashboard/charting_and_reports/html_table_formatting.rb
+++ b/lib/dashboard/charting_and_reports/html_table_formatting.rb
@@ -9,14 +9,24 @@ class HtmlTableFormatting
     @precision = precision
   end
 
-  def html(right_justified_columns: [1..1000])
+  def html(right_justified_columns: [1..1000], widths: nil, scrollable: false)
     template = %{
+      <% if scrollable %>
+        <style> 
+          .table_wrapper{
+              display: block;
+              overflow-x: auto;
+              white-space: nowrap;
+          }
+        </style>
+        <div class="table_wrapper">
+      <% end %>
       <table class="table table-striped table-sm">
         <% unless @header.nil? %>
           <thead>
             <tr class="thead-dark">
-              <% @header.each do |header_titles| %>
-                <th scope="col" class="text-center"> <%= header_titles.to_s %> </th>
+              <% @header.each_with_index do |header_titles, column_number| %>
+                <th scope="col" class="text-center" <%= width(widths, column_number) %>> <%= header_titles.to_s %> </th>
               <% end %>
             </tr>
           </thead>
@@ -38,6 +48,9 @@ class HtmlTableFormatting
           </tr>
         <% end %>
       </table>
+      <% if scrollable %>
+        </div> 
+      <% end %>
     }.gsub(/^  /, '')
 
     generate_html(template, binding)
@@ -48,6 +61,11 @@ class HtmlTableFormatting
       <%= column_td(column_number, right_justified_columns) %><%= format_value(val, column_number) %> </td>
     }.gsub(/^  /, '')
     generate_html(template, binding)
+  end
+
+  private def width(widths, column_number)
+    return '' if widths.nil? || widths[column_number].nil?
+    "width=#{widths[column_number]}"
   end
 
   private def format_value(val, column_number)

--- a/lib/dashboard/time_of_day.rb
+++ b/lib/dashboard/time_of_day.rb
@@ -26,6 +26,11 @@ class TimeOfDay
     @relative_time.to_time
   end
 
+  def self.parse(hh_mm)
+    h, m = hh_mm.split(':')
+    TimeOfDay.new(h.to_f, m.to_f)
+  end
+
   def on_30_minute_interval?
     [0, 30].include?(minutes)
   end


### PR DESCRIPTION
I have made the table scrollable, to see if that helps.

Would prefer not to re-orientate table as  you can't scan similar size values and totals at bottom aren't helpful, lots of other reasons which can be discussed.

We we see what this looks like on test. Looks ok in static HTML. Might also want to review, without scrollability, on a standard EDF complex tariff as there won't be quite so many columns.

Derived from last billing tooltips branch, but with table formatting from the last baseload branch which I don't think has been integrated in yet.