### PR TITLE
bug fix dont backdate DCCtariffs of exemplar meter

### DIFF
--- a/app/models/tariffs/meter_tariff_manager.rb
+++ b/app/models/tariffs/meter_tariff_manager.rb
@@ -56,7 +56,7 @@ class MeterTariffManager
 
   def accounting_cost(date, kwh_x48)
     tariff = accounting_tariff_for_date(date)
-    
+
     return nil if tariff.nil?
 
     tariff.costs(date, kwh_x48)
@@ -224,8 +224,13 @@ class MeterTariffManager
   def backdate_dcc_tariffs(meter)
     return if dcc_tariffs.empty?
 
+    if meter.amr_data.nil?
+      logger.info 'Nil amr data - for benchmark/exemplar(?) dcc meter - not backdating dcc tariffs'
+      return
+    end
+
     days_gap = dcc_tariffs.first.tariff[:start_date] - meter.amr_data.start_date
-   
+
     override_days = meter.meter_attributes[:backdate_tariff].first[:days] if meter.meter_attributes.key?(:backdate_tariff)
 
     if override_days.nil?

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -7,8 +7,8 @@ module Logging
 end
 
 overrides = { 
-  schools: ['bath*'],
-  # adult_dashboard: { control: { pages: pages: %i[baseload] } }
+  schools: ['baseload*'],
+  adult_dashboard: { control: { pages: %i[baseload] } }
 }
 
 script = RunAdultDashboard.default_config.deep_merge(overrides)

--- a/test_support/school_factory.rb
+++ b/test_support/school_factory.rb
@@ -86,7 +86,7 @@ class SchoolFactory
         school = YAML.load_file(yaml_filename)
       }
       # save to marshal for subsequent speedy load
-      File.open(filename, 'wb') { |f| f.write(Marshal.dump(school)) }
+      File.open(marshal_filename, 'wb') { |f| f.write(Marshal.dump(school)) }
     else
       RecordTestTimes.instance.record_time(school_filename, 'marshalload', ''){
         school = Marshal.load(File.open(marshal_filename))


### PR DESCRIPTION
Not sure this is the best solution, and will need testing on some charts, but the code was trying to backdate DCC tariffs on a virtual copy of a meter with DCC/SMETS2 tariffs, when the amr data hadn't actually been calculated yet - in its lazy loaded construction phase - there is a slight risk for a differential tariff that this isn't correctly reflected in the £ scaled charts with benchmark and exemplar meter data on? It is a bit of a moot point, should the benchmark and exemplar schools use the same differential tariff structure of the real parent school, or a flat tariff like most schools?