### PR TITLE
flexible start date, partial months

### DIFF
--- a/lib/dashboard/charting_and_reports/targeting and_tracking_monthly_table.rb
+++ b/lib/dashboard/charting_and_reports/targeting and_tracking_monthly_table.rb
@@ -108,7 +108,7 @@ class TargetingAndTrackingTable < ContentBase
   end
 
   def header
-    ['Month', header_months(data[:current_year_date_ranges])].flatten
+    ['Month', header_months(data[:current_year_date_ranges], data[:partial_months])].flatten
   end
 
   def calculate
@@ -129,8 +129,11 @@ class TargetingAndTrackingTable < ContentBase
     [ name, format_rows(data, datatype) ].flatten
   end
 
-  def header_months(dates)
-    dates.map{ |date_range| date_range.first.strftime('%b') }
+  def header_months(dates, partial_months)
+    dates.map.with_index do |date_range, index|
+      partial = partial_months[index] ? ' (partial)' : ''
+      date_range.first.strftime('%b') + partial
+    end
   end
 
   def format_rows(years_values, datatype = :kwh)

--- a/lib/dashboard/simulator/target_school.rb
+++ b/lib/dashboard/simulator/target_school.rb
@@ -116,7 +116,11 @@ class TargetMeter < Dashboard::Meter
     logger.info calc_text
   end
 
-  def target_start_date(date)
+  def target_start_date(end_date)
+    [end_date - 365, target.first_target_date, @original_meter.amr_data.start_date].max
+  end
+
+  def target_start_date_deprecated(date)
     academic_year = @meter_collection.holidays.calculate_academic_year_tolerant_of_missing_data(date)
     start_of_academic_year = Date.new(academic_year.start_date.year, academic_year.start_date.month, 1)
     target_start_date = target.first_target_date


### PR DESCRIPTION
- changed from academic year based start month, to first month of target, or first meter date, or end meter date minus 365 days whichever is the most recent
- added :partial_months to hash being returned for monthly target table