### PR TITLE
Add school and community use times

### DIFF
--- a/app/models/dashboard/school.rb
+++ b/app/models/dashboard/school.rb
@@ -10,7 +10,7 @@ module Dashboard
 
     # Activation date is when the school was activated by an administrator in the Energy Sparks front end - it is a date
     # Created at is when the school was created during the onboarding process - it is a timestamp
-    attr_reader :name, :address, :floor_area, :number_of_pupils, :school_type, :area_name, :postcode, :activation_date, :created_at
+    attr_reader :name, :address, :floor_area, :number_of_pupils, :school_type, :area_name, :postcode, :activation_date, :created_at, :school_times, :community_use_times
     attr_accessor :urn
 
     def initialize(
@@ -23,7 +23,9 @@ module Dashboard
       urn: nil,
       postcode: nil,
       activation_date: nil,
-      created_at: nil
+      created_at: nil,
+      school_times: [],
+      community_use_times: []
     )
       @school_type = school_type
       @name = name
@@ -36,6 +38,8 @@ module Dashboard
       @postcode = postcode
       @activation_date = activation_date
       @created_at = created_at
+      @school_times = school_times
+      @community_use_times = community_use_times
     end
 
     def to_s

--- a/app/services/meter_collection_factory.rb
+++ b/app/services/meter_collection_factory.rb
@@ -24,7 +24,9 @@ class MeterCollectionFactory
       urn: school_data[:urn],
       postcode: school_data[:postcode],
       activation_date: school_data[:activation_date],
-      created_at: school_data[:created_at]
+      created_at: school_data[:created_at],
+      school_times: school_day[:school_times],
+      community_use_times: school_day[:community_use_times]
     )
 
     meter_collection = MeterCollection.new(school,


### PR DESCRIPTION
Interface for passing community use times from app to analytics.

Times are associated with the school and will be present as part of the `school_data` provided to `MeterCollectionFactory.build`.

This is used to set two attributes on the `Dashboard::School` object, one for the school opening hours, one for community use periods. The attributes contain an array of time periods, that are structured as follows:

```
school_times: [
 {
   day: :monday | :tuesday | :wednesday  #symbols for day of the week. school times are only mon-fri. community use may have :weekdays, :weekends, :everyday
   usage_type: :school_day | :community_use
   opening_time: TimeOfDay #existing object for describing time of day
   closing_time: TimeOfDay
   calendar_period: :term_times, :only_holidays, :all_year #always :term_times for :school_use
 }
]
```

This closely matches the way the application stores school times.