### PR TITLE
Targeting and tracking fitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Results/*
 DCC/*
 OldInputData/*
 OldMeterReadings/*
+Simulator/*
 documents/*
 TestResults/*
 BenchmarkLog/*

--- a/app/models/dashboard/estimated_period_consumption.rb
+++ b/app/models/dashboard/estimated_period_consumption.rb
@@ -1,0 +1,36 @@
+# estimate of meter kWh consumption in absence of 1/2 hourly readings
+# typically used by targeting and tracking system for setting
+# targets where there is < 1 year of half hourly data 
+class EstimatePeriodConsumption
+  def initialize(attributes)
+    @attributes = attributes
+  end
+
+  def annual_kwh
+    @annual_kwh ||= calculate_annual_kwh
+  end
+
+  private
+
+  def calculate_annual_kwh(end_date = nil)
+    reverse_sorted = @attributes.sort_by { |attribute| attribute[:start_date] }.reverse
+    end_date = reverse_sorted.first[:end_date]
+    start_date = end_date - 364
+
+    days = 0
+    kwh = 0.0
+
+    reverse_sorted.each do |attribute|
+      sd = [attribute[:start_date], start_date].max
+      ed = [attribute[:end_date], end_date].min
+      if sd <= ed
+        period_days = (attribute[:end_date] - attribute[:start_date]).to_i
+        overlap_days = (ed - sd).to_i
+        overlap_kwh  = attribute[:kwh] * overlap_days / period_days
+        kwh += overlap_kwh
+        days += overlap_days
+      end
+    end
+    kwh * 364 / days
+  end
+end

--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -75,6 +75,7 @@ module Dashboard
     end
 
     def enough_amr_data_to_set_target?
+      puts "Got here: this needs removing - as limits target setting for analysis pages"
       academic_year = @meter_collection.holidays.calculate_academic_year_tolerant_of_missing_data(amr_data.end_date)
       academic_year.start_date - 364 > amr_data.start_date
     end

--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -74,6 +74,11 @@ module Dashboard
       fa.round(0)
     end
 
+    def annual_kwh_estimate
+      return Float::NAN if @kwh_estimate.nil?
+      @kwh_estimate.annual_kwh
+    end
+
     def enough_amr_data_to_set_target?
       TargetMeter.enough_amr_data_to_set_target?(self)
     end
@@ -120,6 +125,7 @@ module Dashboard
       @solar_pv_overrides       = SolarPVPanels.new(attributes(:solar_pv_override), meter_collection.solar_pv) if @meter_attributes.key?(:solar_pv_override)
       @solar_pv_real_metering   = true if @meter_attributes.key?(:solar_pv_mpan_meter_mapping)
       @partial_meter_coverage ||= PartialMeterCoverage.new(attributes(:partial_meter_coverage))
+      @kwh_estimate = EstimatePeriodConsumption.new(attributes(:estimated_period_consumption)) if @meter_attributes.key?(:estimated_period_consumption)
       @meter_tariffs = MeterTariffManager.new(self)
     end
 

--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -75,9 +75,7 @@ module Dashboard
     end
 
     def enough_amr_data_to_set_target?
-      puts "Got here: this needs removing - as limits target setting for analysis pages"
-      academic_year = @meter_collection.holidays.calculate_academic_year_tolerant_of_missing_data(amr_data.end_date)
-      academic_year.start_date - 364 > amr_data.start_date
+      TargetMeter.enough_amr_data_to_set_target?(self)
     end
 
     def target_set?

--- a/app/models/meter_attributes.rb
+++ b/app/models/meter_attributes.rb
@@ -395,6 +395,21 @@ class MeterAttributes
     )
   end
 
+  class EstimatedPeriodConsumption < MeterAttributeTypes::AttributeBase
+
+    id :estimated_period_consumption
+    aggregate_over :estimated_period_consumption
+    name 'Estimated consumption for period in absence of amr data (typically a year)'
+
+    structure MeterAttributeTypes::Hash.define(
+      structure: {
+        start_date: MeterAttributeTypes::Date.define(required: true),
+        end_date:   MeterAttributeTypes::Date.define(required: true),
+        kwh:        MeterAttributeTypes::Float.define(required: true)
+      }
+    )
+  end
+
   class EconomicTariff < MeterAttributeTypes::AttributeBase
     id :economic_tariff
     key :economic_tariff

--- a/app/models/meter_collection.rb
+++ b/app/models/meter_collection.rb
@@ -57,6 +57,10 @@ class MeterCollection
     @cached_close_time = TimeOfDay.new(16, 30) # for speed
   end
 
+  def merge_additional_pseudo_meter_attributes(pseudo_meter_attributes)
+    @pseudo_meter_attributes = @pseudo_meter_attributes.deep_merge(pseudo_meter_attributes)
+  end
+
   def matches_identifier?(identifier, identifier_type)
     case identifier_type
     when :name

--- a/app/models/targets_progress.rb
+++ b/app/models/targets_progress.rb
@@ -1,7 +1,7 @@
 class TargetsProgress
   attr_reader :fuel_type
 
-  def initialize(fuel_type:, months:, monthly_targets_kwh:, monthly_usage_kwh:, monthly_performance:, cumulative_targets_kwh:, cumulative_usage_kwh:, cumulative_performance:)
+  def initialize(fuel_type:, months:, monthly_targets_kwh:, monthly_usage_kwh:, monthly_performance:, cumulative_targets_kwh:, cumulative_usage_kwh:, cumulative_performance:, partial_months:)
     @fuel_type = fuel_type
     @months = months
     @monthly_targets_kwh = monthly_targets_kwh
@@ -10,6 +10,7 @@ class TargetsProgress
     @cumulative_targets_kwh = cumulative_targets_kwh
     @cumulative_usage_kwh = cumulative_usage_kwh
     @cumulative_performance = cumulative_performance
+    @partial_months = partial_months
   end
 
   def monthly_targets_kwh
@@ -38,6 +39,10 @@ class TargetsProgress
 
   def current_cumulative_performance
     @cumulative_performance.compact.last
+  end
+
+  def partial_months
+    @partial_months
   end
 
   def months

--- a/app/models/targets_progress.rb
+++ b/app/models/targets_progress.rb
@@ -1,7 +1,9 @@
 class TargetsProgress
   attr_reader :fuel_type
 
-  def initialize(fuel_type:, months:, monthly_targets_kwh:, monthly_usage_kwh:, monthly_performance:, cumulative_targets_kwh:, cumulative_usage_kwh:, cumulative_performance:, partial_months:)
+  def initialize(fuel_type:, months:, monthly_targets_kwh:, monthly_usage_kwh:, monthly_performance:,
+                                      cumulative_targets_kwh:, cumulative_usage_kwh:, cumulative_performance:,
+                                      monthly_performance_versus_synthetic_last_year:, cumulative_performance_versus_synthetic_last_year:, partial_months:)
     @fuel_type = fuel_type
     @months = months
     @monthly_targets_kwh = monthly_targets_kwh
@@ -10,6 +12,8 @@ class TargetsProgress
     @cumulative_targets_kwh = cumulative_targets_kwh
     @cumulative_usage_kwh = cumulative_usage_kwh
     @cumulative_performance = cumulative_performance
+    @monthly_performance_versus_synthetic_last_year = monthly_performance_versus_synthetic_last_year
+    @cumulative_performance_versus_synthetic_last_year = cumulative_performance_versus_synthetic_last_year
     @partial_months = partial_months
   end
 
@@ -23,6 +27,10 @@ class TargetsProgress
 
   def monthly_performance
     to_keyed_collection(months, @monthly_performance)
+  end
+
+  def monthly_performance_versus_synthetic_last_year
+    to_keyed_collection(months, @monthly_performance_versus_synthetic_last_year)
   end
 
   def cumulative_targets_kwh
@@ -39,6 +47,14 @@ class TargetsProgress
 
   def current_cumulative_performance
     @cumulative_performance.compact.last
+  end
+
+  def cumulative_performance_versus_synthetic_last_year
+    to_keyed_collection(months, @cumulative_performance_versus_synthetic_last_year)
+  end
+
+  def current_cumulative_performance_versus_synthetic_last_year
+    @cumulative_performance_versus_synthetic_last_year.compact.last
   end
 
   def partial_months

--- a/app/services/aggregation_service.rb
+++ b/app/services/aggregation_service.rb
@@ -270,7 +270,7 @@ class AggregateDataService
         name: combined_name,
         floor_area: combined_floor_area,
         number_of_pupils: combined_pupils,
-        meter_attributes: @meter_collection.pseudo_meter_attributes(:"aggregated_#{fuel_type}")
+        meter_attributes: @meter_collection.pseudo_meter_attributes(Dashboard::Meter.aggregate_pseudo_meter_attribute_key(fuel_type))
       )
 
       combined_meter.add_aggregate_partial_meter_coverage_component(list_of_meters.map{ |m| m.partial_meter_coverage})

--- a/app/services/targets_service.rb
+++ b/app/services/targets_service.rb
@@ -21,6 +21,25 @@ class TargetsService
     )
   end
 
+  def relevance
+    aggregate_meter.nil? ? :never_relevant : :relevant
+  end
+
+  def enough_data # or recent enough
+    aggregate_meter.enough_amr_data_to_set_target? ? :enough : :not_enough
+  end
+
+  def annual_kwh_estimate_required?
+    TargetMeter.annual_kwh_estimate_required?(aggregate_meter)
+  end
+
+  # for backwards compatibility
+  # schools without meter attributes set
+  # may not be needed by front end
+  def target_set?
+    aggregate_meter.target_set?
+  end
+
   def culmulative_progress_chart
     case @fuel_type
     when :electricity
@@ -66,5 +85,17 @@ class TargetsService
 
   def data
     @data ||= CalculateMonthlyTrackAndTraceData.new(@aggregate_school, @fuel_type).raw_data
+  end
+
+  def target_school
+    @target_school ||= @aggregate_school.target_school
+  end
+
+  def target_meter
+    @target_meter ||= target_school.aggregate_meter(@fuel_type)
+  end
+
+  def aggregate_meter
+    @aggregate_meter ||= @aggregate_school.aggregate_meter(@fuel_type)
   end
 end

--- a/app/services/targets_service.rb
+++ b/app/services/targets_service.rb
@@ -13,7 +13,8 @@ class TargetsService
       monthly_performance: data_series(:monthly_performance),
       cumulative_targets_kwh: data_series(:full_cumulative_targets_kwhs),
       cumulative_usage_kwh: data_series(:full_cumulative_current_year_kwhs),
-      cumulative_performance: data_series(:cumulative_performance)
+      cumulative_performance: data_series(:cumulative_performance),
+      partial_months: data_series(:partial_months)
     )
   end
 

--- a/app/services/targets_service.rb
+++ b/app/services/targets_service.rb
@@ -21,6 +21,39 @@ class TargetsService
     )
   end
 
+  def culmulative_progress_chart
+    case @fuel_type
+    when :electricity
+      :targeting_and_tracking_weekly_electricity_to_date_cumulative_line
+    when :gas
+      :targeting_and_tracking_weekly_gas_to_date_cumulative_line
+    when :storage_heater
+      :targeting_and_tracking_weekly_storage_heater_to_date_cumulative_line
+    end
+  end
+
+  def weekly_progress_chart
+    case @fuel_type
+    when :electricity
+      :targeting_and_tracking_weekly_electricity_to_date_line
+    when :gas
+      :targeting_and_tracking_weekly_gas_one_year_line
+    when :storage_heater
+      :targeting_and_tracking_weekly_storage_heater_one_year_line
+    end
+  end
+
+  def weekly_progress_to_date_chart
+    case @fuel_type
+    when :electricity
+      :targeting_and_tracking_weekly_electricity_one_year_line
+    when :gas
+      :targeting_and_tracking_weekly_gas_one_year_line
+    when :storage_heater
+      :targeting_and_tracking_weekly_storage_heater_one_year_line
+    end
+  end
+
   private
 
   def data_headers

--- a/app/services/targets_service.rb
+++ b/app/services/targets_service.rb
@@ -14,6 +14,9 @@ class TargetsService
       cumulative_targets_kwh: data_series(:full_cumulative_targets_kwhs),
       cumulative_usage_kwh: data_series(:full_cumulative_current_year_kwhs),
       cumulative_performance: data_series(:cumulative_performance),
+      monthly_performance_versus_synthetic_last_year: data_series(:monthly_performance_versus_last_year),
+      cumulative_performance_versus_synthetic_last_year: data_series(:cumulative_performance_versus_last_year),
+
       partial_months: data_series(:partial_months)
     )
   end

--- a/lib/dashboard/advice/advice_targets.rb
+++ b/lib/dashboard/advice/advice_targets.rb
@@ -1,6 +1,7 @@
 
 require_relative './advice_general.rb'
 class AdviceTargets < AdviceBase
+  MAX_DAYS_OUT_OF_DATE_FOR_TARGETS = 30
   def initialize(school, fuel_type)
     super(school)
     @fuel_type = fuel_type
@@ -11,7 +12,8 @@ class AdviceTargets < AdviceBase
   end
 
   def relevance
-    (!aggregate_meter.nil? && aggregate_meter.target_set?) ? :relevant : :never_relevant
+    rel = !aggregate_meter.nil? && aggregate_meter.target_set? && aggregate_meter.amr_data.end_date > (Date.today - MAX_DAYS_OUT_OF_DATE_FOR_TARGETS)
+    rel ? :relevant : :never_relevant
   end
 
   def content(user_type: nil)

--- a/lib/dashboard/aggregation/amr_bad_data_types.rb
+++ b/lib/dashboard/aggregation/amr_bad_data_types.rb
@@ -66,6 +66,7 @@ class OneDayAMRReading
     'PSTD'  => { name: 'Partial data for end date - ignoring'},
     'PETD'  => { name: 'Partial data for end date - ignoring'},
     'DCCP'  => { name: 'Partial DCC data for interpolation'},
+    'COVD'  => { name: '3rd lockdown COVID adjustment T&T system'},
   }.freeze
 
   # allow access until front end changes made

--- a/lib/dashboard/alerts/common/alert_targets.rb
+++ b/lib/dashboard/alerts/common/alert_targets.rb
@@ -10,6 +10,11 @@ class AlertTargetBase < AlertAnalysisBase
     aggregate_meter.enough_amr_data_to_set_target? ? :enough : :not_enough
   end
 
+
+  def valid_alert?
+    super && enough_data == :enough
+  end
+
   def relevance
     (!aggregate_meter.nil? && aggregate_meter.target_set?) ? :relevant : :never_relevant
   end
@@ -362,11 +367,8 @@ class AlertTargetBase < AlertAnalysisBase
     saving..saving
   end
 
-  def academic_year
-    @academic_year ||= @school.holidays.calculate_academic_year_tolerant_of_missing_data(maximum_alert_date)
-  end
-
   def previous_year_total(datatype)
+    return nil if previous_year_start_date < aggregate_meter.amr_data.start_date
     total(false, previous_year_start_date, previous_year_end_date, datatype)
   end
 

--- a/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator.rb
+++ b/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator.rb
@@ -162,42 +162,8 @@ class AlertSolarPVBenefitEstimator < AlertElectricityOnlyBase
     scenarios
   end
 
-  # specialize Ruby built-in to reduce computational requirement
-  # the original implementation is rubbish as the logging function
-  # calls the proc 4 times adding +130% to the overall computational
-  # requirement! Changed covergence evaluation to be more efficient
-  # as payback function not 100% compliant with bisection functional
-  # requirements, also only requires 2 rather than 3 payback calls
-  # which are computationally intensive
-  class PVOptimumPayback < Minimization::Bisection
-    def initialize(lower, upper, proc)
-      super(lower, upper, proc)
-      @max_iteration = 10
-      @epsilon = 1.0
-    end
-
-    def iterate
-      ax = @lower
-      cx = @upper
-      k = 0
-      while (ax - cx).abs > @epsilon and k < @max_iteration
-        bx = (ax + cx) / 2.0
-        fb1 = f(bx - @epsilon / 2.0)
-        fb2 = f(bx + @epsilon / 2.0)
-        if fb2 > fb1
-          cx = bx
-        else
-          ax = bx
-        end
-        k += 1
-      end
-      @x_minimum = (ax + cx) / 2.0
-      @f_minimum = f(@x_minimum)
-    end
-  end
-
   def optimum_payback(asof_date)
-    optimum = PVOptimumPayback.minimize(1, max_possible_kwp) {|kwp| payback(kwp, asof_date) }
+    optimum = Minimiser.minimize(1, max_possible_kwp) {|kwp| payback(kwp, asof_date) }
     [optimum.x_minimum, optimum.f_minimum]
   end
 

--- a/lib/dashboard/charting_and_reports/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/chart_configuration.rb
@@ -201,8 +201,27 @@ class ChartManager
       timescale:        :up_to_a_year
     },
 
+    targeting_and_tracking_weekly_electricity_to_date_column_deprecated: {
+      name:           :targeting_and_tracking_weekly_electricity_to_date_column.to_s,
+      chart1_type:    :column,
+      chart1_subtype: nil,
+      inherits_from: :targeting_and_tracking_weekly_electricity_to_date_line
+    },
+    targeting_and_tracking_weekly_electricity_one_year_column_deprecated: {
+      name:           :targeting_and_tracking_weekly_electricity_one_year_column.to_s,
+      target:             {calculation_type: :day, extend_chart_into_future: true},
+      inherits_from: :targeting_and_tracking_weekly_electricity_to_date_column
+    },
+
+    # ============================================================================================
+    # used by front end via targets_service.rb
+    targeting_and_tracking_weekly_electricity_to_date_cumulative_line: {
+      name:          'Cumulative progress versus target',
+      target:        {calculation_type: :day, extend_chart_into_future: false},
+      inherits_from: :targeting_and_tracking_weekly_electricity_one_year_cumulative_line
+    },
     targeting_and_tracking_weekly_electricity_to_date_line: {
-      name:             :targeting_and_tracking_weekly_electricity_to_date_line.to_s,
+      name:             'Weekly progress versus target',
       replace_series_label: [
         ['Energy:<school_name>: target', 'target'],
         ['Energy:<school_name>', 'actual']
@@ -215,183 +234,47 @@ class ChartManager
       target:             {calculation_type: :day, extend_chart_into_future: false},
       inherits_from:      :group_by_week_electricity
     },
-    targeting_and_tracking_weekly_electricity_to_date_column: {
-      name:           :targeting_and_tracking_weekly_electricity_to_date_column.to_s,
-      chart1_type:    :column,
-      chart1_subtype: nil,
-      inherits_from: :targeting_and_tracking_weekly_electricity_to_date_line
-    },
-
     targeting_and_tracking_weekly_electricity_one_year_line: {
-      name:           :targeting_and_tracking_weekly_electricity_one_year_line.to_s,
+      name:           'Weekly progress versus target to date',
       target:             {calculation_type: :day, extend_chart_into_future: true},
       inherits_from: :targeting_and_tracking_weekly_electricity_to_date_line
     },
-    targeting_and_tracking_weekly_electricity_one_year_column: {
-      name:           :targeting_and_tracking_weekly_electricity_one_year_column.to_s,
-      target:             {calculation_type: :day, extend_chart_into_future: true},
-      inherits_from: :targeting_and_tracking_weekly_electricity_to_date_column
+
+    targeting_and_tracking_weekly_gas_to_date_cumulative_line: {
+      inherits_from: :targeting_and_tracking_weekly_electricity_to_date_cumulative_line,
+      meter_definition:   :allheat
+    },
+    targeting_and_tracking_weekly_gas_to_date_line: {
+      inherits_from: :targeting_and_tracking_weekly_electricity_to_date_line,
+      meter_definition:   :allheat
+    },
+    targeting_and_tracking_weekly_gas_one_year_line: {
+      inherits_from: :targeting_and_tracking_weekly_electricity_one_year_line,
+      meter_definition:   :allheat
     },
 
+    targeting_and_tracking_weekly_storage_heater_to_date_cumulative_line: {
+      inherits_from: :targeting_and_tracking_weekly_electricity_to_date_cumulative_line,
+      meter_definition:   :storage_heater_meter
+    },
+    targeting_and_tracking_weekly_storage_heater_to_date_line: {
+      inherits_from: :targeting_and_tracking_weekly_electricity_to_date_line,
+      meter_definition:   :storage_heater_meter
+    },
+    targeting_and_tracking_weekly_storage_heater_one_year_line: {
+      inherits_from: :targeting_and_tracking_weekly_electricity_one_year_line,
+      meter_definition:   :storage_heater_meter
+    },
+
+    # inherited use only
     targeting_and_tracking_weekly_electricity_one_year_cumulative_line: {
       name:          :targeting_and_tracking_weekly_electricity_one_year_culmulative_line.to_s,
       cumulative:    true,
       inherits_from: :targeting_and_tracking_weekly_electricity_one_year_line
     },
-    targeting_and_tracking_weekly_electricity_to_date_cumulative_line: {
-      name:          :targeting_and_tracking_weekly_electricity_to_date_culmulative_line.to_s,
-      target:        {calculation_type: :day, extend_chart_into_future: false},
-      inherits_from: :targeting_and_tracking_weekly_electricity_one_year_cumulative_line
-    },
+    # ============================================================================================
+    # used by front end via targets_service.rb
 
-
-
-    deprecated_targeting_and_tracking_monthly_electricity: {
-      name:             'Ignore: required for the front end test framework to work',
-      x_axis:           :month,
-      timescale:        nil,
-      inherits_from:    :group_by_week_electricity
-    },
-    deprecated_targeting_and_tracking_monthly_electricity_internal_calculation_cumulative: {
-      name:          'Used for internal tabular calculation - projected to end of target period - cumulative',
-      cumulative:    true,
-      inherits_from: :deprecated_targeting_and_tracking_monthly_electricity_internal_calculation
-    },
-    deprecated_targeting_and_tracking_monthly_electricity_internal_calculation_unextended: {
-      name:          'Used for internal tabular calculation - to recent available data 1',
-      x_axis:        :week,
-      target:        {calculation_type: :day, extend_chart_into_future: nil},
-      inherits_from: :deprecated_targeting_and_tracking_monthly_electricity_internal_calculation
-    },
-    deprecated_targeting_and_tracking_monthly_electricity_internal_calculation_unextended_column: {
-      name:          'deprecated_targeting_and_tracking_monthly_electricity_internal_calculation_unextended_column',
-      target:        {calculation_type: :day, extend_chart_into_future: nil},
-      chart1_type:   :column,
-      chart1_subtype: nil,
-      inherits_from: :deprecated_targeting_and_tracking_monthly_electricity_internal_calculation_unextended
-    },
-    deprecated_targeting_and_tracking_monthly_electricity_internal_calculation_unextended_day: {
-      name:          'Used for internal tabular calculation - to recent available data 2',
-      x_axis:        :day,
-      target:        {calculation_type: :day, extend_chart_into_future: nil},
-      inherits_from: :deprecated_targeting_and_tracking_monthly_electricity_internal_calculation_unextended
-    },
-    
-    deprecated_targeting_and_tracking_monthly_electricity_internal_calculation_unextended_cumulative: {
-      name:          'Used for internal tabular calculation - to recent available data - cumulative',
-      cumulative:    true,
-      inherits_from: :deprecated_targeting_and_tracking_monthly_electricity_internal_calculation_unextended
-    },
-    deprecated_targeting_and_tracking_monthly_electricity_internal_calculation_unextended_cumulative_day: {
-      cumulative:    true,
-      x_axis:        :day,
-      inherits_from: :deprecated_targeting_and_tracking_monthly_electricity_internal_calculation_unextended
-    },
-    deprecated_targeting_and_tracking_monthly_electricity_base: {
-      name:             'Tracking experiment (daily line)',
-      replace_series_label: [
-        ['Energy:<school_name>: target', 'Electricity: target'],
-        ['Energy:<school_name>', 'Electricity: actual']
-      ],
-      chart1_type:        :line,
-      series_breakdown:   :none,
-      x_axis:             :day,
-      nullify_zero_data:  true,
-      target:             {calculation_type: :day, extend_chart_into_future: true},
-      inherits_from:      :deprecated_targeting_and_tracking_monthly_electricity
-    },
-    deprecated_targeting_and_tracking_weekly_electricity_1_year_line: {
-      name:             'Weekly electricity targeting and tracking for this year',
-      x_axis:           :week,
-      inherits_from:    :deprecated_targeting_and_tracking_monthly_electricity_base
-    },
-    deprecated_targeting_and_tracking_weekly_electricity_1_year_column: {
-      name:             'Weekly electricity targeting and tracking for this year 2',
-      x_axis:           :week,
-      chart1_type:      :column,
-      inherits_from:    :deprecated_targeting_and_tracking_weekly_electricity_1_year_line
-    },
-    deprecated_targeting_and_tracking_weekly_electricity_1_year_column_unextended: {
-      name:             'Weekly electricity targeting and tracking for this year 3',
-      x_axis:           :week,
-      chart1_type:      :column,
-      target:            {calculation_type: :day, extend_chart_into_future: true},
-      inherits_from:    :deprecated_targeting_and_tracking_weekly_electricity_1_year_column
-    },
-    alert_deprecated_targeting_and_tracking_weekly_electricity_1_year: {
-      inherits_from:    :deprecated_targeting_and_tracking_weekly_electricity_1_year_line
-    },
-    deprecated_targeting_and_tracking_weekly_electricity_1_year_cumulative_line: {
-      name:             'Weekly electricity targeting and tracking for this year - cumulative',
-      cumulative:       true,
-      inherits_from:    :alert_deprecated_targeting_and_tracking_weekly_electricity_1_year
-    },
-    deprecated_targeting_and_tracking_monthly_electricity_experimental0: {
-      name:             'Tracking experiment (weekly line)',
-      x_axis:           :week,
-      inherits_from:    :deprecated_targeting_and_tracking_monthly_electricity
-    },
-    deprecated_targeting_and_tracking_monthly_electricity_experimental1: {
-      name:             'Tracking experiment (cumulative weekly line)',
-      x_axis:           :week,
-      cumulative:       true,
-      inherits_from:    :deprecated_targeting_and_tracking_monthly_electricity
-    },
-    deprecated_targeting_and_tracking_monthly_electricity_experimental_baseload: {
-      name:             'Tracking experiment (baseload kW)',
-      replace_series_label: [
-        ['BASELOAD:<school_name>: target', 'Baseload: target'],
-        ['BASELOAD:<school_name>', 'Baseload: actual']
-      ],
-      chart1_type:       :line,
-      yaxis_units:      :kw,
-      series_breakdown: :baseload,
-      inherits_from:    :deprecated_targeting_and_tracking_monthly_electricity_base
-    },
-    deprecated_targeting_and_tracking_monthly_electricity_experimental2: {
-      name:             'Tracking experiment 2 (datetime over a week)',
-      chart1_type:      :line,
-      x_axis:           :datetime,
-      timescale:        :week,
-      series_breakdown: :none,
-      target:           {calculation_type: :day},
-      inherits_from:    :deprecated_targeting_and_tracking_monthly_electricity
-    },
-    deprecated_targeting_and_tracking_monthly_electricity_experimental3: {
-      name:             'Tracking experiment 3 (datetime over a week - column)',
-      chart1_type:      :column,
-      chart1_subtype:   nil,
-      inherits_from:    :deprecated_targeting_and_tracking_monthly_electricity_experimental2
-    },
-    deprecated_targeting_and_tracking_monthly_electricity_experimental4: {
-      name:             'Tracking experiment 4 (day over a month - column)',
-      chart1_type:      :column,
-      chart1_subtype:   nil,
-      x_axis:           :day,
-      timescale:        :month,
-      inherits_from:    :deprecated_targeting_and_tracking_monthly_electricity_experimental2
-    },
-    deprecated_targeting_and_tracking_weekly_gas_1_year_column: {
-      name:             :deprecated_targeting_and_tracking_monthly_gas.to_s,
-      chart1_type:      :column,
-      meter_definition: :allheat,
-      inherits_from:    :deprecated_targeting_and_tracking_weekly_electricity_1_year_line
-    },
-    deprecated_targeting_and_tracking_weekly_gas_1_year_line: {
-      name:             :deprecated_targeting_and_tracking_monthly_gas.to_s,
-      chart1_type:      :line,
-      meter_definition: :allheat,
-      inherits_from:    :deprecated_targeting_and_tracking_weekly_electricity_1_year_line
-    },
-    deprecated_targeting_and_tracking_weekly_gas_1_year_cumulative: {
-      name:             :deprecated_targeting_and_tracking_weekly_gas_1_year_cumulative.to_s,
-      meter_definition: :allheat,
-      inherits_from:    :deprecated_targeting_and_tracking_weekly_electricity_1_year_cumulative_line
-    },
-    deprecated_targeting_and_tracking_monthly_gas_column: {
-      name:             :deprecated_targeting_and_tracking_monthly_gas_column.to_s,
-      inherits_from:    :deprecated_targeting_and_tracking_weekly_gas_1_year_column
-    },
     electricity_co2_last_year_weekly_with_co2_intensity: {
       name:             'The carbon emissions of your school and the carbon intensity of the National Electricity Grid over the last year',
       inherits_from:    :group_by_week_electricity,

--- a/lib/dashboard/charting_and_reports/targeting and_tracking_monthly_table.rb
+++ b/lib/dashboard/charting_and_reports/targeting and_tracking_monthly_table.rb
@@ -108,7 +108,7 @@ class TargetingAndTrackingTable < ContentBase
   end
 
   def header
-    ['Month', header_months(data[:current_year_date_ranges])].flatten
+    ['Month', header_months(data[:current_year_date_ranges], data[:partial_months])].flatten
   end
 
   def calculate
@@ -129,8 +129,11 @@ class TargetingAndTrackingTable < ContentBase
     [ name, format_rows(data, datatype) ].flatten
   end
 
-  def header_months(dates)
-    dates.map{ |date_range| date_range.first.strftime('%b') }
+  def header_months(dates, partial_months)
+    dates.map.with_index do |date_range, index|
+      partial = partial_months[index] ? ' (partial)' : ''
+      date_range.first.strftime('%b') + partial
+    end
   end
 
   def format_rows(years_values, datatype = :kwh)

--- a/lib/dashboard/charting_and_reports/targeting and_tracking_monthly_table_calculation.rb
+++ b/lib/dashboard/charting_and_reports/targeting and_tracking_monthly_table_calculation.rb
@@ -109,6 +109,7 @@ class CalculateMonthlyTrackAndTraceData
   end
 
   def target_meter
+    puts "Got here for fuel_type #{@fuel_type} got #{@school.target_school.aggregate_meter(@fuel_type)}"
     @school.target_school.aggregate_meter(@fuel_type)
   end
 end

--- a/lib/dashboard/data_sources/data/display_energy_certificates.rb
+++ b/lib/dashboard/data_sources/data/display_energy_certificates.rb
@@ -9,7 +9,6 @@ require 'json'
 require 'date'
 require 'logger'
 require 'faraday'
-require 'awesome_print'
 
 class DisplayEnergyCertificateJson
   def initialize(api_key = ENV['DECAPIKEY'])

--- a/lib/dashboard/data_sources/data/display_energy_certificates.rb
+++ b/lib/dashboard/data_sources/data/display_energy_certificates.rb
@@ -1,0 +1,170 @@
+# https://epc.opendatacommunities.org/docs/api/display
+# - only works for state schools in England and Wales
+# - schools sometimes split into multiple DECs - 1 for each building
+# - range of dates for each school/building - typically annually
+# - sometimes the kwh values aren't available, but can imply from co2
+# - only bulidings > 250 m2 require DECs
+# - they should be updated annually, but many aren't
+require 'json'
+require 'date'
+require 'logger'
+require 'faraday'
+require 'awesome_print'
+
+class DisplayEnergyCertificateJson
+  def initialize(api_key = ENV['DECAPIKEY'])
+    @api_key = api_key
+    @headers = {
+      'Authorization' => "Basic #{@api_key}",
+      'Accept'        => 'application/json',
+    }
+  end
+
+  def query_by_postcode(postcode)
+    url_postcode = postcode.gsub(' ', '%20')
+    url = "https://epc.opendatacommunities.org/api/v1/display/search?postcode=#{url_postcode}"
+    raw_data(url)
+  end
+
+  def raw_data(url)
+    uri = URI(url)
+    connection = Faraday.new(uri, headers: @headers)
+    response = connection.get
+    response.body.empty? ? {} : JSON.parse(response.body)
+  end
+end
+
+class DisplayEnergyCertificate
+  class UnexpectedDataType < StandardError; end
+  DEC_ELECTRICITY_CARBON_INTENSITY_KG_PER_KWH = 0.55
+  DEC_GAS_CARBON_INTENSITY_KG_PER_KWH = 0.195
+
+  def initialize(api_key = ENV['DECAPIKEY'])
+    @api_key = api_key
+  end
+
+  # returns hash: [building_reference] = { latest  data }, { year2 data }
+  def latest_data_by_building(postcode)
+    all = data_all_dates(postcode)
+    return {} if all.empty?
+
+    all.transform_values{ |v| v.last }
+  end
+
+  # returns hash: [building_reference] = { latest  data }, { year2 data }
+  def recent_data_by_building(postcode, recent_months: 9)
+    data  = latest_data_by_building(postcode)
+    return {} if data.empty?
+
+    dates = data.values.map{ |d| d[:date]}.sort
+    within_recent_months = dates.last - recent_months * 30
+    data.select { |building, d| d[:date] >= within_recent_months }
+  end
+
+  # returns hash of latest data for each building, aggregated across all buildings
+  def recent_aggregate_data(postcode)
+    data = recent_data_by_building(postcode)
+    return {} if data.empty?
+
+    arrayed_data = merge_data_into_arrays(data)
+
+    summed_data = sum_arrayed_data(arrayed_data)
+
+    summed_data[:buildings] = arrayed_data.values.first.length
+
+    summed_data
+  end
+
+  # returns hash: [building_reference] = [ { year1  data }, { year2 data } ]
+  def data_all_dates(postcode)
+    raw = DisplayEnergyCertificateJson.new(@api_key).query_by_postcode(postcode)
+    return [] if raw.empty?
+    data = raw['rows'].map do |year_of_data|
+      extract_useful_dec_data_1_year(year_of_data)
+    end
+
+    data.sort_by!{ |d| d[:date] }
+
+    by_building = {}
+    data.each do |building_year|
+      by_building[building_year[:building]] ||= []
+      by_building[building_year[:building]].push(building_year)
+    end
+    by_building
+  end
+
+  private
+
+  def extract_useful_dec_data_1_year(data)
+    floor_area = data['total-floor-area'].to_f
+    data = {
+      building:             data['building-reference-number'],
+      date:                 Date.parse(data['or-assessment-end-date']),
+      address:              data['address'] || [data['address1'],data['address2'], data['address3']].compact.join(', '),
+      name:                 data['address'].split(',').first,
+      postcode:             data['postcode'],
+      air_conditioning:     data['aircon-present'] == 'Yes',
+      electricity_kwh:      data['annual-electrical-fuel-usage'].to_f * floor_area,
+      electricity_co2:      data['electric-co2'].to_f * 1000.0,
+      heating_kwh:          data['annual-thermal-fuel-usage'].to_f * floor_area,
+      heating_co2:          data['heating-co2'].to_f * 1000.0,
+      renewables_kwh:       data['renewables-electrical'].to_f * floor_area,
+      renewable_heat_kwh:   data['renewables-fuel-thermal'].to_f * floor_area,
+      renewables_types:     data['renewable-sources'],
+      main_heating_fuel:    data['main-heating-fuel'],
+      other_heating_fuel:   data['other-fuel'],
+      floor_area:           floor_area,
+      rating:               data['operational-rating-band'],
+      environment:          data['building-environment'],
+      local_authority_name: data['local-authority-label']
+    }
+    add_missing_kwh_data(data)
+  end
+
+  def add_missing_kwh_data(data)
+    data[:calculated_electricity_kwh] =  if data[:electricity_kwh] == 0.0
+      data[:electricity_co2] / DEC_ELECTRICITY_CARBON_INTENSITY_KG_PER_KWH
+    else
+      data[:electricity_kwh]
+    end
+
+    data[:calculated_heating_kwh] =  if data[:heating_kwh] == 0.0
+      # may need enhancing for oil?
+      data[:heating_co2] / DEC_GAS_CARBON_INTENSITY_KG_PER_KWH
+    else
+      data[:heating_kwh]
+    end
+
+    data
+  end
+
+  def merge_data_into_arrays(data)
+    arrayed_data = {}
+    data.values.map do |building|
+      building.each do |type, value|
+        arrayed_data[type] ||= []
+        arrayed_data[type].push(value)
+      end
+    end
+    arrayed_data
+  end
+
+  def sum_arrayed_data(arrayed_data)
+    summed_data = arrayed_data.transform_values do |arr_data|
+      if arr_data.first.is_a?(String)
+        arr_data.uniq.join(' + ')
+      elsif arr_data.first.is_a?(Float)
+        arr_data.sum
+      elsif arr_data.first.is_a?(Date)
+        dates = arr_data.uniq
+        dates.sort.last
+      elsif [true, false].include?(arr_data.first)
+        same = arr_data.all?{ |tf| tf == arr_data.first }
+        same ? arr_data.first : :mixed
+      else
+        raise UnexpectedDataType, "Problem with #{arr_data.first.class.name}"
+      end
+    end
+    summed_data
+  end
+end

--- a/lib/dashboard/data_sources/utilities/temperatures.rb
+++ b/lib/dashboard/data_sources/utilities/temperatures.rb
@@ -123,7 +123,7 @@ class Temperatures < HalfHourlyData
     dh
   end
 
-  def degree_days(date, base_temp)
+  def degree_days(date, base_temp = 15.5)
     # return modified_degree_days(date, base_temp)
     avg_temperature = average_temperature(date)
     avg_temperature <= base_temp ? (base_temp - avg_temperature) : 0.0

--- a/lib/dashboard/half_hourly_data.rb
+++ b/lib/dashboard/half_hourly_data.rb
@@ -166,7 +166,7 @@ class HalfHourlyData < Hash
   end
 
   def days
-    end_date - start_date + 1
+    (end_date - start_date + 1).to_i
   end
 
   def set_validated(valid)

--- a/lib/dashboard/minimiser.rb
+++ b/lib/dashboard/minimiser.rb
@@ -1,0 +1,35 @@
+require 'minimization'
+  # specialize Ruby built-in to reduce computational requirement
+  # the original implementation is rubbish as the logging function
+  # calls the proc 4 times adding +130% to the overall computational
+  # requirement! Changed covergence evaluation to be more efficient
+  # as payback function not 100% compliant with bisection functional
+  # requirements, also only requires 2 rather than 3 payback calls
+  # which are computationally intensive
+  class Minimiser < Minimization::Bisection
+    def initialize(lower, upper, proc, epsilon: 1.0, max_iterations: 10)
+      super(lower, upper, proc)
+      @max_iteration = max_iterations
+      @epsilon = epsilon
+    end
+
+    def iterate
+      ax = @lower
+      cx = @upper
+      k = 0
+      while (ax - cx).abs > @epsilon and k < @max_iteration
+        bx = (ax + cx) / 2.0
+        fb1 = f(bx - @epsilon / 2.0)
+        fb2 = f(bx + @epsilon / 2.0)
+        if fb2 > fb1
+          cx = bx
+        else
+          ax = bx
+        end
+        k += 1
+      end
+      @x_minimum = (ax + cx) / 2.0
+      @f_minimum = f(@x_minimum)
+    end
+  end
+  

--- a/lib/dashboard/simulator/heating_regression_models.rb
+++ b/lib/dashboard/simulator/heating_regression_models.rb
@@ -1128,11 +1128,11 @@ module AnalyseHeatingAndHotWater
       model.predicted_kwh_temperature(temperature)
     end
 
-    private def heating_model_for_future_date(date)
+    def heating_model_for_future_date(date)
       holiday?(date) ? HEATINGHOLIDAYMODEL : weekend?(date) ? HEATINGWEEKENDMODEL : HEATINGOCCUPIEDMODEL
     end
 
-    private def non_heating_model_for_future_date(date)
+    def non_heating_model_for_future_date(date)
       holiday?(date) ? :holiday_hotwater_only : weekend?(date) ? :weekend_hotwater_only : :summer_occupied_all_days
     end
 
@@ -1169,7 +1169,7 @@ module AnalyseHeatingAndHotWater
       'Thermally massive'
     end
 
-    private def heating_model_for_future_date(date)
+    def heating_model_for_future_date(date)
       holiday?(date) ? HEATINGHOLIDAYMODEL : weekend?(date) ? HEATINGWEEKENDMODEL : school_day_model(date)
     end
 

--- a/lib/dashboard/simulator/target_school.rb
+++ b/lib/dashboard/simulator/target_school.rb
@@ -116,7 +116,11 @@ class TargetMeter < Dashboard::Meter
     logger.info calc_text
   end
 
-  def target_start_date(date)
+  def target_start_date(end_date)
+    [end_date - 365, target.first_target_date, @original_meter.amr_data.start_date].max
+  end
+
+  def target_start_date_deprecated(date)
     academic_year = @meter_collection.holidays.calculate_academic_year_tolerant_of_missing_data(date)
     start_of_academic_year = Date.new(academic_year.start_date.year, academic_year.start_date.month, 1)
     target_start_date = target.first_target_date

--- a/lib/dashboard/simulator/targeting and tracking/degreeday_gas_estimation.rb
+++ b/lib/dashboard/simulator/targeting and tracking/degreeday_gas_estimation.rb
@@ -53,12 +53,4 @@ class DegreeDayGasEstimation < GasEstimationBase
       degree_days
     end
   end
-
-  def calculate_holey_amr_data_total_kwh(holey_data)
-    total = 0.0
-    (holey_data.start_date..holey_data.end_date).each do |date|
-      total += holey_data.one_day_total(date) if holey_data.date_exists?(date)
-    end
-    total
-  end
 end

--- a/lib/dashboard/simulator/targeting and tracking/degreeday_gas_estimation.rb
+++ b/lib/dashboard/simulator/targeting and tracking/degreeday_gas_estimation.rb
@@ -7,13 +7,19 @@ class DegreeDayGasEstimation < GasEstimationBase
   def complete_year_amr_data
     fill_in_missing_data_by_daytype(:holiday)
     fill_in_missing_data_by_daytype(:weekend)
-    fill_in_missing_schoolday_data
-    one_year_amr_data
+    percent_real_data = fill_in_missing_schoolday_data
+
+    {
+      amr_data:             one_year_amr_data,
+      percent_real_data:    percent_real_data,
+      adjustments_applied:  'less than 1 years data, filling in missing using degree day adjustment (no modelling data available)'
+    }
   end
 
   private
 
   def fill_in_missing_schoolday_data
+    adjustment_count = 0
     total_kwh_so_far = calculate_holey_amr_data_total_kwh(one_year_amr_data)
     remaining_kwh = @annual_kwh - total_kwh_so_far
     degree_days_remaining = calculate_degree_days_remaining(one_year_amr_data)
@@ -30,7 +36,11 @@ class DegreeDayGasEstimation < GasEstimationBase
       scale = predicted_kwh / school_day_profile_total_kwh
 
       add_scaled_days_kwh(date, scale, school_day_profile_x48)
+
+      adjustment_count += 1
     end
+
+    (365 - adjustment_count) / 365.0
   end
 
   def fill_in_missing_data_by_daytype(daytype)

--- a/lib/dashboard/simulator/targeting and tracking/degreeday_gas_estimation.rb
+++ b/lib/dashboard/simulator/targeting and tracking/degreeday_gas_estimation.rb
@@ -1,0 +1,71 @@
+require_relative './gas_estimation_base.rb'
+# for targeting and tracking:
+# - where there is less than 1 year of gas amr_data
+# - and the gas modelling is not working
+# estimate a complete year's worth of gas data using degree days
+class DegreeDayGasEstimation < GasEstimationBase
+  def complete_year_amr_data
+    fill_in_missing_data_by_daytype(:holiday)
+    fill_in_missing_data_by_daytype(:weekend)
+    fill_in_missing_schoolday_data
+    one_year_amr_data
+  end
+
+  private
+
+  def start_of_year_date
+    @amr_data.end_date - 364
+  end
+
+  def fill_in_missing_schoolday_data
+    total_kwh_so_far = calculate_holey_amr_data_total_kwh(one_year_amr_data)
+    remaining_kwh = @annual_kwh - total_kwh_so_far
+    degree_days_remaining = calculate_degree_days_remaining(one_year_amr_data)
+    school_day_profile_x48 = average_profile_for_day_type_x48(:schoolday)
+    school_day_profile_total_kwh = school_day_profile_x48.sum
+
+    (start_of_year_date..@amr_data.end_date).each do |date|
+      next if @holidays.day_type(date) != :schoolday ||  one_year_amr_data.date_exists?(date)
+
+      degree_days = @meter.meter_collection.temperatures.degree_days(date)
+
+      predicted_kwh = remaining_kwh * (degree_days / degree_days_remaining)
+
+      scale = predicted_kwh / school_day_profile_total_kwh
+
+      days_x48 = AMRData.fast_multiply_x48_x_scalar(school_day_profile_x48, scale)
+
+      one_days_reading = OneDayAMRReading.new(@meter.mpan_mprn, date, 'TARG', nil, DateTime.now, days_x48)
+      one_year_amr_data.add(date, one_days_reading)
+    end
+  end
+
+  def fill_in_missing_data_by_daytype(daytype)
+    avg_profile_x48 = average_profile_for_day_type_x48(daytype)
+
+    (start_of_year_date..@amr_data.end_date).each do |date|
+      next if @holidays.day_type(date) != daytype || one_year_amr_data.date_exists?(date)
+
+      one_days_reading = OneDayAMRReading.new(@meter.mpan_mprn, date, 'TARG', nil, DateTime.now, avg_profile_x48)
+      one_year_amr_data.add(date, one_days_reading)
+    end
+
+    def calculate_degree_days_remaining(one_year_amr_data)
+      degree_days = 0.0
+      (start_of_year_date..@amr_data.end_date).each do |date|
+        unless one_year_amr_data.date_exists?(date)
+          degree_days += @meter.meter_collection.temperatures.degree_days(date)
+        end
+      end
+      degree_days
+    end
+  end
+
+  def calculate_holey_amr_data_total_kwh(holey_data)
+    total = 0.0
+    (holey_data.start_date..holey_data.end_date).each do |date|
+      total += holey_data.one_day_total(date) if holey_data.date_exists?(date)
+    end
+    total
+  end
+end

--- a/lib/dashboard/simulator/targeting and tracking/degreeday_gas_estimation.rb
+++ b/lib/dashboard/simulator/targeting and tracking/degreeday_gas_estimation.rb
@@ -13,10 +13,6 @@ class DegreeDayGasEstimation < GasEstimationBase
 
   private
 
-  def start_of_year_date
-    @amr_data.end_date - 364
-  end
-
   def fill_in_missing_schoolday_data
     total_kwh_so_far = calculate_holey_amr_data_total_kwh(one_year_amr_data)
     remaining_kwh = @annual_kwh - total_kwh_so_far
@@ -33,10 +29,7 @@ class DegreeDayGasEstimation < GasEstimationBase
 
       scale = predicted_kwh / school_day_profile_total_kwh
 
-      days_x48 = AMRData.fast_multiply_x48_x_scalar(school_day_profile_x48, scale)
-
-      one_days_reading = OneDayAMRReading.new(@meter.mpan_mprn, date, 'TARG', nil, DateTime.now, days_x48)
-      one_year_amr_data.add(date, one_days_reading)
+      add_scaled_days_kwh(date, scale, school_day_profile_x48)
     end
   end
 

--- a/lib/dashboard/simulator/targeting and tracking/electricity_annual_consumption_profile_fitter.rb
+++ b/lib/dashboard/simulator/targeting and tracking/electricity_annual_consumption_profile_fitter.rb
@@ -1,0 +1,136 @@
+# given up to 52 weeks of data fit a seasonal profile
+# to the weekly electricity data
+# general documentation for approach under:
+# Google Drive\Energy Sparks\Energy Sparks Project Team Documents\Analytics\Targeting and Tracking\Targeting and Tracking Modelling Analysis.gdoc
+#
+
+class ElectricityAnnualProfileFitter
+  MAXWEEKSANALYSIS = 53 # to cover just over a year as 52.14 weeks in a year
+  MINDAYSINWEEKFORANALYSIS = 3
+  class TooMuchData < StandardError; end
+
+  def initialize(amr_data, holidays, start_date, end_date)
+    raise TooMuchData, "Only up to 1 year expected but got #{start_date} to #{end_date}" if end_date - start_date > MAXWEEKSANALYSIS * 7
+    @amr_data = amr_data
+    @holidays = holidays
+    @start_date = start_date
+    @end_date = end_date
+  end
+
+  # returns a normalised fit of 52 or 53 weeks of estimated/fitted electricity
+  # profile data for a school between start, end dates; summ of kWhs = 1.0
+  def fit(exclude_date_ranges: [])
+    school_weeks_kwh = aggregate_schoolweek_kwhs(@start_date, @end_date, exclude_date_ranges)
+    return nil if school_weeks_kwh.empty?
+    sd, _eps = fit_optimum_sd(school_weeks_kwh)
+    profile = SyntheticSeasonalSchoolWeeklyElectricityProfile.new(sd, school_weeks_kwh).profile
+    { profile: profile, actual: school_weeks_kwh, sd: sd }
+  end
+
+  private
+
+  def aggregate_schoolweek_kwhs(start_date, end_date, exclude_date_ranges)
+    return {} if @amr_data.start_date > start_date || @amr_data.end_date < end_date
+  
+    school_week_kwh       = Array.new(MAXWEEKSANALYSIS, 0.0)
+    school_week_day_count = Array.new(MAXWEEKSANALYSIS, 0.0)
+  
+    (start_date..end_date).each do |date|
+      next if @holidays.day_type(date) != :schoolday
+
+      next if in_date_ranges?(exclude_date_ranges, date)
+  
+      week = week_of_year(date)
+  
+      school_week_kwh[week]       += @amr_data.one_day_kwh(date)
+      school_week_day_count[week] += 1.0
+    end
+  
+    average_school_day_kwh_by_week = school_week_kwh.map.with_index do |kwh, week|
+      if school_week_day_count[week] >= MINDAYSINWEEKFORANALYSIS
+        kwh / school_week_day_count[week]
+      else
+        Float::NAN
+      end
+    end
+  
+    total = average_school_day_kwh_by_week.map{ |v| v.nan? ? 0.0 : v }.sum
+  
+    school_day_kwh_by_week_normalised_to_1 = average_school_day_kwh_by_week.map { |kwh| kwh / total }
+  end
+
+  def in_date_ranges?(date_ranges, date)
+    return false if date_ranges.nil? || date_ranges.empty?
+    date_ranges.each do |date_range|
+      return true if date.between?(date_range.first, date_range.last)
+    end
+    false
+  end
+
+  def week_of_year(date)
+    jan_1 = Date.new(date.year, 1, 1)
+    sunday_of_week1 = jan_1 - jan_1.wday
+    week = ((date - sunday_of_week1) / 7).to_i
+  end
+
+  def fit_optimum_sd(school_weeks_kwh)
+    optimum = Minimiser.minimize(10.0, 50.0) {|sd| difference_to_theoretical_profile(sd, school_weeks_kwh) }
+    [optimum.x_minimum, optimum.f_minimum]
+  end
+  
+  def difference_to_theoretical_profile(sd, school_weeks_kwh)
+    theoretical_profile = SyntheticSeasonalSchoolWeeklyElectricityProfile.new(sd.to_f, school_weeks_kwh).profile
+    difference(school_weeks_kwh, theoretical_profile)
+  end
+  
+  def difference(school_profile, standard_profile)
+    diff = 0.0
+    school_profile.each_with_index do |val, index|
+      diff += (val - standard_profile[index]).magnitude unless val.nan?
+    end
+    diff
+  end
+
+  class SyntheticSeasonalSchoolWeeklyElectricityProfile
+    attr_reader :profile
+    def initialize(sd, weekly_kwhs)
+      weeks_avg_kwh = map_to_weeks(LogNormProfile.new(sd).profile)
+      @profile = weeks_avg_kwh.map { |v| v * 52.0 / school_weeks(weekly_kwhs) }
+    end
+  
+    private
+
+    # norm profile lowest at either end, lowest in school in June
+    # so remap, at [25] to make up to 53 weeks in year
+    # i.e. norm profile Jul to Jun, gets transposed to Jan to Dec
+    def map_to_weeks(profile)
+       # profile[26..51] + profile[0..25] + profile[25..25]
+       centre_week = 23
+       profile[centre_week..51] + profile[0...centre_week] + profile[centre_week..centre_week]
+    end
+  
+    def school_weeks(weekly_kwhs)
+      weekly_kwhs.count{ |wkwh| !wkwh.nan? }
+    end
+  end
+
+  class LogNormProfile
+    def initialize(sd, mean = 26, n = 52)
+      @sd = sd
+      @n = n
+      @mean = mean
+    end
+  
+    def profile
+      dist = (0...@n).to_a.map { |x| normal_distribution(@sd, @mean, x) }
+      sum = dist.sum
+      normalised_to_1 = dist.map { |v| v / sum }
+    end
+  
+    private
+  
+    def normal_distribution(sd, mean, x)
+      (1.0 / (sd * ((2.0 * Math::PI) ** 0.5)) ) * Math.exp( -0.5 * (((x - mean)/sd) ** 2.0) )
+    end
+  end
+end

--- a/lib/dashboard/simulator/targeting and tracking/fitting_base.rb
+++ b/lib/dashboard/simulator/targeting and tracking/fitting_base.rb
@@ -1,0 +1,37 @@
+class TargetingAndTrackingFittingBase
+  def initialize(amr_data, holidays)
+    @amr_data = amr_data
+    @holidays = holidays
+  end
+
+  private
+
+  def average_kwh_for_daytype(start_date, end_date, daytype = :schoolday)
+    total = 0.0
+    count = 0
+    (start_date..end_date).each do |date|
+      next if @holidays.day_type(date) != daytype
+      if date.between?(@amr_data.start_date, @amr_data.end_date)
+        total += @amr_data.one_day_kwh(date)
+        count += 1
+      end
+    end
+    total / count
+  end
+
+  def average_profile_for_day_type_x48(daytype)
+    matching_days = []
+    (@amr_data.start_date..@amr_data.end_date).each do |date|
+      if @holidays.day_type(date) == daytype && @amr_data.date_exists?(date)
+        matching_days.push(@amr_data.days_kwh_x48(date))
+      end     
+    end
+    
+    if matching_days.empty?
+      AMDData.one_day_zero_kwh_x48
+    else
+      total_all_days_x48 = AMRData.fast_add_multiple_x48_x_x48(matching_days)
+      AMRData.fast_multiply_x48_x_scalar(total_all_days_x48, 1.0 / matching_days.length)
+    end
+  end
+end

--- a/lib/dashboard/simulator/targeting and tracking/gas_estimation_base.rb
+++ b/lib/dashboard/simulator/targeting and tracking/gas_estimation_base.rb
@@ -22,4 +22,24 @@ class GasEstimationBase < TargetingAndTrackingFittingBase
   def one_year_amr_data
     @one_year_amr_data ||= AMRData.copy_amr_data(@amr_data)
   end
+
+  def start_of_year_date
+    @amr_data.end_date - 364
+  end
+
+  def heating_model
+    @heating_model ||= calculate_heating_model
+  end
+
+  def calculate_heating_model
+    whole_meter_period = SchoolDatePeriod.new(:available, 'target model', @amr_data.start_date, @amr_data.end_date)
+    @meter.heating_model(whole_meter_period)
+  end
+
+  def add_scaled_days_kwh(date, scale, profile_x48)
+    days_x48 = AMRData.fast_multiply_x48_x_scalar(profile_x48, scale)
+
+    one_days_reading = OneDayAMRReading.new(@meter.mpan_mprn, date, 'TARG', nil, DateTime.now, days_x48)
+    one_year_amr_data.add(date, one_days_reading)
+  end
 end

--- a/lib/dashboard/simulator/targeting and tracking/gas_estimation_base.rb
+++ b/lib/dashboard/simulator/targeting and tracking/gas_estimation_base.rb
@@ -1,0 +1,25 @@
+require_relative './fitting_base.rb'
+class GasEstimationBase < TargetingAndTrackingFittingBase
+  class EnoughGas < StandardError; end
+  class MoreDataAlreadyThanEstimate < StandardError; end
+  class UnexpectedAbstractBaseClassRequest < StandardError; end
+  include Logging
+
+  def initialize(meter, annual_kwh)
+    super(meter.amr_data, meter.meter_collection.holidays)
+    @meter = meter
+    @annual_kwh = annual_kwh
+    raise MoreDataAlreadyThanEstimate, "amr data total #{@amr_data.total.round(0)} kWh > #{annual_kwh.round(0)}" if @amr_data.total > annual_kwh
+    raise EnoughGas, "Unexpected request to fill in missing gas data as > 365 days (#{@amr_data.days})" if @amr_data.days > 365
+  end
+
+  def complete_year_amr_data
+    raise UnexpectedAbstractBaseClassRequest, "Unexepected call to base class #{self.class.name}"
+  end
+
+  private
+
+  def one_year_amr_data
+    @one_year_amr_data ||= AMRData.copy_amr_data(@amr_data)
+  end
+end

--- a/lib/dashboard/simulator/targeting and tracking/missing_gas.rb
+++ b/lib/dashboard/simulator/targeting and tracking/missing_gas.rb
@@ -1,0 +1,30 @@
+class MissingGasEstimation < GasEstimationBase
+  def complete_year_amr_data
+    calc_class = case methodology
+    when :model
+    when :degree_days
+      DegreeDayGasEstimation
+    end
+
+    calculator = calc_class.new(@meter, @annual_kwh)
+    calculator.complete_year_amr_data
+  end
+
+  def methodology
+    heating_model
+    :model
+  rescue EnergySparksNotEnoughDataException => e
+    :degree_days
+  end
+
+  private
+
+  def heating_model
+    @heating_model ||= calculate_heating_model
+  end
+
+  def calculate_heating_model
+    whole_meter_period = SchoolDatePeriod.year_to_date(:available, 'target model', @amr_data.start_date, @amr_data.end_date)
+    @meter.heating_model(whole_meter_period)
+  end
+end

--- a/lib/dashboard/simulator/targeting and tracking/missing_gas.rb
+++ b/lib/dashboard/simulator/targeting and tracking/missing_gas.rb
@@ -15,7 +15,6 @@ class MissingGasEstimation < GasEstimationBase
     heating_model
     :model
   rescue EnergySparksNotEnoughDataException => e
-    puts e.message
     :degree_days
   end
 end

--- a/lib/dashboard/simulator/targeting and tracking/missing_gas.rb
+++ b/lib/dashboard/simulator/targeting and tracking/missing_gas.rb
@@ -2,6 +2,7 @@ class MissingGasEstimation < GasEstimationBase
   def complete_year_amr_data
     calc_class = case methodology
     when :model
+      ModelGasEstimation
     when :degree_days
       DegreeDayGasEstimation
     end
@@ -14,17 +15,7 @@ class MissingGasEstimation < GasEstimationBase
     heating_model
     :model
   rescue EnergySparksNotEnoughDataException => e
+    puts e.message
     :degree_days
-  end
-
-  private
-
-  def heating_model
-    @heating_model ||= calculate_heating_model
-  end
-
-  def calculate_heating_model
-    whole_meter_period = SchoolDatePeriod.year_to_date(:available, 'target model', @amr_data.start_date, @amr_data.end_date)
-    @meter.heating_model(whole_meter_period)
   end
 end

--- a/lib/dashboard/simulator/targeting and tracking/missing_gas.rb
+++ b/lib/dashboard/simulator/targeting and tracking/missing_gas.rb
@@ -1,5 +1,5 @@
 class MissingGasEstimation < GasEstimationBase
-  def complete_year_amr_data
+  def adjusted_amr_data
     calc_class = case methodology
     when :model
       ModelGasEstimation

--- a/lib/dashboard/simulator/targeting and tracking/model_gas_estimation.rb
+++ b/lib/dashboard/simulator/targeting and tracking/model_gas_estimation.rb
@@ -14,10 +14,16 @@ class ModelGasEstimation < GasEstimationBase
             else
               missing_days_scale(missing_days)
             end
+
+    scale_description = scale == 1.0 ? ' - no annual kwh estimate to scale' : ''
         
     add_scaled_missing_days(missing_days, scale)
-    
-    one_year_amr_data
+
+    {
+      amr_data:             one_year_amr_data,
+      percent_real_data:    (365 - missing_days.length)/ 365.0,
+      adjustments_applied:  "less than 1 years data, filling in missing using regression models #{scale_description}"
+    }
   end
 
   private

--- a/lib/dashboard/simulator/targeting and tracking/model_gas_estimation.rb
+++ b/lib/dashboard/simulator/targeting and tracking/model_gas_estimation.rb
@@ -1,0 +1,76 @@
+require_relative './gas_estimation_base.rb'
+# for targeting and tracking:
+# - where there is less than 1 year of gas amr_data
+# - and the gas modelling is not working
+# estimate a complete year's worth of gas data using degree days
+class ModelGasEstimation < GasEstimationBase
+  HEATING_ON_DEGREE_DAYS = 0.0
+
+  def complete_year_amr_data
+    calculate_missing_days
+    one_year_amr_data
+  end
+
+  private
+
+  def calculate_missing_days
+    (start_of_year_date..@amr_data.end_date).each do |date|
+      next if one_year_amr_data.date_exists?(date)
+
+      avg_temp = @meter.meter_collection.temperatures.average_temperature(date)
+
+      dd = @meter.meter_collection.temperatures.degree_days(date)
+
+      heating_on = dd > HEATING_ON_DEGREE_DAYS
+
+      days_kwh =  if heating_on
+                    heating_model.predicted_heating_kwh_future_date(date, avg_temp)
+                  else
+                    heating_model.predicted_non_heating_kwh_future_date(date, avg_temp)
+                  end
+
+      model_type = heating_on ? heating_model.heating_model_for_future_date(date) : heating_model.non_heating_model_for_future_date(date)
+
+      profile = profiles_by_model_type_x48[model_type]
+
+      add_scaled_days_kwh(date, days_kwh, profile)
+    end
+  end
+
+  def profiles_by_model_type_x48
+    @profiles_by_model_type_x48 ||= calculate_profiles_by_model_type_x48
+  end
+
+  def calculate_profiles_by_model_type_x48
+    profiles_by_model_type = {}
+    (@amr_data.start_date..@amr_data.end_date).each do |date|
+      next unless one_year_amr_data.date_exists?(date)
+
+      model_type = heating_model.model_type?(date)
+
+      profiles_by_model_type[model_type] ||= []
+
+      profiles_by_model_type[model_type].push(@amr_data.days_kwh_x48(date))
+    end
+
+    average_profiles = profiles_by_model_type.transform_values do |n_x_48|
+      total_all_days_x48 = AMRData.fast_add_multiple_x48_x_x48(n_x_48)
+      AMRData.fast_multiply_x48_x_scalar(total_all_days_x48, 1.0 / total_all_days_x48.sum)
+    end
+
+    average_profiles
+  end
+
+  def average_profile_x48(dates)
+    matching_days = date.map do |date|
+      @amr_data.days_kwh_x48(date)
+    end
+    
+    if matching_days.empty?
+      AMDData.one_day_zero_kwh_x48
+    else
+      total_all_days_x48 = AMRData.fast_add_multiple_x48_x_x48(matching_days)
+      AMRData.fast_multiply_x48_x_scalar(total_all_days_x48, 1.0 / matching_days.length)
+    end
+  end
+end

--- a/lib/dashboard/simulator/targeting and tracking/one_year_targeting_and_tracking_amr_data.rb
+++ b/lib/dashboard/simulator/targeting and tracking/one_year_targeting_and_tracking_amr_data.rb
@@ -1,0 +1,81 @@
+# consolidates various adjustments needed to calculate next year's targets
+# by 'calculating' underlying AMR data for the last year
+# Main adjustments
+# - electricity: where less than 1 year's data
+#                for COVID lockdown3 where there was a ~20% drop in usage
+# - gas:         where there is less than 1 year's data
+#
+# returns a amr data for meter either the original if no adjustment is necessary
+# or adjusted data - going back 1+ year, so next year's target can be calculated
+#
+class OneYearTargetingAndTrackingAmrData
+  def initialize(meter)
+    @meter = meter
+  end
+
+  # returns
+  # {
+  #   amr_data:             amr data,
+  #   percent_real_data:    Float,
+  #   adjustments_applied:  text description
+  # }
+  def last_years_amr_data
+    @calculate_last_years_amr_data ||= calculate_last_years_amr_data
+  end
+
+  def annual_kwh_estimate_required?
+    # probably unnecessary, to be calculated and marshaled by the front end?
+    false
+  end
+
+  private
+
+  def calculate_last_years_amr_data
+    case @meter.fuel_type
+    when :electricity
+      if seasonal_electricity_covid_adjustment.enough_data?
+        seasonal_electricity_covid_adjustment_amr_data
+      elsif enough_data?
+        enough_data_already
+      else
+        raise StandardError, 'targeting and tracking electric < 1 year not intergrated yet'
+      end    
+    when :gas
+      if enough_data?
+        enough_data_already
+      else
+        full_year_gas_estimate_amr_data
+      end
+    else
+      raise StandardError, "targeting and tracking adjustment for fuel #{@meter.fuel_type} currently not supported"
+    end
+  end
+
+  def enough_data?
+    @meter.enough_amr_data_to_set_target?
+  end
+
+  def enough_data_already
+    {
+      amr_data:             @meter.amr_data,
+      percent_real_data:    1.0,
+      adjustments_applied:  "No adjustments necessary as > 1 year data (#{@meter.amr_data.days}) and recent (to #{@meter.amr_data.end_date})"
+    }
+  end
+
+  def seasonal_electricity_covid_adjustment
+    @seasonal_electricity_covid_adjustment ||= SeasonalMirroringCovidAdjustment.new(@meter.amr_data, @meter.meter_collection.holidays)
+  end
+
+  def seasonal_electricity_covid_adjustment_amr_data
+    @seasonal_electricity_covid_adjustment_amr_data ||= seasonal_electricity_covid_adjustment.adjusted_amr_data
+  end
+
+  def full_year_gas_estimate
+    @full_year_gas_estimate ||= MissingGasEstimation.new(@meter, @meter.annual_kwh_estimate)
+  end
+
+  def full_year_gas_estimate_amr_data
+    @full_year_gas_estimate_amr_data ||= full_year_gas_estimate.adjusted_amr_data
+  end
+end

--- a/lib/dashboard/simulator/targeting and tracking/seasonal_mirroring_electricity_covid_adjustment.rb
+++ b/lib/dashboard/simulator/targeting and tracking/seasonal_mirroring_electricity_covid_adjustment.rb
@@ -1,12 +1,11 @@
 # correct for reduced consumption during the 3rd lockdown (Jan-Mar 2021)
 # - by using data from Jan-Mar 2020 if available
 # - or using data from Oct - Dec 2020 (mirrored)
-class SeasonalMirroringCovidAdjustment
+class SeasonalMirroringCovidAdjustment < TargetingAndTrackingFittingBase
   MAX_CHANGE_BEFORE_MIRRORING = 0.05
   include Logging
   def initialize(amr_data, holidays)
-    @amr_data = amr_data
-    @holidays = holidays
+    super(amr_data, holidays)
     @lockdown_start_date  = Date.new(2021, 1, 4)
     @lockdown_end_date    = Date.new(2021, 3, 7)
   end
@@ -142,18 +141,7 @@ class SeasonalMirroringCovidAdjustment
     end
   end
 
-  def average_kwh_for_daytype(start_date, end_date)
-    total = 0.0
-    count = 0
-    (start_date..end_date).each do |date|
-      next if @holidays.day_type(date) != :schoolday
-      if date.between?(@amr_data.start_date, @amr_data.end_date)
-        total += @amr_data.one_day_kwh(date)
-        count += 1
-      end
-    end
-    total / count
-  end
+
 
   def mirrored_weeks_dates
     @mirrored_weeks_dates ||= calculate_mirrored_week_dates

--- a/lib/dashboard/simulator/targeting and tracking/seasonal_mirroring_electricity_covid_adjustment.rb
+++ b/lib/dashboard/simulator/targeting and tracking/seasonal_mirroring_electricity_covid_adjustment.rb
@@ -27,6 +27,10 @@ class SeasonalMirroringCovidAdjustment
     @alternative_date_cache[date] ||= calculate_alternative_date(date)
   end
 
+  def mirroring_rules
+    @mirroring_rules ||= calculate_mirroring_rules
+  end
+
   def lockdown_versus_mirror_percent_change
     @lockdown_versus_mirror_percent_change ||= reduction_percent(:lockdown_weeks, :mirror_weeks)
   end
@@ -104,10 +108,6 @@ class SeasonalMirroringCovidAdjustment
 
   def holiday_or_weekend?(date)
     %i[holiday weekend].include?(@holidays.day_type(date))
-  end
-
-  def mirroring_rules
-    @mirroring_rules ||= calculate_mirroring_rules
   end
 
   def calculate_mirroring_rules

--- a/lib/dashboard/simulator/targeting and tracking/seasonal_mirroring_electricity_covid_adjustment.rb
+++ b/lib/dashboard/simulator/targeting and tracking/seasonal_mirroring_electricity_covid_adjustment.rb
@@ -1,0 +1,103 @@
+# correct for reduced consumption during the 3rd lockdown (Jan-Mar 2021)
+# - by using data from Jan-Mar 2020 if available
+# - or using data from Oct - Dec 2020 (mirrored)
+class SeasonalMirroringCovidAdjustment
+  def initialize(amr_data, holidays)
+    @amr_data = amr_data
+    @holidays = holidays
+    @lockdown_start_date  = Date.new(2021, 1, 4)
+    @lockdown_end_date    = Date.new(2021, 3, 7)
+  end
+
+  def enough_data_for_annual_mirror?
+    @amr_data.start_date  <= @lockdown_start_date - 365 &&
+    @amr_data.end_date    >= @lockdown_end_date
+  end
+
+  def enough_data_for_seasonal_mirror?
+    @amr_data.start_date  <= mirrored_weeks_dates[:mirror_weeks].last.first &&
+    @amr_data.end_date    >= mirrored_weeks_dates[:lockdown_weeks].last.last
+  end
+
+  def lockdown_versus_mirror_percent_change
+    reduction_percent(:lockdown_weeks, :mirror_weeks)
+  end
+
+  def lockdown_versus_previous_year_percent_change
+    reduction_percent(:lockdown_weeks, :previous_year_weeks)
+  end
+
+  private
+
+  def reduction_percent(type_1, type_2)
+    paired_weeks = compare_mirrored_week_average_school_day_kwhs(type_1, type_2)
+    average_lockdown_kwh = paired_weeks.map { |l_v_m| l_v_m[0] }.sum / paired_weeks.length
+    average_mirrored_kwh = paired_weeks.map { |l_v_m| l_v_m[1] }.sum / paired_weeks.length
+    (average_mirrored_kwh - average_lockdown_kwh) / average_mirrored_kwh
+  end
+
+  def compare_mirrored_week_average_school_day_kwhs(type_1, type_2)
+    mirrored_weeks_dates[type_1].map.with_index do |lockdown_week, index|
+      mirrored_week = mirrored_weeks_dates[type_2][index]
+      [
+        average_kwh_for_daytype(lockdown_week.first, lockdown_week.last),
+        average_kwh_for_daytype(mirrored_week.first, mirrored_week.last)
+      ]
+    end
+  end
+
+  def average_kwh_for_daytype(start_date, end_date)
+    total = 0.0
+    count = 0
+    (start_date..end_date).each do |date|
+      next if @holidays.day_type(date) != :schoolday
+      if date.between?(@amr_data.start_date, @amr_data.end_date)
+        total += @amr_data.one_day_kwh(date)
+        count += 1
+      end
+    end
+    total / count
+  end
+
+  def mirrored_weeks_dates
+    @mirrored_weeks_dates ||= calculate_mirrored_week_dates
+  end
+
+  def calculate_mirrored_week_dates
+    results = {}
+
+    starting_sunday = Date.new(2021, 1, 3)
+    ending_saturday = Date.new(2021, 3, 6)
+    lockdown_weeks = classify_weeks(starting_sunday, ending_saturday, :schoolday)
+
+    mirror_start_sunday = Date.new(2020,  9,  6)
+    mirror_end_saturday = Date.new(2020, 12, 19)
+    mirror_weeks = classify_weeks(mirror_start_sunday, mirror_end_saturday, :schoolday).reverse[0...lockdown_weeks.length]
+
+    starting_sunday = Date.new(2020, 1, 5)
+    ending_saturday = Date.new(2020, 3, 7)
+    previous_year = classify_weeks(starting_sunday, ending_saturday, :schoolday)
+
+    {
+      lockdown_weeks:       lockdown_weeks,
+      mirror_weeks:         mirror_weeks,
+      previous_year_weeks:  previous_year
+    }
+  end
+
+  def classify_weeks(starting_sunday, ending_saturday, type)
+    weeks = []
+    (starting_sunday..ending_saturday).each_slice(7) do |days|
+      weeks.push(days.first..days.last) if  week_type(days.first + 1, days.last - 1) == type
+    end
+    weeks
+  end
+
+  def week_type(start_monday, end_friday)
+    type_count = { schoolday: 0,  weekend: 0,  holiday: 0 }
+    (start_monday..end_friday).each do |date|
+      type_count[@holidays.day_type(date)] += 1
+    end
+    type_count.sort_by { |daytype, count| -count }.to_h.keys[0]
+  end
+end

--- a/lib/dashboard/simulator/targeting and tracking/target_school.rb
+++ b/lib/dashboard/simulator/targeting and tracking/target_school.rb
@@ -44,7 +44,7 @@ class TargetAttributes
   def initialize(meter)
     @attributes = nil
     if meter.target_set?
-      @attributes = meter.attributes(:targeting_and_tracking).sort { |a, b| a[:start_date] <=> b[:start_date] } 
+      @attributes = meter.target_attributes.sort { |a, b| a[:start_date] <=> b[:start_date] } 
     end
   end
 

--- a/lib/dashboard/simulator/targeting and tracking/target_school.rb
+++ b/lib/dashboard/simulator/targeting and tracking/target_school.rb
@@ -130,6 +130,10 @@ class TargetMeter < Dashboard::Meter
     meter.amr_data.days > 365 + 30
   end
 
+  def self.annual_kwh_estimate_required?(meter)
+    meter.amr_data.days < 365
+  end
+
   def target_start_date_deprecated(date)
     academic_year = @meter_collection.holidays.calculate_academic_year_tolerant_of_missing_data(date)
     start_of_academic_year = Date.new(academic_year.start_date.year, academic_year.start_date.month, 1)

--- a/lib/dashboard/simulator/targeting and tracking/target_school.rb
+++ b/lib/dashboard/simulator/targeting and tracking/target_school.rb
@@ -120,6 +120,11 @@ class TargetMeter < Dashboard::Meter
     [end_date - 365, target.first_target_date, @original_meter.amr_data.start_date].max
   end
 
+  def self.enough_amr_data_to_set_target?(meter)
+    meter.amr_data.end_date > Date.today - 30 &&
+    meter.amr_data.days > 365 + 30
+  end
+
   def target_start_date_deprecated(date)
     academic_year = @meter_collection.holidays.calculate_academic_year_tolerant_of_missing_data(date)
     start_of_academic_year = Date.new(academic_year.start_date.year, academic_year.start_date.month, 1)

--- a/lib/dashboard/simulator/targeting and tracking/third_lockdown_electricity_covid_adjustment.rb
+++ b/lib/dashboard/simulator/targeting and tracking/third_lockdown_electricity_covid_adjustment.rb
@@ -8,5 +8,20 @@
 #    a. use data from the Autumn as a substitute
 #    b. adjust upwards the fit to the 2020/2021 data ex. the 3rd lockdown 
 class ThirdLockdownElectricityCovidAdjustment
+  def initialize(amr_data, holidays, start_date, end_date)
+    @amr_data = amr_data
+    @holidays = holidays
+    @start_date = start_date
+    @end_date = end_date
+    @lockdown_start_date = Date.new(2021, 1, 4)
+    @lockdown_end_date = Date.new(2021, 3, 7)
+  end
 
+  def needs_adjustment?
+    return false if start_date > @lockdown_end_date
+
+    fitter = ElectricityAnnualProfileFitter.new(@amr_data, @holidays, @start_date, @end_date)
+    fitted_data = fitter.fit
+
+  end
 end

--- a/lib/dashboard/simulator/targeting and tracking/third_lockdown_electricity_covid_adjustment.rb
+++ b/lib/dashboard/simulator/targeting and tracking/third_lockdown_electricity_covid_adjustment.rb
@@ -1,0 +1,12 @@
+# between 4 Jan 2021 and 8 Mar 2021 during the thrid UK lockdown
+# some schools saw up to a 30% reduction in electricity usage
+# this needs to be adjusted for for setting targets for 2021/2022
+#
+# 1. try to determine whether there has been a signifcant drop, if not do nothing
+# 2. if Jan to March 2020 data available use that
+# 3. if not then:
+#    a. use data from the Autumn as a substitute
+#    b. adjust upwards the fit to the 2020/2021 data ex. the 3rd lockdown 
+class ThirdLockdownElectricityCovidAdjustment
+
+end

--- a/lib/dashboard/simulator/targeting and tracking/third_lockdown_electricity_covid_adjustment.rb
+++ b/lib/dashboard/simulator/targeting and tracking/third_lockdown_electricity_covid_adjustment.rb
@@ -18,10 +18,11 @@ class ThirdLockdownElectricityCovidAdjustment
   end
 
   def needs_adjustment?
-    return false if start_date > @lockdown_end_date
+    return false if @start_date > @lockdown_end_date
 
     fitter = ElectricityAnnualProfileFitter.new(@amr_data, @holidays, @start_date, @end_date)
-    fitted_data = fitter.fit
-
+    exclude_lockdown = @lockdown_start_date..@lockdown_end_date
+    fitted_data = fitter.fit(exclude_date_ranges: [exclude_lockdown])
+    ap fitted_data
   end
 end

--- a/lib/dashboard/simulator/targeting and tracking/third_lockdown_electricity_covid_adjustment_deprecated.rb
+++ b/lib/dashboard/simulator/targeting and tracking/third_lockdown_electricity_covid_adjustment_deprecated.rb
@@ -1,4 +1,4 @@
-# between 4 Jan 2021 and 8 Mar 2021 during the thrid UK lockdown
+# between 4 Jan 2021 and 8 Mar 2021 during the third UK lockdown
 # some schools saw up to a 30% reduction in electricity usage
 # this needs to be adjusted for for setting targets for 2021/2022
 #
@@ -7,7 +7,7 @@
 # 3. if not then:
 #    a. use data from the Autumn as a substitute
 #    b. adjust upwards the fit to the 2020/2021 data ex. the 3rd lockdown 
-class ThirdLockdownElectricityCovidAdjustment
+class ThirdLockdownElectricityCovidAdjustmentDeprecated
   def initialize(amr_data, holidays, start_date, end_date)
     @amr_data = amr_data
     @holidays = holidays

--- a/script/external/download_display_energy_certificate_data.rb
+++ b/script/external/download_display_energy_certificate_data.rb
@@ -1,0 +1,104 @@
+require 'require_all'
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
+
+module Logging
+  @logger = Logger.new('log/display energy certificates ' + Time.now.strftime('%H %M') + '.log')
+  logger.level = :debug
+end
+
+def header
+  %i[
+    es_name
+    es_floor_area
+    floor_area
+    electricity_kwh
+    es_electricity_kwh
+    calculated_electricity_kwh
+    es_electricity_status
+    heating_kwh
+    es_gas_kwh
+    calculated_heating_kwh
+    es_gas_status
+    renewables_kwh
+    date
+    address
+    name
+    postcode
+    buildings
+    air_conditioning
+    renewable_heat_kwh
+    renewables_types
+    main_heating_fuel
+    other_heating_fuel
+    rating
+    environment
+    local_authority_name
+  ]
+end
+
+def annual_kwh(school, fuel_type, dec_date)
+  meter = school.aggregate_meter(fuel_type)
+  return {} if meter.nil?
+
+  meter = meter.original_meter
+
+  if !dec_date.nil? && dec_date - 365 >= meter.amr_data.start_date && dec_date <= meter.amr_data.end_date
+    {
+      kwh:     meter.amr_data.kwh_date_range(dec_date - 365, dec_date),
+      status:  :matches_dec_dates
+    } 
+  elsif meter.amr_data.days >= 365
+    {
+      kwh:     meter.amr_data.kwh_date_range(meter.amr_data.end_date - 365, meter.amr_data.end_date),
+      status:  :latest_data_only
+    } 
+  else
+    {
+      kwh:     meter.amr_data.kwh_date_range(meter.amr_data.start_date, meter.amr_data.end_date),
+      status:  :partial_year_only
+    } 
+  end
+end
+
+def save_csv(data)
+  filename = './Results/display_energy_certificate.csv'
+  puts "Saving results to #{filename}"
+  CSV.open(filename, 'w') do |csv|
+    csv << header
+    data.each do |_school_name, one_school|
+      csv << header.map { |key| one_school[key] }
+    end
+  end
+end
+
+school_name_pattern_match = ['*']
+source_db = :unvalidated_meter_data
+
+school_names = RunTests.resolve_school_list(source_db, school_name_pattern_match)
+
+ap school_names
+data = {}
+
+school_names.each do |school_name|
+  school = SchoolFactory.new.load_or_use_cached_meter_collection(:name, school_name, source_db)
+
+  dec_data = DisplayEnergyCertificate.new.recent_aggregate_data(school.postcode)
+
+  dec_date = dec_data.nil? ? nil : dec_data[:date]
+
+  es_electric = annual_kwh(school, :electricity, dec_date)
+  es_gas = annual_kwh(school, :gas, dec_date)
+
+  data[school_name] = {
+    es_name:                school_name,
+    es_floor_area:          school.floor_area,
+    es_electricity_kwh:     es_electric[:kwh],
+    es_electricity_status:  es_electric[:status],
+    es_gas_kwh:             es_gas[:kwh],
+    es_gas_status:          es_gas[:status]
+  }
+  data[school_name].merge!(dec_data) unless dec_data.nil?
+end
+
+save_csv(data)

--- a/script/research/targeting_and_tracking_3rd_covid_lockdown.rb
+++ b/script/research/targeting_and_tracking_3rd_covid_lockdown.rb
@@ -1,0 +1,53 @@
+require 'require_all'
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
+
+module Logging
+  @logger = Logger.new('log/covid lockdown testing ' + Time.now.strftime('%H %M') + '.log')
+  logger.level = :debug
+end
+
+def sub_nil_nan(arr)
+  arr.map { |v| v.nan? ? nil : v }
+end
+
+def save_csv(filename, data)
+  puts "Saving results to #{filename}"
+  CSV.open(filename, 'w') do |csv|
+    data.each do |school_name, week_avg_kwhs|
+      csv << [school_name, sub_nil_nan(week_avg_kwhs)].flatten
+    end
+  end
+end
+
+# CONFIG
+
+filename = "./Results/targeting_and_tracking_3rd covid lockdown schools.csv"
+school_name_pattern_match = ['*'] # ' ['abbey*', 'bathamp*']
+start_date = Date.new(2020, 7, 1)
+end_date = Date.new(2021, 6, 30)
+fuel_type = :electricity
+source_db = :unvalidated_meter_data
+
+# RUN SCRIPT:
+
+school_names = RunTests.resolve_school_list(source_db, school_name_pattern_match)
+
+ap school_names
+data = {}
+
+school_names.each do |school_name|
+  school = SchoolFactory.new.load_or_use_cached_meter_collection(:name, school_name, source_db)
+
+  meter = school.aggregate_meter(fuel_type)
+  next if meter.nil?
+
+  fitter = ElectricityAnnualProfileFitter.new(meter.amr_data, school.holidays, start_date, end_date)
+  fitted_data = fitter.fit
+  next if fitted_data.nil?
+
+  data["#{school_name} - actual"] = fitted_data[:actual]
+  data["#{school_name} - best fit #{fitted_data[:sd].round(1)}"] = fitted_data[:profile]
+end
+
+save_csv(filename, data)

--- a/script/research/targeting_and_tracking_3rd_covid_lockdown.rb
+++ b/script/research/targeting_and_tracking_3rd_covid_lockdown.rb
@@ -56,25 +56,26 @@ school_names.each do |school_name|
 
   seasonal = SeasonalMirroringCovidAdjustment.new(meter.amr_data, school.holidays)
 
-  lockdown_reduction[school_name] = []
-  lockdown_reduction[school_name].push(seasonal.lockdown_versus_mirror_percent_change)
-  lockdown_reduction[school_name].push(seasonal.lockdown_versus_previous_year_percent_change)
+  info = seasonal.adjusted_amr_data
 
-  amr = seasonal.adjusted_amr_data
+  lockdown_reduction[school_name] = []
+  lockdown_reduction[school_name].push(info[:percent_reduction_versus_Oct_Dec_2020])
+  lockdown_reduction[school_name].push(info[:percent_reduction_versus_Jan_Mar_2020])
+
   ed = meter.amr_data.end_date
   sd = ed - 365
   before = meter.amr_data.kwh_date_range(sd, ed)
-  after = amr.kwh_date_range(sd, ed)
+  after = info[:amr_data].kwh_date_range(sd, ed)
   puts "3rd lock down adjustment of AMRData before #{before} after #{after}"
   lockdown_reduction[school_name].push(before)
   lockdown_reduction[school_name].push(after)
 
-  seasonal.log_mirror_amr_data_rules
+  puts info[:adjustments_applied]
 
   (Date.new(2021, 1, 10)..Date.new(2021, 1, 23)).each do |date| # sunday to sunday
-    puts "Swapping #{date} for #{seasonal.alternative_date(date)}"
+    # puts "Swapping #{date} for #{seasonal.alternative_date(date)}"
   end
-  
+
 =begin
 
   fitter = ElectricityAnnualProfileFitter.new(meter.amr_data, school.holidays, start_date, end_date)
@@ -88,6 +89,8 @@ school_names.each do |school_name|
   data["#{school_name} - best fit #{fitted_data[:sd].round(1)}"] = fitted_data[:profile]
 =end
 end
+
+ap lockdown_reduction
 
 save_reductions(reduction_filename, lockdown_reduction)
 exit

--- a/script/research/targeting_and_tracking_3rd_covid_lockdown.rb
+++ b/script/research/targeting_and_tracking_3rd_covid_lockdown.rb
@@ -14,7 +14,7 @@ end
 def save_reductions(filename, data)
   puts "Saving results to #{filename}"
   CSV.open(filename, 'w') do |csv|
-    csv << ['school name', 'v. Autumn 2020 mirrored', 'v. Spring 2020']
+    csv << ['school name', 'v. Autumn 2020 mirrored', 'v. Spring 2020', '2020-2021 before', '2020-2021 after']
     data.each do |school_name, percent_reduction|
       csv << [school_name, sub_nil_nan(percent_reduction)].flatten
     end
@@ -34,7 +34,7 @@ end
 
 filename = "./Results/targeting_and_tracking_3rd covid lockdown schools.csv"
 reduction_filename = "./Results/targeting_and_tracking_3rd covid lockdown schools reduction stats.csv"
-school_name_pattern_match = ['trinity*'] # ' ['abbey*', 'bathamp*']
+school_name_pattern_match = ['abbey*', 'bathamp*']
 start_date = Date.new(2020, 7, 1)
 end_date = Date.new(2021, 6, 30)
 fuel_type = :electricity
@@ -60,9 +60,18 @@ school_names.each do |school_name|
   lockdown_reduction[school_name].push(seasonal.lockdown_versus_mirror_percent_change)
   lockdown_reduction[school_name].push(seasonal.lockdown_versus_previous_year_percent_change)
 
+  amr = seasonal.adjusted_amr_data
+  ed = meter.amr_data.end_date
+  sd = ed - 365
+  before = meter.amr_data.kwh_date_range(sd, ed)
+  after = amr.kwh_date_range(sd, ed)
+  puts "3rd lock down adjustment of AMRData before #{before} after #{after}"
+  lockdown_reduction[school_name].push(before)
+  lockdown_reduction[school_name].push(after)
+
   seasonal.log_mirror_amr_data_rules
 
-  (Date.new(2021, 1, 10)..Date.new(2021, 1, 16)).each do |date| # sunday to sunday
+  (Date.new(2021, 1, 10)..Date.new(2021, 1, 23)).each do |date| # sunday to sunday
     puts "Swapping #{date} for #{seasonal.alternative_date(date)}"
   end
   

--- a/script/research/targeting_and_tracking_3rd_covid_lockdown.rb
+++ b/script/research/targeting_and_tracking_3rd_covid_lockdown.rb
@@ -23,7 +23,7 @@ end
 # CONFIG
 
 filename = "./Results/targeting_and_tracking_3rd covid lockdown schools.csv"
-school_name_pattern_match = ['*'] # ' ['abbey*', 'bathamp*']
+school_name_pattern_match = ['batheast*'] # ' ['abbey*', 'bathamp*']
 start_date = Date.new(2020, 7, 1)
 end_date = Date.new(2021, 6, 30)
 fuel_type = :electricity
@@ -45,6 +45,9 @@ school_names.each do |school_name|
   fitter = ElectricityAnnualProfileFitter.new(meter.amr_data, school.holidays, start_date, end_date)
   fitted_data = fitter.fit
   next if fitted_data.nil?
+
+  covid_3 = ThirdLockdownElectricityCovidAdjustment.new(meter.amr_data, school.holidays, start_date, end_date)
+  covid_3.needs_adjustment?
 
   data["#{school_name} - actual"] = fitted_data[:actual]
   data["#{school_name} - best fit #{fitted_data[:sd].round(1)}"] = fitted_data[:profile]

--- a/script/research/targeting_and_tracking_3rd_covid_lockdown.rb
+++ b/script/research/targeting_and_tracking_3rd_covid_lockdown.rb
@@ -34,7 +34,7 @@ end
 
 filename = "./Results/targeting_and_tracking_3rd covid lockdown schools.csv"
 reduction_filename = "./Results/targeting_and_tracking_3rd covid lockdown schools reduction stats.csv"
-school_name_pattern_match = ['*'] # ' ['abbey*', 'bathamp*']
+school_name_pattern_match = ['trinity*'] # ' ['abbey*', 'bathamp*']
 start_date = Date.new(2020, 7, 1)
 end_date = Date.new(2021, 6, 30)
 fuel_type = :electricity
@@ -59,6 +59,12 @@ school_names.each do |school_name|
   lockdown_reduction[school_name] = []
   lockdown_reduction[school_name].push(seasonal.lockdown_versus_mirror_percent_change)
   lockdown_reduction[school_name].push(seasonal.lockdown_versus_previous_year_percent_change)
+
+  seasonal.log_mirror_amr_data_rules
+
+  (Date.new(2021, 1, 10)..Date.new(2021, 1, 16)).each do |date| # sunday to sunday
+    puts "Swapping #{date} for #{seasonal.alternative_date(date)}"
+  end
   
 =begin
 

--- a/script/research/targeting_and_tracking_not_enough_gas_data.rb
+++ b/script/research/targeting_and_tracking_not_enough_gas_data.rb
@@ -1,0 +1,38 @@
+# targeting and tracking covid/shortage of data stats for keeping track of progress
+require 'require_all'
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
+
+module Logging
+  @logger = Logger.new('log/targetting stats' + Time.now.strftime('%H %M') + '.log')
+  logger.level = :debug
+end
+
+def school_factory
+  $SCHOOL_FACTORY ||= SchoolFactory.new
+end
+
+def analyse_gas_meter(meter)
+  puts "Analysing #{meter.mpxn}"
+  puts "sd #{meter.amr_data.start_date} ed #{meter.amr_data.end_date}"
+  puts "d1 #{meter.amr_data.keys.sort.first} d2 #{meter.amr_data.keys.sort.last}"
+  estimate = MissingGasEstimation.new(meter, meter.annual_kwh_estimate)
+  puts "Using method #{estimate.methodology}"
+  puts "Total kwh = #{estimate.complete_year_amr_data.total}, estimate #{meter.annual_kwh_estimate}"
+end
+
+school_name_pattern_match = ['mundella*']
+source_db = :unvalidated_meter_data
+
+school_names = RunTests.resolve_school_list(source_db, school_name_pattern_match)
+
+schools = school_names.map do |school_name|
+  school_factory.load_or_use_cached_meter_collection(:name, school_name, source_db)
+end
+
+schools.each do |school|
+  meter = school.aggregate_meter(:gas)
+  unless meter.nil?
+    analyse_gas_meter(meter)
+  end
+end

--- a/script/research/targeting_and_tracking_not_enough_gas_data.rb
+++ b/script/research/targeting_and_tracking_not_enough_gas_data.rb
@@ -16,12 +16,18 @@ def analyse_gas_meter(meter)
   puts "Analysing #{meter.mpxn}"
   puts "sd #{meter.amr_data.start_date} ed #{meter.amr_data.end_date}"
   puts "d1 #{meter.amr_data.keys.sort.first} d2 #{meter.amr_data.keys.sort.last}"
+  gas_estimate_info = OneYearTargetingAndTrackingAmrData.new(meter).last_years_amr_data
+  puts "Using method: #{gas_estimate_info[:adjustments_applied]}"
+  puts "Total kwh = #{gas_estimate_info[:amr_data].total}, estimate #{meter.annual_kwh_estimate}"
+=begin
+deprecated delete
   estimate = MissingGasEstimation.new(meter, meter.annual_kwh_estimate)
   puts "Using method #{estimate.methodology}"
   puts "Total kwh = #{estimate.complete_year_amr_data.total}, estimate #{meter.annual_kwh_estimate}"
+=end
 end
 
-school_name_pattern_match = ['wimble*'] # ['mundella*', ''] or MC school for modelling
+school_name_pattern_match = ['mundella*', 'wimble*'] # ['mundella*', ''] or MC school for modelling
 source_db = :unvalidated_meter_data
 
 school_names = RunTests.resolve_school_list(source_db, school_name_pattern_match)
@@ -31,6 +37,8 @@ schools = school_names.map do |school_name|
 end
 
 schools.each do |school|
+  puts '=' * 80
+  puts "Loading #{school.name}"
   meter = school.aggregate_meter(:gas)
   unless meter.nil?
     Logging.logger.info "Philip was here"

--- a/script/research/targeting_and_tracking_not_enough_gas_data.rb
+++ b/script/research/targeting_and_tracking_not_enough_gas_data.rb
@@ -4,7 +4,7 @@ require_relative '../../lib/dashboard.rb'
 require_rel '../../test_support'
 
 module Logging
-  @logger = Logger.new('log/targetting stats' + Time.now.strftime('%H %M') + '.log')
+  @logger = Logger.new('log/targetting not enough gas' + Time.now.strftime('%H %M') + '.log')
   logger.level = :debug
 end
 
@@ -21,7 +21,7 @@ def analyse_gas_meter(meter)
   puts "Total kwh = #{estimate.complete_year_amr_data.total}, estimate #{meter.annual_kwh_estimate}"
 end
 
-school_name_pattern_match = ['mundella*']
+school_name_pattern_match = ['wimble*'] # ['mundella*', ''] or MC school for modelling
 source_db = :unvalidated_meter_data
 
 school_names = RunTests.resolve_school_list(source_db, school_name_pattern_match)
@@ -33,6 +33,7 @@ end
 schools.each do |school|
   meter = school.aggregate_meter(:gas)
   unless meter.nil?
+    Logging.logger.info "Philip was here"
     analyse_gas_meter(meter)
   end
 end

--- a/script/research/targeting_and_tracking_seasonality_analysis.rb
+++ b/script/research/targeting_and_tracking_seasonality_analysis.rb
@@ -110,7 +110,7 @@ def save_csv(year, data)
   end
 end
 
-school_name_pattern_match = ['*']
+school_name_pattern_match = ['b*']
 years = [2018, 2019, 2020]
 
 source_db = :unvalidated_meter_data

--- a/script/research/targeting_and_tracking_seasonality_analysis.rb
+++ b/script/research/targeting_and_tracking_seasonality_analysis.rb
@@ -1,0 +1,125 @@
+require 'require_all'
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
+
+module Logging
+  @logger = Logger.new('log/display energy certificates ' + Time.now.strftime('%H %M') + '.log')
+  logger.level = :debug
+end
+
+def month_start_dates
+  [
+    Date.new(2020,  7, 1),
+    Date.new(2020,  8, 1),
+    Date.new(2020,  9, 1),
+    Date.new(2020, 10, 1),
+    Date.new(2020, 11, 1),
+    Date.new(2020, 12, 1),
+    Date.new(2021,  1, 1),
+    Date.new(2021,  2, 1),
+    Date.new(2021,  3, 1),
+    Date.new(2021,  4, 1),
+    Date.new(2021,  5, 1),
+    Date.new(2021,  6, 1)
+  ]
+end
+
+def month_date_ranges
+  @month_date_ranges ||= month_start_dates.map { |d1| d1..DateTimeHelper.last_day_of_month(d1) }
+end
+
+def year_start_date; month_date_ranges.first.first end
+def year_end_date; month_date_ranges.last.last end
+
+
+def monthly_kwhs(school, fuel_type)
+  meter = school.aggregate_meter(fuel_type)
+  return {} if meter.nil? || meter.amr_data.start_date > year_start_date || meter.amr_data.end_date < year_end_date
+
+  data = {}
+  count = {}
+
+  month_date_ranges.each do |month_date_range|
+    data[month_date_range] = { schoolday: 0.0, weekend: 0.0, holiday: 0.0 }
+    count[month_date_range] = { schoolday: 0, weekend: 0, holiday: 0 }
+    month_date_range.each do |date|
+      daytype = school.holidays.day_type(date)
+      data[month_date_range][daytype]  += meter.amr_data.one_day_kwh(date)
+      count[month_date_range][daytype] += 1
+    end
+  end
+
+  [data, count]
+end
+
+def calculate_average_monthly_percent_by_daytype(school, fuel_type)
+  data, count = monthly_kwhs(school, fuel_type)
+  average_daytype = average_annual_kwh_by_daytype(data, count)
+
+  average = {}
+  data.each_key do |month_date_range|
+    average[month_date_range] = { schoolday: 0.0, weekend: 0.0, holiday: 0.0 }
+  end
+
+  %i[schoolday weekend holiday].each do |daytype|
+    data.each do |month_range, months_data|
+      avg = average_daytype[daytype]
+      average[month_range][daytype] = (months_data[daytype] / count[month_range][daytype]) / avg
+    end
+  end
+
+  average
+end
+
+def average_annual_kwh_by_daytype(data, count)
+  average = {}
+  %i[schoolday weekend holiday].each do |daytype|
+    s = 0.0
+    c = 0.0
+    data.each do |month_range, months_data|
+      s += months_data[daytype]
+      c += count[month_range][daytype]
+    end
+    average[daytype] = c > 0 ? s / c : 0.0
+  end
+  average
+end
+
+def sub_nil_nan(arr)
+  arr.map { |v| v.nan? ? nil : v }
+end
+
+def save_csv(data)
+  filename = './Results/targeting_and_tracking_seasonality.csv'
+  puts "Saving results to #{filename}"
+  CSV.open(filename, 'w') do |csv|
+    months = month_date_ranges.map { |dr| dr.first.strftime('%b %Y') }
+    csv << ['School', 'School days', months, 'Weekends', months, 'Holidays', months].flatten
+    data.each do |school_name, years_data|
+      row = [school_name] +
+            [nil] +
+            sub_nil_nan(years_data.values.map{ |months| months[:schoolday] }) +
+            [nil] +
+            sub_nil_nan(years_data.values.map{ |months| months[:weekend] }) +
+            [nil] +
+            sub_nil_nan(years_data.values.map{ |months| months[:holiday] })
+      csv << row.flatten
+    end
+  end
+end
+
+school_name_pattern_match = ['*']
+source_db = :unvalidated_meter_data
+
+school_names = RunTests.resolve_school_list(source_db, school_name_pattern_match)
+
+ap school_names
+data = {}
+
+school_names.each do |school_name|
+  school = SchoolFactory.new.load_or_use_cached_meter_collection(:name, school_name, source_db)
+
+  data[school_name] = calculate_average_monthly_percent_by_daytype(school, :electricity)
+end
+
+save_csv(data)

--- a/script/research/targeting_and_tracking_seasonality_analysis_degreedays.rb
+++ b/script/research/targeting_and_tracking_seasonality_analysis_degreedays.rb
@@ -1,0 +1,117 @@
+require 'require_all'
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
+
+module Logging
+  @logger = Logger.new('log/display energy certificates ' + Time.now.strftime('%H %M') + '.log')
+  logger.level = :debug
+end
+
+def week_of_year(date)
+  jan_1 = Date.new(date.year, 1, 1)
+  # use Saturday for gas, as weekend thermal mass will have an influence
+  saturday_of_week1 = jan_1 - jan_1.wday - 1
+  week = ((date - saturday_of_week1) / 7).to_i
+end
+
+def weekly_school_day_kwhs(school, fuel_type, start_date, end_date)
+  meter = school.aggregate_meter(fuel_type)
+  return {} if meter.nil? || meter.amr_data.start_date > start_date || meter.amr_data.end_date < end_date
+
+  school_week_kwh       = Array.new(53, 0.0)
+  degreedays            = Array.new(53, 0.0)
+  school_week_day_count = Array.new(53, 0.0)
+
+  (start_date..end_date).each do |date|
+    next if school.holidays.day_type(date) != :schoolday
+
+    week = week_of_year(date)
+
+    school_week_kwh[week]       += meter.amr_data.one_day_kwh(date)
+    degreedays[week]            += school.temperatures.degree_days(date, 15.5)
+    school_week_day_count[week] += 1.0
+  end
+
+  average_school_day_kwh_by_week = school_week_kwh.map.with_index do |kwh, week|
+    if school_week_day_count[week] > 2
+      kwh / school_week_day_count[week]
+    else
+      Float::NAN
+    end
+  end
+
+  average_school_day_degreedays_by_week = degreedays.map.with_index do |dd, week|
+    if school_week_day_count[week] > 2
+      dd / school_week_day_count[week]
+    else
+      Float::NAN
+    end
+  end
+
+  total_dd  = average_school_day_degreedays_by_week.map{ |v| v.nan? ? 0.0 : v }.sum
+  total_kwh = average_school_day_kwh_by_week.map{ |v| v.nan? ? 0.0 : v }.sum
+
+  school_day_dd_by_week_normalised_to_1 = average_school_day_degreedays_by_week.map { |dd| dd / total_dd }
+  school_day_kwh_by_week_normalised_to_1 = average_school_day_kwh_by_week.map { |kwh| kwh / total_kwh }
+  [school_day_kwh_by_week_normalised_to_1, school_day_dd_by_week_normalised_to_1]
+end
+
+def sub_nil_nan(arr)
+  arr.map { |v| v.nan? ? nil : v }
+end
+
+def save_csv(data)
+  filename = "./Results/targeting_and_tracking_synthetic_distributions gas schools.csv"
+  puts "Saving results to #{filename}"
+  CSV.open(filename, 'w') do |csv|
+    data.each do |school_name, week_avg_kwhs|
+      csv << [school_name, sub_nil_nan(week_avg_kwhs)].flatten
+    end
+  end
+end
+
+class LogNormProfile
+  def initialize(sd, mean = 26, n = 52)
+    @sd = sd
+    @n = n
+    @mean = mean
+  end
+
+  def profile
+    dist = (0...@n).to_a.map { |x| normal_distribution(@sd, @mean, x) }
+    sum = dist.sum
+    normalised_to_1 = dist.map { |v| v / sum }
+  end
+
+  private
+
+  def normal_distribution(sd, mean, x)
+    (1.0 / (sd * ((2.0 * Math::PI) ** 0.5)) ) * Math.exp( -0.5 * (((x - mean)/sd) ** 2.0) )
+  end
+end
+
+
+regional_school_examples = ['bathampton', 'saunders', 'portsm*', 'peven*', 'long*', 'abbey*', 'durham*']
+
+school_name_pattern_match = regional_school_examples
+
+source_db = :unvalidated_meter_data
+
+school_names = RunTests.resolve_school_list(source_db, school_name_pattern_match)
+
+ap school_names
+data = {}
+start_date = Date.new(2020, 7, 1)
+end_date = Date.new(2021, 6, 30)
+
+school_names.each do |school_name|
+  school = SchoolFactory.new.load_or_use_cached_meter_collection(:name, school_name, source_db)
+
+  school_data, degreedays = weekly_school_day_kwhs(school, :gas, start_date, end_date)
+  next if school_data.empty?
+  data[school_name] = school_data
+  data["#{school_name} - best fit dd"] = degreedays
+end
+
+save_csv(data)
+

--- a/script/research/targeting_and_tracking_seasonality_analysis_normal_distribution.rb
+++ b/script/research/targeting_and_tracking_seasonality_analysis_normal_distribution.rb
@@ -155,7 +155,7 @@ def skip
   save_csv_dist(dist)
 end
 
-school_name_pattern_match = ['*'] # ' ['abbey*', 'bathamp*']
+school_name_pattern_match = ['b*'] # ' ['abbey*', 'bathamp*']
 
 source_db = :unvalidated_meter_data
 

--- a/script/research/targeting_and_tracking_seasonality_analysis_normal_distribution.rb
+++ b/script/research/targeting_and_tracking_seasonality_analysis_normal_distribution.rb
@@ -1,0 +1,186 @@
+require 'require_all'
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
+
+module Logging
+  @logger = Logger.new('log/display energy certificates ' + Time.now.strftime('%H %M') + '.log')
+  logger.level = :debug
+end
+
+def optimum_sd(school_weeks_kwh)
+  optimum = Minimiser.minimize(10.0, 50.0) {|sd| difference_to_theoretical_profile(sd, school_weeks_kwh) }
+  [optimum.x_minimum, optimum.f_minimum]
+end
+
+def difference_to_theoretical_profile(sd, school_weeks_kwh)
+  theoretical_profile = SyntheticSeasonalSchoolWeeklyElectricityProfile.new(sd.to_f, school_weeks_kwh).profile
+  difference(school_weeks_kwh, theoretical_profile)
+end
+
+def difference(school_profile, standard_profile)
+  diff = 0.0
+  school_profile.each_with_index do |val, index|
+    diff += (val - standard_profile[index]).magnitude unless val.nan?
+  end
+  diff
+end
+
+def week_of_year(date)
+  jan_1 = Date.new(date.year, 1, 1)
+  sunday_of_week1 = jan_1 - jan_1.wday
+  week = ((date - sunday_of_week1) / 7).to_i
+end
+
+def weekly_school_day_kwhs(school, fuel_type, start_date, end_date)
+  meter = school.aggregate_meter(fuel_type)
+  return {} if meter.nil? || meter.amr_data.start_date > start_date || meter.amr_data.end_date < end_date
+
+  school_week_kwh       = Array.new(53, 0.0)
+  school_week_day_count = Array.new(53, 0.0)
+
+  (start_date..end_date).each do |date|
+    next if school.holidays.day_type(date) != :schoolday
+
+    week = week_of_year(date)
+
+    school_week_kwh[week]       += meter.amr_data.one_day_kwh(date)
+    school_week_day_count[week] += 1.0
+  end
+
+  average_school_day_kwh_by_week = school_week_kwh.map.with_index do |kwh, week|
+    if school_week_day_count[week] > 2
+      kwh / school_week_day_count[week]
+    else
+      Float::NAN
+    end
+  end
+
+  total = average_school_day_kwh_by_week.map{ |v| v.nan? ? 0.0 : v }.sum
+
+  school_day_kwh_by_week_normalised_to_1 = average_school_day_kwh_by_week.map { |kwh| kwh / total }
+end
+
+def sub_nil_nan(arr)
+  arr.map { |v| v.nan? ? nil : v }
+end
+
+def save_csv(data)
+  filename = "./Results/targeting_and_tracking_synthetic_distributions schools.csv"
+  puts "Saving results to #{filename}"
+  CSV.open(filename, 'w') do |csv|
+    data.each do |school_name, week_avg_kwhs|
+      csv << [school_name, sub_nil_nan(week_avg_kwhs)].flatten
+    end
+  end
+end
+
+class LogNormProfile
+  def initialize(sd, mean = 26, n = 52)
+    @sd = sd
+    @n = n
+    @mean = mean
+  end
+
+  def profile
+    dist = (0...@n).to_a.map { |x| normal_distribution(@sd, @mean, x) }
+    sum = dist.sum
+    normalised_to_1 = dist.map { |v| v / sum }
+  end
+
+  private
+
+  def normal_distribution(sd, mean, x)
+    (1.0 / (sd * ((2.0 * Math::PI) ** 0.5)) ) * Math.exp( -0.5 * (((x - mean)/sd) ** 2.0) )
+  end
+end
+
+class SyntheticSeasonalSchoolWeeklyElectricityProfile
+  attr_reader :profile
+  def initialize(sd, weekly_kwhs)
+    weeks_avg_kwh = map_to_weeks(LogNormProfile.new(sd).profile)
+    @profile = weeks_avg_kwh.map { |v| v * 52.0 / school_weeks(weekly_kwhs) }
+  end
+
+  private
+  # norm profile lowest at either end, school ni middle in June
+  # so remap, at [25] to make up to 53 weeks in year
+  def map_to_weeks(profile)
+     # profile[26..51] + profile[0..25] + profile[25..25]
+     centre_week = 23
+     profile[centre_week..51] + profile[0...centre_week] + profile[centre_week..centre_week]
+  end
+
+  def school_weeks(weekly_kwhs)
+    weekly_kwhs.count{ |wkwh| !wkwh.nan? }
+  end
+end
+
+class FitProfile
+  def initialize(school_weeks_kwh)
+    @standard_profiles = {}
+    dist = {}
+    (10..50).step(5).each do |sd|
+      @standard_profiles[sd] = SyntheticSeasonalSchoolWeeklyElectricityProfile.new(sd.to_f, school_weeks_kwh).profile
+    end
+  end
+
+  def best_match(school_profile)
+    differences = {}
+    @standard_profiles.each do |sd, standard_profile|
+      differences[sd] = difference(school_profile, standard_profile)
+    end
+
+    min = differences.values.min
+    sd = differences.key(min)
+
+    { profile: @standard_profiles[sd], sd: sd }
+  end
+
+  private
+
+  def difference(school_profile, standard_profile)
+    diff = 0.0
+    school_profile.each_with_index do |val, index|
+      diff += (val - standard_profile[index]).magnitude unless val.nan?
+    end
+    diff
+  end
+end
+
+def skip
+  dist = {}
+  (10..50).step(5).each do |sd|
+    dist[sd] = SyntheticSeasonalSchoolWeeklyElectricityProfile.new(sd.to_f).profile
+  end
+  save_csv_dist(dist)
+end
+
+school_name_pattern_match = ['*'] # ' ['abbey*', 'bathamp*']
+
+source_db = :unvalidated_meter_data
+
+school_names = RunTests.resolve_school_list(source_db, school_name_pattern_match)
+
+ap school_names
+data = {}
+start_date = Date.new(2018, 7, 1)
+end_date = Date.new(2019, 6, 30)
+
+school_names.each do |school_name|
+  school = SchoolFactory.new.load_or_use_cached_meter_collection(:name, school_name, source_db)
+
+  school_data = weekly_school_day_kwhs(school, :electricity, start_date, end_date)
+  next if school_data.empty?
+  data[school_name] = school_data
+  fitter = FitProfile.new(school_data)
+  match = fitter.best_match(school_data)
+  sd1, eps = optimum_sd(school_data)
+  puts "=" * 100
+  puts "Optimum sd = #{sd1.round(1)} v. #{match[:sd]}"
+  puts "="  * 100
+  data["#{school_name} - ok fit #{sd1.round(1)}"]  = match[:profile]
+  data["#{school_name} - best fit #{match[:sd]}"] = SyntheticSeasonalSchoolWeeklyElectricityProfile.new(sd1, school_data).profile
+end
+
+save_csv(data)
+

--- a/script/research/targeting_and_tracking_stats.rb
+++ b/script/research/targeting_and_tracking_stats.rb
@@ -20,8 +20,9 @@ def covid_stats(schools)
       else
         if fuel_type == :electricity
           season = SeasonalMirroringCovidAdjustment.new(meter.amr_data, school.holidays)
-          stats[season.mirroring_rules] ||= []
-          stats[season.mirroring_rules].push(school.name)
+          rule = season.enough_data? ? season.adjusted_amr_data[:rule] : 'not enough data'
+          stats[rule] ||= []
+          stats[rule].push(school.name)
         end
 
         enough_data = TargetMeter.enough_amr_data_to_set_target?(meter)
@@ -54,7 +55,7 @@ def school_factory
   $SCHOOL_FACTORY ||= SchoolFactory.new
 end
 
-school_name_pattern_match = ['*']
+school_name_pattern_match = ['b*']
 source_db = :unvalidated_meter_data
 
 school_names = RunTests.resolve_school_list(source_db, school_name_pattern_match)

--- a/script/research/targeting_and_tracking_stats.rb
+++ b/script/research/targeting_and_tracking_stats.rb
@@ -28,6 +28,12 @@ def covid_stats(schools)
         stats["enough #{fuel_type} amr data"] ||= [] if enough_data
         stats["not enough #{fuel_type} amr data"] ||= [] unless enough_data
         stats[enough_data ? "enough #{fuel_type} amr data" : "not enough #{fuel_type} amr data"].push(school.name)
+
+        if meter.target_set?
+          target_set = "target already set #{fuel_type}"
+          stats[target_set] ||= []
+          stats[target_set].push(school.name)
+        end
       end
     end
   end

--- a/script/research/targeting_and_tracking_stats.rb
+++ b/script/research/targeting_and_tracking_stats.rb
@@ -1,0 +1,62 @@
+
+# targeting and tracking covid/shortage of data stats for keeping track of progress
+require 'require_all'
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
+
+module Logging
+  @logger = Logger.new('log/targetting stats' + Time.now.strftime('%H %M') + '.log')
+  logger.level = :debug
+end
+
+def covid_stats(schools)
+  stats = {}
+  schools.each do |school|
+    %i[electricity gas storage_heater].each do |fuel_type|
+      meter = school.aggregate_meter(fuel_type)
+      if meter.nil?
+        stats["No #{fuel_type} meter"] ||= []
+        stats["No #{fuel_type} meter"].push(school.name)
+      else
+        if fuel_type == :electricity
+          season = SeasonalMirroringCovidAdjustment.new(meter.amr_data, school.holidays)
+          stats[season.mirroring_rules] ||= []
+          stats[season.mirroring_rules].push(school.name)
+        end
+
+        enough_data = TargetMeter.enough_amr_data_to_set_target?(meter)
+        stats["enough #{fuel_type} amr data"] ||= [] if enough_data
+        stats["not enough #{fuel_type} amr data"] ||= [] unless enough_data
+        stats[enough_data ? "enough #{fuel_type} amr data" : "not enough #{fuel_type} amr data"].push(school.name)
+      end
+    end
+  end
+  stats
+end
+
+def print_stats(stats)
+  stats.each do |type, school_names|
+    puts type
+    school_names.each_slice(6) do |names|
+      row = names.map{ |ns| ns[0..15].ljust(16) }.join(' | ')
+      puts "    #{row}"
+    end
+  end
+end
+
+def school_factory
+  $SCHOOL_FACTORY ||= SchoolFactory.new
+end
+
+school_name_pattern_match = ['*']
+source_db = :unvalidated_meter_data
+
+school_names = RunTests.resolve_school_list(source_db, school_name_pattern_match)
+
+schools = school_names.map do |school_name|
+  school_factory.load_or_use_cached_meter_collection(:name, school_name, source_db)
+end
+
+stats = covid_stats(schools)
+
+print_stats(stats)

--- a/script/research/test_front_end_service.rb
+++ b/script/research/test_front_end_service.rb
@@ -50,7 +50,8 @@ def set_meter_attributes(schools, start_date = Date.new(2020, 9, 1), target = 0.
           }
         ]
 
-      meter.set_meter_attributes(attributes)
+      pseudo_attributes = { Dashboard::Meter.aggregate_pseudo_meter_attribute_key(fuel_type) => attributes }
+      school.merge_additional_pseudo_meter_attributes(pseudo_attributes)
     end
   end
 end
@@ -80,7 +81,7 @@ def school_factory
   $SCHOOL_FACTORY ||= SchoolFactory.new
 end
 
-school_name_pattern_match = ['b*']
+school_name_pattern_match = ['trinity*']
 source_db = :unvalidated_meter_data
 
 school_names = RunTests.resolve_school_list(source_db, school_name_pattern_match)
@@ -89,7 +90,7 @@ schools = school_names.map do |school_name|
   school_factory.load_or_use_cached_meter_collection(:name, school_name, source_db)
 end
 
-set_meter_attributes(schools)
+# set_meter_attributes(schools)
 
 schools.each do |school|
   test_service(school)

--- a/script/research/test_front_end_service.rb
+++ b/script/research/test_front_end_service.rb
@@ -55,6 +55,27 @@ def set_meter_attributes(schools, start_date = Date.new(2020, 9, 1), target = 0.
   end
 end
 
+def test_service(school)
+  puts '=' * 80
+  puts "Testing service for #{school.name}"
+  %i[electricity gas storage_heater].each do |fuel_type|
+    puts "For fuel type #{fuel_type}"
+    meter = school.aggregate_meter(fuel_type)
+    if meter.nil?
+      puts "Meter of fuel type #{fuel_type} not available"
+    else
+      if !meter.enough_amr_data_to_set_target?
+        puts 'not enough data to set target'
+      elsif !meter.target_set?
+        puts 'enough data but no target set'
+      else
+        service = TargetsService.new(school, fuel_type)
+        ap service.progress
+      end
+    end
+  end
+end
+
 def school_factory
   $SCHOOL_FACTORY ||= SchoolFactory.new
 end
@@ -69,6 +90,10 @@ schools = school_names.map do |school_name|
 end
 
 set_meter_attributes(schools)
+
+schools.each do |school|
+  test_service(school)
+end
 
 script = test_script_config(school_name_pattern_match, source_db, {})
 RunTests.new(script).run

--- a/script/research/test_targeting_and_tracking.rb
+++ b/script/research/test_targeting_and_tracking.rb
@@ -50,7 +50,8 @@ def set_meter_attributes(schools, start_date = Date.new(2020, 9, 1), target = 0.
           }
         ]
 
-      meter.set_meter_attributes(attributes)
+      pseudo_attributes = { Dashboard::Meter.aggregate_pseudo_meter_attribute_key(fuel_type) => attributes }
+      school.merge_additional_pseudo_meter_attributes(pseudo_attributes)
     end
   end
 end

--- a/script/research/test_targeting_and_tracking.rb
+++ b/script/research/test_targeting_and_tracking.rb
@@ -59,7 +59,7 @@ def school_factory
   $SCHOOL_FACTORY ||= SchoolFactory.new
 end
 
-school_name_pattern_match = ['b*']
+school_name_pattern_match = ['*']
 source_db = :unvalidated_meter_data
 
 school_names = RunTests.resolve_school_list(source_db, school_name_pattern_match)

--- a/script/research/test_targeting_and_tracking.rb
+++ b/script/research/test_targeting_and_tracking.rb
@@ -1,0 +1,74 @@
+require 'require_all'
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
+
+module Logging
+  @logger = Logger.new('log/targetting startup ' + Time.now.strftime('%H %M') + '.log')
+  logger.level = :debug
+end
+
+def test_script_config(school_name_pattern_match, source_db, attribute_overrides)
+  {
+    logger1:          { name: TestDirectoryConfiguration::LOG + "/target %{time}.log", format: "%{severity.ljust(5, ' ')}: %{msg}\n" },
+    schools:          school_name_pattern_match,
+    source:           source_db,
+    meter_attribute_overrides:  attribute_overrides,
+    logger2:          { name: "./log/pupil dashboard %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
+    adult_dashboard:  {
+                        control: {
+                          root:    :adult_analysis_page,
+                          display_average_calculation_rate: true,
+                          summarise_differences: true,
+                          report_failed_charts:   :summary,
+                          user: { user_role: :analytics, staff_role: nil },
+                          pages: %i[electric_target gas_target],
+
+                          compare_results: [
+                            { comparison_directory: 'C:\Users\phili\Documents\TestResultsDontBackup\Target\Base' },
+                            { output_directory:     'C:\Users\phili\Documents\TestResultsDontBackup\Target\New' },
+                            :summary,
+                            :report_differences,
+                            :report_differing_charts,
+                          ]
+                        }
+                      }
+  }
+end
+
+def set_meter_attributes(schools, start_date = Date.new(2020, 9, 1), target = 0.9)
+  schools.each do |school|
+    %i[electricity gas storage_heater].each do |fuel_type|
+      meter = school.aggregate_meter(fuel_type)
+      next if meter.nil?
+
+      attributes = meter.meter_attributes
+
+      attributes[:targeting_and_tracking] = [
+          {
+            start_date: start_date,
+            target:     target
+          }
+        ]
+
+      meter.set_meter_attributes(attributes)
+    end
+  end
+end
+
+def school_factory
+  $SCHOOL_FACTORY ||= SchoolFactory.new
+end
+
+school_name_pattern_match = ['b*']
+source_db = :unvalidated_meter_data
+
+school_names = RunTests.resolve_school_list(source_db, school_name_pattern_match)
+
+schools = school_names.map do |school_name|
+  school_factory.load_or_use_cached_meter_collection(:name, school_name, source_db)
+end
+
+set_meter_attributes(schools)
+
+script = test_script_config(school_name_pattern_match, source_db, {})
+RunTests.new(script).run

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -9,7 +9,7 @@ script = {
                               'combe*', 'catsfield', 'miller*','tomnac*',
                               'king-e*'
                             ],
-  schools: ['mundella*'],
+  schools: ['trinity*'],
   source:                   :unvalidated_meter_data,
   logger2:                  { name: "./log/pupil dashboard %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
   adult_dashboard:          {
@@ -20,8 +20,7 @@ script = {
                                 summarise_differences: true,
                                 report_failed_charts:   :summary, # :detailed
                                 user: { user_role: :analytics, staff_role: nil },
-                                no_pages: %i[electricity_profit_loss gas_profit_loss baseload],
-                                no_pages1: %i[gas_out_of_hours],
+                                pages: %i[electric_target gas_target],
                                 compare_results: [
                                   { comparison_directory: 'C:\Users\phili\Documents\TestResultsDontBackup\AdultDashboard\Base' },
                                   { output_directory:     'C:\Users\phili\Documents\TestResultsDontBackup\AdultDashboard\New' },

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -9,7 +9,7 @@ script = {
                               'combe*', 'catsfield', 'miller*','tomnac*',
                               'king-e*'
                             ],
-  schools: ['trinity*'],
+  schools: ['mundella*'],
   source:                   :unvalidated_meter_data,
   logger2:                  { name: "./log/pupil dashboard %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
   adult_dashboard:          {

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -9,7 +9,7 @@ script = {
                               'combe*', 'catsfield', 'miller*','tomnac*',
                               'king-e*'
                             ],
-  schools: ['*'],
+  schools: ['batheaston-slow*'],
   source:                   :unvalidated_meter_data,
   logger2:                  { name: "./log/pupil dashboard %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
   adult_dashboard:          {

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -9,7 +9,7 @@ script = {
                               'combe*', 'catsfield', 'miller*','tomnac*',
                               'king-e*'
                             ],
-  schools: ['batheaston-slow*'],
+  schools: ['trinity*'],
   source:                   :unvalidated_meter_data,
   logger2:                  { name: "./log/pupil dashboard %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
   adult_dashboard:          {

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -43,7 +43,7 @@ script = {
                 no_save_priority_variables:  { filename: './TestResults/alert priorities.csv' },
                 no_benchmark:          %i[school alert ], # detail],
                 # asof_date:          (Date.new(2018,6,14)..Date.new(2019,6,14)).each_slice(7).map(&:first),
-               asof_date:      Date.new(2021, 6, 20)
+               asof_date:      Date.new(2021, 7, 10)
               } 
   }
 }

--- a/test_support/run_tests.rb
+++ b/test_support/run_tests.rb
@@ -80,7 +80,7 @@ class RunTests
       when :source
         @meter_readings_source = configuration
       when :meter_attribute_overrides
-        @meter_attribute_overrides = meter_attribute_overrides
+        @meter_attribute_overrides = configuration
       when :reports
         $logger_format = 2
         run_reports(configuration[:charts], configuration[:control])


### PR DESCRIPTION
new interfaces in target service:
- relevance to be used to cut down list of electricity, gas, SH meters on 'Review targets' page
- enough_data - indication whether t&t will work, with further analytics development this list of school aggregate meters without enough data will dwindle
- annual_kwh_estimate_required? - whether user needs to type in an annual (DEC?) estimate; note if meter data is reset/long gap e.g. B&NES with gas, then the status of this might go from false to true when a gap appears
- culmulative_progress_chart, weekly_progress_chart, weekly_progress_to_date_chart - to be used for the 3 T&T charts used by the front end, so the analytics can the chart definition if necessary, either statically or dynamically
- target_set? - probably not needed by the front end, but used by the analytics testing at the moment as my production YAML unvalidated school data currently doesn;t have many target attributes set, this may not be true for 'test'
- monthly performance versus synthetic version of last year, as alternative to 'variance'

targeting and tracking attributes now work on aggregate meters

Not sure whether this branch is suitable for production, will need to discuss.
