### PR TITLE
Refactor y-axis manipulation to reduce dependency on meter collection

### DIFF
--- a/lib/dashboard/charting_and_reports/charts/chart_manager.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_manager.rb
@@ -44,8 +44,9 @@ class ChartManager
     chart_group_result
   end
 
-  # recursively inherit previous chart definitions config
-  def resolve_chart_inheritance(chart_config_original, max_inheritance = 20)
+  #Recursively build up complete chart config from the inheritance tree
+  #Does not resolve any data specific chart options, e.g. x axis groupings
+  def self.build_chart_config(chart_config_original, max_inheritance = 20)
     chart_config = chart_config_original.dup
     while chart_config.key?(:inherits_from)
       base_chart_config_param = chart_config[:inherits_from]
@@ -62,6 +63,12 @@ class ChartManager
         raise ChartInheritanceConfigurationTooDeep, "Inheritance too deep for #{chart_config_original}"
       end
     end
+    chart_config
+  end
+
+  # recursively inherit previous chart definitions config, then resolve x-axis against available data
+  def resolve_chart_inheritance(chart_config_original, max_inheritance = 20)
+    chart_config = build_chart_config(chart_config_original, max_inheritance)
     resolve_x_axis_grouping(chart_config)
   end
 

--- a/lib/dashboard/charting_and_reports/charts/chart_manager.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_manager.rb
@@ -68,7 +68,7 @@ class ChartManager
 
   # recursively inherit previous chart definitions config, then resolve x-axis against available data
   def resolve_chart_inheritance(chart_config_original, max_inheritance = 20)
-    chart_config = build_chart_config(chart_config_original, max_inheritance)
+    chart_config = self.class.build_chart_config(chart_config_original, max_inheritance)
     resolve_x_axis_grouping(chart_config)
   end
 
@@ -81,7 +81,7 @@ class ChartManager
 
   # Used by ES Web application
   def get_chart_config(chart_param, override_config = nil)
-    resolved_chart = resolve_chart_inheritance(standard_chart(chart_param))
+    resolved_chart = resolve_chart_inheritance(self.class.standard_chart(chart_param))
     resolved_chart = resolve_x_axis_grouping(resolved_chart)
     resolved_chart.merge!(override_config) unless override_config.nil?
     resolved_chart
@@ -187,7 +187,7 @@ class ChartManager
 
   private
 
-  def standard_chart(chart_name)
+  def self.standard_chart(chart_name)
     STANDARD_CHART_CONFIGURATION[chart_name]
   end
 

--- a/lib/dashboard/charting_and_reports/charts/chart_manager.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_manager.rb
@@ -93,6 +93,7 @@ class ChartManager
     logger.info '>' * 120
 
     chart_config = resolve_chart_inheritance(chart_config) if resolve_inheritance
+    chart_config = resolve_x_axis_grouping(chart_config) unless resolve_inheritance #dont do it twice
 
     # overrides standard chart config, for example if you want to override
     # the default meter if providing charts at meter rather than aggregate level

--- a/lib/dashboard/charting_and_reports/charts/chart_manager.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_manager.rb
@@ -82,7 +82,6 @@ class ChartManager
   # Used by ES Web application
   def get_chart_config(chart_param, override_config = nil)
     resolved_chart = resolve_chart_inheritance(self.class.standard_chart(chart_param))
-    resolved_chart = resolve_x_axis_grouping(resolved_chart)
     resolved_chart.merge!(override_config) unless override_config.nil?
     resolved_chart
   end
@@ -94,7 +93,6 @@ class ChartManager
     logger.info '>' * 120
 
     chart_config = resolve_chart_inheritance(chart_config) if resolve_inheritance
-    chart_config = resolve_x_axis_grouping(chart_config)
 
     # overrides standard chart config, for example if you want to override
     # the default meter if providing charts at meter rather than aggregate level

--- a/lib/dashboard/charting_and_reports/charts/chart_y_axis_manipulation.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_y_axis_manipulation.rb
@@ -3,10 +3,6 @@ class ChartYAxisManipulation
   class CantChangeY1AxisException < StandardError; end
   class CantChangeY2AxisException < StandardError; end
 
-  def initialize(school)
-    @chart_manager = ChartManager.new(school)
-  end
-
   def y1_axis_choices(inherited_chart_config)
     full_y1_choices = %i[kwh £ co2]
     chart_axis_choices(inherited_chart_config, full_y1_choices, :yaxis_units, :restrict_y1_axis)
@@ -16,7 +12,7 @@ class ChartYAxisManipulation
     choices = y1_axis_choices(inherited_chart_config)
     raise CantChangeY1AxisException, "Unable to change y1 axis to #{new_axis_units}" if choices.nil? ||  !choices.include?(new_axis_units)
 
-    new_config = @chart_manager.resolve_chart_inheritance(inherited_chart_config)
+    new_config = ChartManager.build_chart_config(inherited_chart_config)
 
     new_config.merge({yaxis_units: new_axis_units})
   end
@@ -30,13 +26,13 @@ class ChartYAxisManipulation
     choices = y2_axis_choices(inherited_chart_config)
     raise CantChangeY2AxisException, "Unable to change y2 axis to #{new_axis_units}"  if choices.nil? ||  !choices.include?(new_axis_units)
 
-    new_config = @chart_manager.resolve_chart_inheritance(inherited_chart_config)
+    new_config = ChartManager.build_chart_config(inherited_chart_config)
 
     new_config.merge({y2_axis: new_axis_units})
   end
 
   def chart_axis_choices(inherited_chart_config, choices, axis_key, restriction_key)
-    chart_config = @chart_manager.resolve_chart_inheritance(inherited_chart_config)
+    chart_config = ChartManager.build_chart_config(inherited_chart_config)
 
     current_unit = chart_config[axis_key]
 

--- a/script/standard/test_y_axis_manipulation.rb
+++ b/script/standard/test_y_axis_manipulation.rb
@@ -24,34 +24,34 @@ puts "Chart: #{chart_name}"
 
 existing_chart_config = ChartManager::STANDARD_CHART_CONFIGURATION[chart_name]
 
-ChartYAxisManipulation.new(school).y1_axis_choices(existing_chart_config).each do |y1_axis_unit|
-  chart_config = ChartYAxisManipulation.new(school).change_y1_axis_config(existing_chart_config, y1_axis_unit)
+ChartYAxisManipulation.new.y1_axis_choices(existing_chart_config).each do |y1_axis_unit|
+  chart_config = ChartYAxisManipulation.new.change_y1_axis_config(existing_chart_config, y1_axis_unit)
   chart_data = chart_manager.run_chart(chart_config, chart_name)
   charts.push(chart_data)
 end
 
-ChartYAxisManipulation.new(school).y2_axis_choices(existing_chart_config).each do |y2_axis_unit|
-  chart_config = ChartYAxisManipulation.new(school).change_y2_axis_config(existing_chart_config, y2_axis_unit)
+ChartYAxisManipulation.new.y2_axis_choices(existing_chart_config).each do |y2_axis_unit|
+  chart_config = ChartYAxisManipulation.new.change_y2_axis_config(existing_chart_config, y2_axis_unit)
   chart_data = chart_manager.run_chart(chart_config, chart_name)
   charts.push(chart_data)
 end
 
 puts "Checking solar charts cant be changed"
 
-%i[benchmark solar_pv_group_by_week solar_pv_group_by_week_by_submeter pupil_dashboard_solar_pv_one_week_by_day solar_pv_group_by_month].each do |chart_name| 
+%i[benchmark solar_pv_group_by_week solar_pv_group_by_week_by_submeter pupil_dashboard_solar_pv_one_week_by_day solar_pv_group_by_month].each do |chart_name|
   existing_chart_config = ChartManager::STANDARD_CHART_CONFIGURATION[chart_name]
-  puts "#{sprintf('%-40.40s',chart_name)}: #{ChartYAxisManipulation.new(school).y1_axis_choices(existing_chart_config)}"
+  puts "#{sprintf('%-40.40s',chart_name)}: #{ChartYAxisManipulation.new.y1_axis_choices(existing_chart_config)}"
 end
 
 puts 'Testing exception checking:'
 begin
-  chart_config = ChartYAxisManipulation.new(school).change_y1_axis_config(existing_chart_config, :rubbish)
+  chart_config = ChartYAxisManipulation.new.change_y1_axis_config(existing_chart_config, :rubbish)
 rescue ChartYAxisManipulation::CantChangeY1AxisException => e
   puts e.message
 end
 
 begin
-  chart_config = ChartYAxisManipulation.new(school).change_y2_axis_config(existing_chart_config, :rubbish)
+  chart_config = ChartYAxisManipulation.new.change_y2_axis_config(existing_chart_config, :rubbish)
 rescue ChartYAxisManipulation::CantChangeY2AxisException => e
   puts e.message
 end

--- a/script/utilities/test_community_use.rb
+++ b/script/utilities/test_community_use.rb
@@ -17,8 +17,8 @@ def calculate_charts_with_and_without_community_use(school, chart_name, non_comm
 
   existing_chart_config = ChartManager::STANDARD_CHART_CONFIGURATION[chart_name]
 
-  ChartYAxisManipulation.new(school).y1_axis_choices(existing_chart_config).each do |y1_axis_unit|
-    chart_config = ChartYAxisManipulation.new(school).change_y1_axis_config(existing_chart_config, y1_axis_unit)
+  ChartYAxisManipulation.new.y1_axis_choices(existing_chart_config).each do |y1_axis_unit|
+    chart_config = ChartYAxisManipulation.new.change_y1_axis_config(existing_chart_config, y1_axis_unit)
 
     chart_data = chart_manager.run_chart(chart_config, chart_name, true)
     charts.push(chart_data)
@@ -126,7 +126,7 @@ school_names.each do |school_name|
   # test_community_use_breakdowns(school)
 
   # random_dates(school)
-  
+
   charts = run_charts(school)
 
   excel_school_name = school_name.gsub(' ', '').gsub('-', '')[0..10]

--- a/spec/lib/dashboard/charting_and_reports/chart_manager_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/chart_manager_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe ChartManager do
+
+  context '#build_chart_config' do
+    let(:chart_name)   { :benchmark }
+    let(:chart_config) { ChartManager::STANDARD_CHART_CONFIGURATION[chart_name] }
+
+    it 'returns original if no inheritance' do
+      expect( ChartManager.build_chart_config(chart_config) ).to eql chart_config
+    end
+
+    context 'when chart inherits from another' do
+      let(:chart_name)    { :benchmark_kwh }
+      let(:new_config)    { ChartManager.build_chart_config(chart_config) }
+
+      it 'resolves inherited properties' do
+        expect(new_config[:chart1_type]).to eql(:bar)
+      end
+
+      it 'preserves child properties' do
+        expect(new_config[:yaxis_units]).to eql(:kwh) #not :£
+      end
+
+      it 'removes inherit_from' do
+        expect(new_config[:inherits_from]).to be_nil
+      end
+    end
+  end
+
+  context '#resolve_chart_inheritance' do
+    let(:chart_name)    { :benchmark }
+    let(:chart_config)  { ChartManager::STANDARD_CHART_CONFIGURATION[chart_name] }
+    let(:school)        { nil }
+    let(:chart_manager) { ChartManager.new(school) }
+
+    it 'resolves config' do
+      expect( chart_manager.resolve_chart_inheritance(chart_config) ).to eql chart_config
+    end
+  end
+
+  context '#get_chart_config' do
+    let(:chart_name)    { :benchmark }
+    let(:school)        { nil }
+    let(:chart_manager) { ChartManager.new(school) }
+
+    let(:overrides)     { {this: :that} }
+
+    it 'retrieves config' do
+      expect( chart_manager.get_chart_config(chart_name) ).to eql ChartManager::STANDARD_CHART_CONFIGURATION[chart_name]
+    end
+
+    it 'applies overrides' do
+      config = chart_manager.get_chart_config(chart_name, overrides)
+      expect(config[:this]).to eql :that
+    end
+
+  end
+end

--- a/spec/lib/dashboard/charting_and_reports/charts/chart_y_axis_manipulation_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/chart_y_axis_manipulation_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe ChartYAxisManipulation do
+
+  let(:chart_name)            { :gas_longterm_trend }
+  let(:existing_chart_config) { ChartManager::STANDARD_CHART_CONFIGURATION[chart_name] }
+  let(:full_y1_choices)       { %i[kwh £ co2] }
+  let(:full_y2_choices)       { %i[temperature degreedays irradiance gridcarbon gascarbon] }
+
+  let(:manipulator)           { ChartYAxisManipulation.new }
+  describe '#y1_axis_choices' do
+    it 'returns valid choices' do
+      expect( manipulator.y1_axis_choices(existing_chart_config) ).to match_array(full_y1_choices)
+    end
+
+    context 'with solar charts' do
+      let(:chart_name) { :solar_pv_group_by_week }
+      it 'removes all choices' do
+        expect( manipulator.y1_axis_choices(existing_chart_config) ).to be_nil
+      end
+    end
+
+    context 'with benchmarks' do
+      let(:chart_name) { :benchmark }
+      it 'restricts to £ and c02' do
+        expect( manipulator.y1_axis_choices(existing_chart_config) ).to match_array([:£, :co2])
+      end
+    end
+  end
+
+  describe '#y2_axis_choices' do
+    it 'returns valid choices' do
+      expect( manipulator.y2_axis_choices(existing_chart_config) ).to match_array(full_y2_choices)
+    end
+  end
+
+  describe '#change_y1_axis_config' do
+    it 'changes axis on valid choice' do
+      choices = manipulator.y1_axis_choices(existing_chart_config)
+      new_config = manipulator.change_y1_axis_config(existing_chart_config, choices.first)
+      expect(new_config[:yaxis_units]).to eql choices.first
+    end
+
+    it 'raises exception for invalid choice' do
+      expect { manipulator.change_y1_axis_config(existing_chart_config, :rubbish) }.to raise_error ChartYAxisManipulation::CantChangeY1AxisException
+    end
+  end
+
+  describe '#change_y2_axis_config' do
+    it 'changes axis on valid choice' do
+      choices = manipulator.y2_axis_choices(existing_chart_config)
+      new_config = manipulator.change_y2_axis_config(existing_chart_config, choices.first)
+      expect(new_config[:y2_axis]).to eql choices.first
+    end
+
+    it 'raises exception for invalid choice' do
+      expect { manipulator.change_y2_axis_config(existing_chart_config, :rubbish) }.to raise_error ChartYAxisManipulation::CantChangeY2AxisException
+    end
+  end
+
+end


### PR DESCRIPTION
* Factor out code for resolving inherited chart config into a new class method
* Keep original `resolve_chart_inheritance` method and call to `resolve_x_axis_grouping` which requires access to school meter data
* Change Y-Axis manipulation to only use ChartManager class methods so we don't need any meter data to determine y-axis choices. Required so the application doesn't have to aggregate the school unnecessarily.
* Add rspec tests to cover all of the above
* Removed unnecessary repeated call to `resolve_x_axis_grouping` in `get_chart_config` and add a conditional check to avoid calling the method twice in `run_chart`