### PR TITLE
Fix sign of solar pv co2

### DIFF
--- a/lib/dashboard/aggregation/amr_data.rb
+++ b/lib/dashboard/aggregation/amr_data.rb
@@ -8,7 +8,6 @@ class AMRData < HalfHourlyData
 
   def initialize(type)
     super(type)
-    puts "Got here creating amr_data of type #{type}"
     @total = {}
   end
 
@@ -225,7 +224,7 @@ class AMRData < HalfHourlyData
     return self[date].one_day_kwh  if type == :kwh
     return @economic_tariff.one_day_total_cost(date) if type == :£ || type == :economic_cost
     return @accounting_tariff.one_day_total_cost(date) if type == :accounting_cost
-    return @carbon_emissions.one_day_total(date) if type == :co2
+    return co2_one_day(date) if type == :co2
   end
 
   private def co2_one_day(date)

--- a/lib/dashboard/charting_and_reports/management_summary_table.rb
+++ b/lib/dashboard/charting_and_reports/management_summary_table.rb
@@ -187,7 +187,8 @@ class ManagementSummaryTable < ContentBase
     scalar = ScalarkWhCO2CostValues.new(@school)
     consumption   = checked_get_aggregate({ year: 0}, :electricity, :co2)
     pv_production = checked_get_aggregate({ year: 0}, :solar_pv,    :co2)
-    net_co2 = consumption.nil? || pv_production.nil? ? nil : (consumption - pv_production)
+    # NB solar pv panel putput CO2 is -tve, sign reversed in AMRData
+    net_co2 = consumption.nil? || pv_production.nil? ? nil : (consumption + pv_production)
   end
 
   def comparison_out_of_date(period1, fuel_type, max_days_out_of_date)

--- a/lib/dashboard/charting_and_reports/scalar_kwh_co2_cost_values.rb
+++ b/lib/dashboard/charting_and_reports/scalar_kwh_co2_cost_values.rb
@@ -109,6 +109,7 @@ class ScalarkWhCO2CostValues
     dates = aggregator.x_axis_bucket_date_ranges
     check_dates(aggregator.last_meter_date, max_days_out_of_date)
     value = aggregator.valid ? aggregator.bucketed_data['Energy'][0] : nil
+    puts "Got here #{timescale} #{fuel_type}, #{data_type} #{dates[0][0]} #{dates[0][1]} = #{value.round(0)}"
     { value: value, start_date: dates[0][0], end_date: dates[0][1] }
   end
 

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -9,7 +9,7 @@ script = {
                               'combe*', 'catsfield', 'miller*','tomnac*',
                               'king-e*'
                             ],
-  schools: ['fresh*'],
+  schools: ['*'],
   source:                   :unvalidated_meter_data,
   logger2:                  { name: "./log/pupil dashboard %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
   adult_dashboard:          {
@@ -21,7 +21,7 @@ script = {
                                 report_failed_charts:   :summary, # :detailed
                                 user: { user_role: :analytics, staff_role: nil },
                                 no_pages: %i[electricity_profit_loss gas_profit_loss baseload],
-                                pages: %i[electric_target],
+                                no_pages: %i[electric_target],
                                 compare_results: [
                                   { comparison_directory: 'C:\Users\phili\Documents\TestResultsDontBackup\AdultDashboard\Base' },
                                   { output_directory:     'C:\Users\phili\Documents\TestResultsDontBackup\AdultDashboard\New' },

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -9,7 +9,7 @@ script = {
                               'combe*', 'catsfield', 'miller*','tomnac*',
                               'king-e*'
                             ],
-  schools: ['*'],
+  schools: ['fresh*'],
   source:                   :unvalidated_meter_data,
   logger2:                  { name: "./log/pupil dashboard %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
   adult_dashboard:          {
@@ -21,7 +21,7 @@ script = {
                                 report_failed_charts:   :summary, # :detailed
                                 user: { user_role: :analytics, staff_role: nil },
                                 no_pages: %i[electricity_profit_loss gas_profit_loss baseload],
-                                no_pages1: %i[gas_out_of_hours],
+                                pages: %i[electric_target],
                                 compare_results: [
                                   { comparison_directory: 'C:\Users\phili\Documents\TestResultsDontBackup\AdultDashboard\Base' },
                                   { output_directory:     'C:\Users\phili\Documents\TestResultsDontBackup\AdultDashboard\New' },

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -43,7 +43,7 @@ script = {
                 no_save_priority_variables:  { filename: './TestResults/alert priorities.csv' },
                 no_benchmark:          %i[school alert ], # detail],
                 # asof_date:          (Date.new(2018,6,14)..Date.new(2019,6,14)).each_slice(7).map(&:first),
-               asof_date:      Date.new(2021, 6, 20)
+               asof_date:      Date.new(2021, 7, 1)
               } 
   }
 }

--- a/script/standard/test_benchmarks.rb
+++ b/script/standard/test_benchmarks.rb
@@ -3,7 +3,7 @@ require_relative '../../lib/dashboard.rb'
 require_rel '../../test_support'
 ENV['ENERGYSPARKSTESTMODE'] = 'ON'
 
-run_date = Date.new(2021, 7, 10)
+run_date = Date.new(2021, 7, 1)
 
 script = {
   logger1:                  { name: TestDirectoryConfiguration::LOG + "/benchmark db %{time}.log", format: "%{severity.ljust(5, ' ')}: %{msg}\n" },


### PR DESCRIPTION
Fixed sign of solar pv in energy/co2 benchmark, from positive value to negative value. 

The issue manifested itself in the co2 change school comparison. Its a slightly philosophical question how you account for the CO2 from solar PV panels, so ultimately the values may change further, perhaps taking 40g/kWh embedded energy in manufacturing them.

There was is no impact to the co2 on the management summary table as its code had already corrected for the issue, but given this is a fundamental change lower down the code base which should correct in the charts etc., the management summary table adjustment was reversed to take into account the reversal in the underlying data.

Can you please install on test, then integrate to master, then release to production? And notify me when it goes to production as I need to notify the school/Paula who picked up the issue.