### PR TITLE
fridge alert/comparison, el target comparison

### DIFF
--- a/lib/dashboard/advice/adult_dashboard_configuration.rb
+++ b/lib/dashboard/advice/adult_dashboard_configuration.rb
@@ -17,6 +17,7 @@ class DashboardConfiguration
       solar_pv_group
       underlying_electricity_meters_breakdown
       electricity_profit_loss
+      refrigeration
     ],
     gas_group: %i[
       gas_annual
@@ -128,6 +129,26 @@ class DashboardConfiguration
           exemplar_per_pupil_kw:              :exemplar_per_pupil_kw,
           benchmark_per_pupil_kw:             :benchmark_per_pupil_kw,
           summary:                            :summary
+        }
+      },
+    },
+    refrigeration: {   
+      name:                   'Experimental refrigeration analysis',
+      content_class:           AdviceRefrigeration,
+      excel_worksheet_name:   'Fridge',
+      charts: %i[
+        baseload_lastyear
+        baseload
+      ],
+      promoted_variables: {
+        AlertSummerHolidayRefrigerationAnalysis => {
+          rating:                 :rating,
+          annualised_reduction_£: :annualised_reduction_£,
+          holiday_reduction_£:    :holiday_reduction_£,
+          reduction_kw:           :reduction_kw,
+          reduction_rating:       :reduction_rating,
+          turn_off_rating:        :turn_off_rating,
+          summary:                :summary
         }
       },
     },

--- a/lib/dashboard/advice/advice_refrigeration.rb
+++ b/lib/dashboard/advice/advice_refrigeration.rb
@@ -1,0 +1,18 @@
+
+require_relative './advice_general.rb'
+require_relative '../benchmarking/benchmark_content_general.rb'
+class AdviceRefrigeration < AdviceElectricityBase
+  def baseload_one_year_chart
+    @bdown_1year_chart ||= charts[0]
+  end
+
+  def content(user_type: nil)
+    charts_and_html = []
+    charts_and_html.push( { type: :html, content: "<h2>Refrigeration</h2>" } )
+    charts_and_html += debug_content
+    charts_and_html.push( { type: :html,  content: Benchmarking::BenchmarkRefrigeration.intro } )
+    charts_and_html.push( { type: :chart, content: baseload_one_year_chart } )
+
+    remove_diagnostics_from_html(charts_and_html, user_type)
+  end 
+end

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -474,7 +474,7 @@ class AlertAnalysisBase < ContentBase
       AlertGasLongTermTrend                         => 'gslt',
       AlertStorageHeatersLongTermTrend              => 'shlt',
       AlertOptimumStartAnalysis                     => 'opts',
-      AlertSummerHolidayRefridgerationAnalysis      => 'shol',
+      AlertSummerHolidayRefrigerationAnalysis      => 'free',
       AlertElectricityTargetAnnual                  => 'etga',
       AlertGasTargetAnnual                          => 'gtga',
       AlertElectricityTarget4Week                   => 'etg4',

--- a/lib/dashboard/benchmarking/benchmark_configuration.rb
+++ b/lib/dashboard/benchmarking/benchmark_configuration.rb
@@ -98,6 +98,8 @@ module Benchmarking
           summer_holiday_electricity_analysis
           electricity_peak_kw_per_pupil
           solar_pv_benefit_estimate
+          refrigeration
+          electricity_targets
           change_in_electricity_consumption_recent_school_weeks
           change_in_electricity_holiday_consumption_previous_holiday
           change_in_electricity_holiday_consumption_previous_years_holiday
@@ -291,6 +293,34 @@ module Benchmarking
           { data: ->{ elba_£lyr_last_year },  name: 'Annual electricity £ (last year)', units: :£}
         ],
         sort_by:  [1], # column 1 i.e. Annual kWh
+        type: %i[chart table]
+      },
+      refrigeration: {
+        benchmark_class:  BenchmarkRefrigeration,
+        name:     'Annual cost of running refrigeration',
+        columns:  [
+          { data:   'addp_name',    name: 'School name', units: String, chart_data: true, content_class: AdviceElectricityAnnual },
+          { data: ->{ free_ann£ },  name: 'Estimate of annual refrigeration cost', units: :£, chart_data: true },
+          { data: ->{ free_hol£ },  name: 'Saving over summer holiday', units: :£, chart_data: true },
+          { data: ->{ -1.0 * free_kwrd },  name: 'Reduction in kW over summer holiday', units: :kw},
+        ],
+        sort_by:  [1], # column 1 i.e. annual refrigeration costs
+        type: %i[chart table]
+      },
+      electricity_targets: {
+        benchmark_class:  BenchmarkElectricityTarget,
+        name:     'Progress versus electricity target',
+        columns:  [
+          { data:   'addp_name',    name: 'School name', units: String, chart_data: true, content_class: AdviceElectricityAnnual },
+          { data: ->{ etga_tptd },  name: 'Percent above or below target since target set', units: :relative_percent, chart_data: true },
+          { data: ->{ etga_aptd },  name: 'Percent above or below last year',  units: :relative_percent},
+          { data: ->{ etga_cktd },  name: 'kWh consumption since target set',  units: :kwh},
+          { data: ->{ etga_tktd },  name: 'target kWh consumption',            units: :kwh},
+          { data: ->{ etga_uktd },  name: 'last year kWh consumption',         units: :kwh},
+          { data: ->{ etga_trsd },  name: 'start date for target',             units: :date},
+          
+        ],
+        sort_by:  [1], # column 1 i.e. annual refrigeration costs
         type: %i[chart table]
       },
       annual_electricity_out_of_hours_use: {

--- a/lib/dashboard/benchmarking/benchmark_content_general.rb
+++ b/lib/dashboard/benchmarking/benchmark_content_general.rb
@@ -1,4 +1,5 @@
 require_relative './benchmark_no_text_mixin.rb'
+require_relative './benchmark_content_base.rb'
 module Benchmarking
   CAVEAT_TEXT = {
     es_doesnt_have_all_meter_data: %q(
@@ -228,6 +229,53 @@ module Benchmarking
           annual electricity costs of &pound;1,100.
         </p>
         <%= CAVEAT_TEXT[:es_exclude_storage_heaters_and_solar_pv] %>
+      )
+      ERB.new(text).result(binding)
+    end
+  end
+  #=======================================================================================
+  class BenchmarkRefrigeration < BenchmarkContentBase
+    include BenchmarkingNoTextMixin
+
+    def self.intro
+      text = %q(
+        <p>
+          This benchmark looks at any overnight reduction in electricity consumption
+          during the last summer holidays and assumes this is mainly from refrigeration
+          being turned off, using this information to assess the efficiency of schools&apos
+          refrigeration.
+        </p>
+        <p>
+          The analysis is experimental and can create false positives.
+          If no impact is detected either the school didn&apos;t
+          turn their fridges and freezers off during the summer holidays
+          or they are very efficient with very little reduction.
+        </p>
+        <p>
+          If a potential saving is identified then
+          <a href="https://www.amazon.co.uk/electricity-usage-monitor/s?k=electricity+usage+monitor"  target="_blank">appliance monitors</a>
+          can be used to determine which fridge or freezer is most inefficient and would be economic to replace
+          (please see the case study on Energy Sparks homepage
+            <a href="https://energysparks.uk/case-studies"  target="_blank">here</a>
+          ).
+        </p>
+      )
+      ERB.new(text).result(binding)
+    end
+
+    private def introduction_text
+      BenchmarkRefrigeration.intro
+    end
+  end
+  #=======================================================================================
+  class BenchmarkElectricityTarget < BenchmarkContentBase
+    include BenchmarkingNoTextMixin
+
+    private def introduction_text
+      text = %q(
+        <p>
+          How school is progressing versus the target it has set for this year.
+        </p>
       )
       ERB.new(text).result(binding)
     end

--- a/lib/dashboard/modelling/electricity/electricity_simulator.rb
+++ b/lib/dashboard/modelling/electricity/electricity_simulator.rb
@@ -571,10 +571,10 @@ class ElectricitySimulator
         end
       end
     end
-    if @appliance_definitions[:kitchen].key?(:average_refridgeration_power)
+    if @appliance_definitions[:kitchen].key?(:average_refrigeration_power)
       (kitchen_data.start_date..kitchen_data.end_date).each do |date|
         (0..47).each do |half_hour_index|
-          kitchen_data.add_to_kwh(date, half_hour_index, @appliance_definitions[:kitchen][:average_refridgeration_power] / 2.0) # kW to kWh per 0.5 hour
+          kitchen_data.add_to_kwh(date, half_hour_index, @appliance_definitions[:kitchen][:average_refrigeration_power] / 2.0) # kW to kWh per 0.5 hour
         end
       end
     end

--- a/lib/dashboard/modelling/electricity/electricity_simulator_configuration.rb
+++ b/lib/dashboard/modelling/electricity/electricity_simulator_configuration.rb
@@ -76,11 +76,11 @@ class ElectricitySimulatorConfiguration
     },
     kitchen: {
       title: 'Kitchen',
-      editable:                 [:power, :start_time, :end_time, :average_refridgeration_power, :warming_oven_power, :warming_oven_start_time, :warming_oven_end_time],
+      editable:                 [:power, :start_time, :end_time, :average_refrigeration_power, :warming_oven_power, :warming_oven_start_time, :warming_oven_end_time],
       start_time:               TimeOfDay.new(8, 0),
       end_time:                 TimeOfDay.new(13, 0),
       power:                    3.0,
-      average_refridgeration_power: 0.4,
+      average_refrigeration_power: 0.4,
       warming_oven_power:          2.0,
       warming_oven_start_time:    TimeOfDay.new(11, 30),
       warming_oven_end_time:      TimeOfDay.new(13, 0)

--- a/lib/dashboard/modelling/electricity/electricity_simulator_exemplar_configuration.rb
+++ b/lib/dashboard/modelling/electricity/electricity_simulator_exemplar_configuration.rb
@@ -21,7 +21,7 @@ class ElectricitySimulator
 
     config[:kitchen][:start_time] = TimeOfDay.new(11, 0)
     config[:kitchen][:end_time] = TimeOfDay.new(12, 30)
-    config[:kitchen][:average_refridgeration_power] = (250 + 250 + 350) / (365 * 24)
+    config[:kitchen][:average_refrigeration_power] = (250 + 250 + 350) / (365 * 24)
     config[:kitchen][:warming_oven_power] = 1.5
     config[:kitchen][:warming_oven_end_time] = TimeOfDay.new(12, 30)
 

--- a/lib/dashboard/modelling/electricity/electricity_simulator_fitter.rb
+++ b/lib/dashboard/modelling/electricity/electricity_simulator_fitter.rb
@@ -390,8 +390,8 @@ class ElectricitySimulator
   def fit_unaccounted_for_baseload(config)
     amr_data = @existing_electricity_meter.amr_data
     baseload = amr_data.average_overnight_baseload_kw_date_range(@period.start_date, @period.end_date)
-    if config[:kitchen].key?(:average_refridgeration_power)
-      baseload += config[:kitchen][:average_refridgeration_power] / 2.0 # kW to kWh per 0.5 hour
+    if config[:kitchen].key?(:average_refrigeration_power)
+      baseload += config[:kitchen][:average_refrigeration_power] / 2.0 # kW to kWh per 0.5 hour
     end
     unaccounted_for_baseload = baseload - ict_baseload(config)
     unaccounted_for_baseload = [unaccounted_for_baseload, 0.0].max

--- a/lib/dashboard/modelling/electricity/refrigeration_analysis.rb
+++ b/lib/dashboard/modelling/electricity/refrigeration_analysis.rb
@@ -1,11 +1,11 @@
-class RefridgerationAnalysis
+class RefrigerationAnalysis
   def initialize(school)
     @school = school
     @amr_data = @school.aggregated_electricity_meters.amr_data
     @holidays = @school.holidays
   end
 
-  def attempt_to_detect_refridgeration_being_turned_off_over_summer_holidays(period, drop_criteria)
+  def attempt_to_detect_refrigeration_being_turned_off_over_summer_holidays(period, drop_criteria)
     weekend_baseloads, holiday_baseloads = weekend_versus_holiday_baseloads(period)
 
     holiday_average_baseload_kw = holiday_baseloads.sum / holiday_baseloads.length

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -22,7 +22,7 @@ script = {
                                 user: { user_role: :analytics, staff_role: nil },
 
                                 no_pages: %i[electric_target gas_target storage_heater_target],
-                                pages: %i[electric_target gas_target],
+                                no_pages: %i[electric_target gas_target],
                                 compare_results: [
                                   { comparison_directory: ENV['ANALYTICSTESTRESULTDIR'] + '\AdultDashboard\Base' },
                                   { output_directory:     ENV['ANALYTICSTESTRESULTDIR'] + '\AdultDashboard\New' },

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -5,21 +5,12 @@ require_rel '../../test_support'
 script = {
   logger1:                  { name: TestDirectoryConfiguration::LOG + "/datafeeds %{time}.log", format: "%{severity.ljust(5, ' ')}: %{msg}\n" },
   # ruby_profiler:            true,
-  no_schools:                  ['*ound*'], # ['Round.*'],
-  no_source:                   :aggregated_meter_collection,
-  schools:                  ['marks*'], # ['*astle*',], # ['White.*', 'Trin.*', 'Round.*' ,'St John.*'],
-  schools:                  ['*'], # ['*astle*',], # ['White.*', 'Trin.*', 'Round.*' ,'St John.*'],
-  no_source:                :analytics_db, # :aggregated_meter_collection,
+  schools:                  ['*'],
   source:                   :unvalidated_meter_data,
   logger2:                  { name: "./log/reports %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
   alerts:                   {
-    alerts:   nil,
-    # alerts: [ AlertEnergyAnnualVersusBenchmark ],
-    no_alerts:   [ AlertElectricityBaseloadVersusBenchmark,
-                AlertChangeInElectricityBaseloadShortTerm,
-                AlertSeasonalBaseloadVariation,
-                AlertIntraweekBaseloadVariation],
-    # nil [ AlertSummerHolidayRefridgerationAnalysis ],
+    no_alerts:   [ AlertElectricityTargetAnnual ],
+    alerts: nil,
     control:  {
                 # print_alert_banner: true,
                 # alerts_history: true,
@@ -43,7 +34,7 @@ script = {
                 no_save_priority_variables:  { filename: './TestResults/alert priorities.csv' },
                 no_benchmark:          %i[school alert ], # detail],
                 # asof_date:          (Date.new(2018,6,14)..Date.new(2019,6,14)).each_slice(7).map(&:first),
-               asof_date:      Date.new(2021, 7, 10)
+               asof_date:      Date.new(2021, 9, 25)
               } 
   }
 }

--- a/script/standard/test_benchmarks.rb
+++ b/script/standard/test_benchmarks.rb
@@ -3,7 +3,7 @@ require_relative '../../lib/dashboard.rb'
 require_rel '../../test_support'
 ENV['ENERGYSPARKSTESTMODE'] = 'ON'
 
-run_date = Date.new(2021, 7, 1)
+run_date = Date.new(2021, 9, 15)
 
 script = {
   logger1:                  { name: TestDirectoryConfiguration::LOG + "/benchmark db %{time}.log", format: "%{severity.ljust(5, ' ')}: %{msg}\n" },

--- a/test_support/run_alerts.rb
+++ b/test_support/run_alerts.rb
@@ -47,7 +47,7 @@ class RunAlerts
     AlertStorageHeaterOutOfHours                  =>'StorageHOutOfHours',
     AlertStorageHeatersLongTermTrend              =>'StorageHLongTerm',
     AlertStorageHeaterThermostatic                =>'StorageHThermo',
-    AlertSummerHolidayRefridgerationAnalysis      =>'Fridge',
+    AlertSummerHolidayRefrigerationAnalysis      =>'Fridge',
     AlertElectricityTargetAnnual                  => 'ElectricTarget1yr',
     AlertGasTargetAnnual                          => 'GasTarget1yr',
     AlertElectricityTarget4Week                   => 'ElectricTarget4wk',
@@ -66,7 +66,7 @@ class RunAlerts
     AlertStorageHeaterOutOfHours                  => 'StorageHOutOfHours',
     AlertStorageHeatersLongTermTrend              => 'StorageHLongTerm',
     AlertStorageHeaterThermostatic                => 'StorageHThermo',
-    AlertSummerHolidayRefridgerationAnalysis      => 'Fridge'
+    AlertSummerHolidayRefrigerationAnalysis      => 'Fridge'
 =end
   RESULT_CALCULATION_METHOD_CALLS = {
     front_end_template_variables:   { on_class: true,   method: :front_end_template_variables, name: 'Front end template variables', args: nil, use_puts: false },


### PR DESCRIPTION
- enabled fridge/freezer alert to help with Autumn audits, baseload analysis as some schools seem to have turned their refrigeration off over the summer
- refrigeration school comparison
- adjusted the target alerts so more useful information available
- created electricity target school comparison (currently only Ullapool showing up)