### PR TITLE
better % presentation, data available from date

### DIFF
--- a/lib/dashboard/charting_and_reports/scalar/format_energy_unit.rb
+++ b/lib/dashboard/charting_and_reports/scalar/format_energy_unit.rb
@@ -40,6 +40,7 @@ class FormatEnergyUnit
     percent_0dp:                  '%',
     relative_percent:             '%',
     relative_percent_0dp:         '%',
+    comparison_percent:           '%',
     r2:                           '',
     opt_start_standard_deviation: 'standard deviation (hours)',
     morning_start_time:           'time of day',
@@ -125,6 +126,8 @@ class FormatEnergyUnit
       formatted_val = "#{scale_num(value * 100.0, false, user_numeric_comprehension_level)}#{type_format(unit, medium)}"
       formatted_val = '+' + formatted_val if value > 0.0
       formatted_val
+    elsif unit == :comparison_percent
+      format_comparison_percent(value, medium)
     elsif unit == :date
       value.strftime('%A %e %b %Y')
     elsif unit == :datetime
@@ -149,6 +152,23 @@ class FormatEnergyUnit
     else
       sprintf('%.1f%', val * 100.0)
     end
+  end
+
+  # 1.234 => +1,230%, 0.105 => +10%, 0.095 => +9.5%, 0.005 => +0.5%, 0.0005 => +0.0%
+  def self.format_comparison_percent(value, medium)
+    percent = value * 100.0
+
+    pct_str = if !percent.infinite?.nil?
+                'Infinity'
+              elsif percent.magnitude < 10.0
+                sprintf('%+.1f', percent)
+              elsif percent.magnitude < 150.0
+                sprintf('%+.0f', percent)
+              else
+                scale_num(percent)
+              end
+
+    pct_str + type_format(:percent, medium)
   end
 
   def self.format_pound_range(range, medium, user_numeric_comprehension_level)
@@ -284,8 +304,6 @@ class FormatEnergyUnit
     BigDecimal(value, significant_figures).to_f # value.round(-(Math.log10(value).ceil - significant_figures))
   end
 end
-
-
 
 # eventually migrate from FormatEnergyUnit to more generic FormatUnit
 class FormatUnit < FormatEnergyUnit

--- a/lib/dashboard/charting_and_reports/tables/management_summary_table.rb
+++ b/lib/dashboard/charting_and_reports/tables/management_summary_table.rb
@@ -59,8 +59,8 @@ class ManagementSummaryTable < ContentBase
     KWH_NOT_ENOUGH_IN_COL_FORMAT,
     :co2,
     :£,
-    :relative_percent, # or text saying 'No recent data'
-    :relative_percent, # or text saying 'No recent data'
+    :comparison_percent, # or text saying 'No recent data'
+    :comparison_percent, # or text saying 'No recent data'
     :£
   ] # needs to be kept in sync with instance table
 
@@ -241,7 +241,7 @@ class ManagementSummaryTable < ContentBase
     elsif percent_change == NOTAVAILABLE
       NOTAVAILABLE
     else
-      format_field(percent_change,  :percent)
+      format_field(percent_change,  :comparison_percent)
     end
   end
 
@@ -367,11 +367,13 @@ class ManagementSummaryTable < ContentBase
 
   def date_available_from(period, fuel_type_data)
     if period == :workweek
-      d = fuel_type_data[:start_date] + ((7 - fuel_type_data[:start_date].wday) % 7)
-      "Data available from #{d.strftime('%a %d %b %Y')}"
+      d = fuel_type_data[:start_date] + ((7 - fuel_type_data[:start_date].wday) % 7) + 7
+      dd = [d, @asof_date].max
+      "Data available from #{dd.strftime('%a %d %b %Y')}"
     elsif period == :year
       d = fuel_type_data[:start_date] + 365
-      "Data available from #{format_future_date(d)}"
+      dd = [d, @asof_date].max
+      "Data available from #{format_future_date(dd)}"
     else
       'Date available from: internal error'
     end
@@ -413,13 +415,13 @@ class ManagementSummaryTable < ContentBase
       this_year_kwh:      { data: calc[:year][:kwh],               units: KWH_NOT_ENOUGH_IN_COL_FORMAT },
       this_year_co2:      { data: calc[:year][:co2],               units: :co2 },
       this_year_£:        { data: calc[:year][:£],                 units: :£ },
-      change_years:       { data: calc[:year][:percent_change],    units: :relative_percent },
-      change_4_weeks:     { data: calc[:last_4_weeks][:percent_change], units: :relative_percent },
+      change_years:       { data: calc[:year][:percent_change],    units: :comparison_percent },
+      change_4_weeks:     { data: calc[:last_4_weeks][:percent_change], units: :comparison_percent },
       exemplar_benefit:   { data: calc[:year][:savings_£],         units: :£ }
     }
   end
 end
 
 # old name for backwards compatibility with front end
-class HeadTeachersSchoolSummaryTable < ManagementSummaryTable
-end
+# class HeadTeachersSchoolSummaryTable < ManagementSummaryTable
+# end


### PR DESCRIPTION
+ better presentation of percent data: <10% then only to 1 dp, > 10% no dp, > 1000% 3sf
+ date available from corrected for 'Last week' so now on following Sunday and not in past

Front end changes will be required for 'no recent data' to span all 'Last week' numeric columns.

Front end warning: deprecated HeadTeachersSchoolSummaryTable class removed