### PR TITLE
Revised logic, add rspec tests

### DIFF
--- a/app/services/targets_service.rb
+++ b/app/services/targets_service.rb
@@ -36,6 +36,10 @@ class TargetsService
     Holidays.check_school_holidays(@aggregate_school)
   end
 
+  def default_target_start_date
+    TargetDates.default_target_start_date(aggregate_meter)
+  end
+
   #Are there enough historical meter readings to calculate a target?
   #This should be checking whether there’s enough historical data, regardless of
   #whether the data is currently lagging behind (see below). So checking for the

--- a/lib/dashboard/modelling/targeting and tracking/target_dates.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_dates.rb
@@ -57,26 +57,70 @@ class TargetDates
     synthetic_benchmark_start_date..synthetic_benchmark_end_date
   end
 
+  # Used by TargetsService
+  #
+  #The default start date for new targets is the 1st of the current month.
+  #
+  #But the most recent data for the aggregate meter might be a few weeks out of date, so
+  #instead default to the first of that month instead.
+  #
+  #In practice this should only ever result in us creating targets with a date of this month,
+  #or first of last month, as we're not allowing schools that have data that is more than 30 days out of date to
+  #set targets
+  #
+  #This date is also specific to this fuel type. The front-end will deal with choosing
+  #which month (this month, previous month) is used across the different fuel types
+  #when it builds the suggested target for the user
+  def self.default_target_start_date(original_meter)
+    default_date = Date.new(Date.today.year, Date.today.month, 1)
+    end_date = original_meter.amr_data.end_date
+
+    if end_date && end_date < default_date
+      #use end date year and month to deal with year boundaries
+      default_date = Date.new(end_date.year, end_date.month, 1)
+    end
+
+    default_date
+  end
+
   # used by TargetsService
+  #
+  # Should return true if we have at more than a years worth of AMR data
+  # but only if that data is not lagging by more than 30 days
+  #
+  # If its lagging by a few weeks, that's fine so long as we still have about a
+  # years worth of data
+  #
+  # TODO: suggest renaming to: one_year_of_recent_meter_readings
   def self.one_year_of_meter_readings_available_prior_to_1st_date?(original_meter)
+    target = TargetAttributes.new(original_meter)
+
+    if target.target_set?
+      #if target is set, just check there's at least a years worth of data
+      return target.first_target_date - original_meter.amr_data.start_date > 365
+    else
+      #while we could potentially generate a report if data is < 30 days old, we've decided not to allow this.
+      #Using TargetMeter.recent_data? to ensure we maintain consistency with TargetsService interface
+      return false unless TargetMeter.recent_data?(original_meter)
+
+      #Now, do we have enough data if the user created a target today?
+      #Determinee the target start date, then check there's at least a year of data available before then
+      return default_target_start_date(original_meter) - original_meter.amr_data.start_date > 365
+    end
+  end
+
+  # used by TargetsService
+  def self.can_calculate_one_year_of_synthetic_data?(original_meter)
     target = TargetAttributes.new(original_meter)
     return original_meter.amr_data.days > 365 unless target.target_set?
 
-    target.first_target_date - original_meter.amr_data.start_date > 365
-  end
-
-    # used by TargetsService
-    def self.can_calculate_one_year_of_synthetic_data?(original_meter)
-      target = TargetAttributes.new(original_meter)
-      return original_meter.amr_data.days > 365 unless target.target_set?
-  
-      # TODO(PH, 10Sep2021) - this is arbitrarily set to 30 days for the moment, refine
-      if original_meter.fuel_type == :electricity
-        TargetDates.minimum_5_school_days_1_weekend_meter_readings?(original_meter)
-      else
-        target.first_target_date - original_meter.amr_data.start_date > 30
-      end
+    # TODO(PH, 10Sep2021) - this is arbitrarily set to 30 days for the moment, refine
+    if original_meter.fuel_type == :electricity
+      TargetDates.minimum_5_school_days_1_weekend_meter_readings?(original_meter)
+    else
+      target.first_target_date - original_meter.amr_data.start_date > 30
     end
+  end
 
   def days_benchmark_data
     (benchmark_end_date - benchmark_start_date + 1).to_i

--- a/spec/app/services/targets_service_spec.rb
+++ b/spec/app/services/targets_service_spec.rb
@@ -129,7 +129,6 @@ describe TargetsService do
       allow(ENV).to receive(:[]).with("FEATURE_FLAG_TARGETS_DISABLE_ELECTRICITY").and_return("false")
       expect(service.enough_data_to_set_target?).to be true
     end
-
   end
 
 end

--- a/spec/lib/dashboard/modelling/targeting_and_tracking/target_dates_spec.rb
+++ b/spec/lib/dashboard/modelling/targeting_and_tracking/target_dates_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe TargetDates do
+
+  #mock objects that will feed test data into methods
+  let(:aggregate_meter)   { double('aggregate-meter') }
+  let(:amr_data)          { double('amr-data') }
+
+  let(:amr_start_date)        { nil }
+  let(:amr_end_date)          { nil }
+  before(:each) do
+    allow(aggregate_meter).to receive(:amr_data).and_return(amr_data)
+    allow(amr_data).to receive(:start_date).and_return(amr_start_date)
+    allow(amr_data).to receive(:end_date).and_return(amr_end_date)
+    #allow(amr_data).to receive(:days).and_return(amr_end_date - amr_start_date)
+  end
+
+  describe '#default_target_start_date' do
+    context 'there is no data' do
+      let(:this_month)        { Date.new(Date.today.year, Date.today.month, 1) }
+      it 'defaults to this month' do
+        expect(TargetDates.default_target_start_date(aggregate_meter)).to eql this_month
+      end
+    end
+
+    context 'there is recent data' do
+      #2 years
+      let(:amr_start_date)    { Date.today.prev_year.prev_year}
+      let(:amr_end_date)      { Date.today - 1 }
+      let(:this_month)        { Date.new(Date.today.year, Date.today.month, 1) }
+
+      it 'defaults to this month' do
+        expect(TargetDates.default_target_start_date(aggregate_meter)).to eql this_month
+      end
+    end
+
+    context 'the data is lagging' do
+      #2 years
+      let(:amr_start_date)    { Date.today.prev_year.prev_year}
+      #last month
+      let(:amr_end_date)      { Date.today.prev_month }
+      let(:last_month)        { Date.new(amr_end_date.year, amr_end_date.month, 1) }
+
+      it 'rolls back to month of end date' do
+        expect(TargetDates.default_target_start_date(aggregate_meter)).to eql last_month
+      end
+    end
+  end
+
+  describe '#one_year_of_meter_readings_available_prior_to_1st_date?' do
+    context 'no target set' do
+      before(:each) do
+        allow(aggregate_meter).to receive(:target_set?).and_return(false)
+        allow_any_instance_of(TargetAttributes).to receive(:target_set?).and_return(false)
+      end
+
+      context 'and there is recent data' do
+        #2 years
+        let(:amr_start_date)    { Date.today.prev_year.prev_year}
+        #less than a month ago
+        let(:amr_end_date)      { Date.today.prev_month + 10 }
+
+        it 'reports enough data' do
+          expect(TargetDates.one_year_of_meter_readings_available_prior_to_1st_date?(aggregate_meter)).to be true
+        end
+      end
+
+      context 'and data is lagging' do
+        #2 years
+        let(:amr_start_date)    { Date.today.prev_year.prev_year}
+        #more than 30 days ago
+        let(:amr_end_date)      { Date.today.prev_month - 5 }
+        it 'reports not enough data' do
+          expect(TargetDates.one_year_of_meter_readings_available_prior_to_1st_date?(aggregate_meter)).to be false
+        end
+
+      end
+
+      context 'there is less than a year of data' do
+        #90 days
+        let(:amr_start_date)    { Date.today - 90}
+        let(:amr_end_date)      { Date.today }
+        it 'reports not enough data' do
+          expect(TargetDates.one_year_of_meter_readings_available_prior_to_1st_date?(aggregate_meter)).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Added new method to TargetsService to provide a default start date for fuel type, to be used as suggestion by front-end
* Revised logic in TargetDates class when there is no current target, so that it checks for recent data and also uses a default target start date of either this month or the end date of the amr readings when checking if there's at least a years worth of data
* Added rspec tests for this logic in the TargetDates class

@PhilipTB if you could look this over, that would be helpful. I've added comments to the code and specs.

The application will still decide what the actual start date will be by checking across the various fuel types for the school. I've implemented that logic also.