### PR TITLE
fix missing feature?

### DIFF
--- a/lib/dashboard/charting_and_reports/charts/chart_manager.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_manager.rb
@@ -62,7 +62,7 @@ class ChartManager
         raise ChartInheritanceConfigurationTooDeep, "Inheritance too deep for #{chart_config_original}"
       end
     end
-    chart_config
+    resolve_x_axis_grouping(chart_config)
   end
 
   # Used by ES Web application

--- a/lib/dashboard/charting_and_reports/charts/chart_timescale_manipulation.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_timescale_manipulation.rb
@@ -158,7 +158,7 @@ class ChartManagerTimescaleManipulation
     start_date, end_date = determine_chart_range(chart_config_original)
     timescale_type, value = timescale_type(chart_config_original)
     case timescale_type
-    when :year
+    when :year, :up_to_a_year
       ((end_date - start_date + 1) / 365.0).floor
     when :academicyear
       @school.holidays.academic_years(start_date, end_date).length

--- a/script/standard/test_drilldown_and_timescales.rb
+++ b/script/standard/test_drilldown_and_timescales.rb
@@ -1,15 +1,17 @@
 require 'require_all'
-require_relative '../lib/dashboard.rb'
-require_rel '../test_support'
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
+
+ENV['ENERGYSPARKSMETERCOLLECTIONDIRECTORY'] +=  '\\Working'
 
 script = {
   logger1:                  { name: TestDirectoryConfiguration::LOG + "/datafeeds %{time}.log", format: "%{severity.ljust(5, ' ')}: %{msg}\n" },
   # ruby_profiler:            true,
-  schools:                  ['Trin.*'], # ['Round.*'],
-  source:                   :analytics_db,
+  schools:                  ['bathamp*'], # ['Round.*'],
+  source:                   :unvalidated_meter_data,
   logger2:                  { name: "./log/reports %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
   # drilldown:                true
-  timescales:               true
+  timescales:               { chart_name: :management_dashboard_group_by_week_electricity }
   # timescale_and_drilldown:    true
 }
 

--- a/test_support/run_tests.rb
+++ b/test_support/run_tests.rb
@@ -91,7 +91,7 @@ class RunTests
       when :generate_analytics_school_meta_data
         generate_analytics_school_meta_data
       when :timescales
-        run_timescales
+        run_timescales(configuration)
       when :timescale_and_drilldown
         run_timescales_drilldown
       when :pupil_dashboard
@@ -192,12 +192,13 @@ class RunTests
     end
   end
 
-  def run_timescales
+  def run_timescales(control)
+    chart_name = control[:chart_name]
+
     schools_list.each do |school_name|
       excel_filename = TestDirectory.instance.results_directory + school_name + '- timescale shift.xlsx'
       school = load_school(school_name)
       chart_manager = ChartManager.new(school)
-      chart_name = :activities_14_days_daytype_electricity_cost 
       chart_config = chart_manager.get_chart_config(chart_name)
       result = chart_manager.run_chart(chart_config, chart_name)
 


### PR DESCRIPTION
Should fix CT request for management dashboard charts to be able to move back and forwards.

Based on the current master branch.

May be a clash with other branches as minor change to method ChartManager.resolve_chart_inheritance