### PR TITLE
experimental release

### DIFF
--- a/lib/dashboard/charting_and_reports/tables/management_summary_table.rb
+++ b/lib/dashboard/charting_and_reports/tables/management_summary_table.rb
@@ -130,7 +130,7 @@ class ManagementSummaryTable < ContentBase
         period0: { year: 0 },
         period1: { year: -1 },
         versus_exemplar: true,
-        recent_limit: 2 * 365
+        recent_limit: 3 * 30
       },
       last_4_weeks: {
         period0: { schoolweek: -3..0 },


### PR DESCRIPTION
This is an attempt to signal that annual data on the management summary table is > 3 months out of date. Suspect it might not work as intended as it depends on how the front end interprets it, but if not too much work we could review it on test to see if it helps, otherwise many need some new explicit flags to indicate the staleness of the data?