### PR TITLE
Reduced test script memory usage

### DIFF
--- a/app/models/meter_indicative_standing_charge.rb
+++ b/app/models/meter_indicative_standing_charge.rb
@@ -8,7 +8,6 @@ class MeterIndicativeStandingCharge
   def daily_standing_charge_£_per_day
     if (defined? @tariff) && !@tariff.nil?
       logger.info "Using indicative standing charge for meter #{@mpxn} of #{@tariff[:rate]}"
-      puts "Using indicative standing charge for meter #{@mpxn} of #{@tariff[:rate]}"
       @tariff[:rate]
     else
       3.0

--- a/lib/dashboard/alerts/common/alert_prioritisation_data.rb
+++ b/lib/dashboard/alerts/common/alert_prioritisation_data.rb
@@ -3,7 +3,7 @@
 class AlertAdditionalPrioritisationData < AlertAnalysisBase
   include Logging
   attr_reader :days_to_next_holiday, :days_from_last_holiday
-  attr_reader :average_temperature_last_week, :average_forecast_temperature_next_week
+  attr_reader :average_temperature_last_week, :average_forecast_temperature_next_week_deprecated
   attr_reader :annual_electricity_kwh, :annual_gas_kwh, :annual_storage_heater_kwh
   attr_reader :annual_electricity_£, :annual_gas_£, :annual_storage_heater_£
   attr_reader :degree_days_15_5C_domestic
@@ -77,7 +77,7 @@ class AlertAdditionalPrioritisationData < AlertAnalysisBase
       units: Float,
       priority_code:  'AVGT'
     },
-    average_forecast_temperature_next_week: {
+    average_forecast_temperature_next_week_deprecated: {
       description: 'average forecast temperature next week',
       units: Float,
       priority_code:  'FAVT'
@@ -142,8 +142,8 @@ class AlertAdditionalPrioritisationData < AlertAnalysisBase
     @days_to_next_holiday = calculate_days_to_next_holiday(asof_date)
     @days_from_last_holiday = calculate_days_to_previous_holiday(asof_date)
     temperatures = AverageHistoricOrForecastTemperatures.new(@school)
-    @average_temperature_last_week = temperatures.calculate_average_temperature_for_week_following(asof_date - 7)
-    @average_forecast_temperature_next_week = temperatures.calculate_average_temperature_for_week_following(asof_date)
+    # @average_temperature_last_week = temperatures.calculate_average_temperature_for_week_following(asof_date - 7)
+    # @average_forecast_temperature_next_week = temperatures.calculate_average_temperature_for_week_following(asof_date)
 
     @annual_electricity_kwh     = annual_kwh(@school.aggregated_electricity_meters, :electricity,     asof_date, :kwh)
     @annual_gas_kwh             = annual_kwh(@school.aggregated_heat_meters,        :gas,             asof_date, :kwh)

--- a/lib/dashboard/alerts/common/average_historic_or_forecast_temperatures.rb
+++ b/lib/dashboard/alerts/common/average_historic_or_forecast_temperatures.rb
@@ -8,7 +8,7 @@ class AverageHistoricOrForecastTemperatures
     @school = school
   end
 
-  def calculate_average_temperature_for_week_following(asof_date)
+  def calculate_average_temperature_for_week_following_deprecated(asof_date)
     calculate_average_temperature_from_forecast_or_historic(asof_date, 7)
   end
 

--- a/lib/dashboard/alerts/gas/alert_model_cache_mixin.rb
+++ b/lib/dashboard/alerts/gas/alert_model_cache_mixin.rb
@@ -2,9 +2,10 @@ module AlertModelCacheMixin
   # during analytics testing store model results to save recalculating for different alerts at same school
   private def model_cache(urn, asof_date)
     return call_model(asof_date) unless AlertAnalysisBase.test_mode
-    @@model_cache_results = {} unless defined?(@@model_cache_results)
+    @@model_cache_results ||= {}
     composite_key = urn.to_s + ':' + asof_date.to_s
     return @@model_cache_results[composite_key] if @@model_cache_results.key?(composite_key)
+    @@model_cache_results.delete(@@model_cache_results.keys.first) if @@model_cache_results.length > 10 # limit cache size else memory leak
     @@model_cache_results[composite_key] = call_model(asof_date)
   end
 

--- a/lib/dashboard/charting_and_reports/content_base.rb
+++ b/lib/dashboard/charting_and_reports/content_base.rb
@@ -56,7 +56,7 @@ class ContentBase
     header  = ['Variable', 'Value']
     units   = [String,     String ]
 
-    tb_format = tables.map { |k, t| "<h3>#{k}</h3>" + t }.join(' ')
+    tb_format = tables.map { |k, t| "<h3>#{k}</h3>" + (t || "<b>Nil table</b>") }.join(' ')
 
     HtmlTableFormatting.new(header, scalars.to_a, units).html + tb_format
   end

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -3,13 +3,14 @@ require_relative '../../lib/dashboard.rb'
 require_all './test_support/'
 
 module Logging
-  logger.level = :debug
+  @logger = Logger.new('log\logs.log')
+  logger.level = :error
 end
 
 overrides = {
   schools: ['*'], # ['bxxxxalli*', 'wimble*'],
   # adult_dashboard: { control: { pages: %i[boiler_control_morning_start_time], user: { user_role: :analytics, staff_role: nil } } }
-  adult_dashboard: { control: { pages: %i[ gas_target] } }
+  # adult_dashboard: { control: { pages: %i[ gas_target] } }
 }
 
 script = RunAdultDashboard.default_config.deep_merge(overrides)

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -2,15 +2,19 @@ require 'require_all'
 require_relative '../../lib/dashboard.rb'
 require_rel '../../test_support'
 
-asof_date = Date.new(2022, 3, 3)
+module Logging
+  @logger = Logger.new('log\logs.log')
+  logger.level = :error
+end
+
+asof_date = Date.new(2022, 4, 23)
 schools = ['marksb*']
 
 overrides = {
-  schools:  ['*'],
-  alerts:   { alerts: nil, control: { asof_date: Date.new(2022, 2, 1) } }
+  schools:  ['king-j*'],
+  alerts:   { alerts: nil, control: { asof_date: asof_date} }
   # alerts:   { alerts: [ AlertElectricityTarget1Week, AlertGasTarget1Week ], control: { asof_date: Date.new(2022, 2, 1) } }
 }
-
 
 script = RunAlerts.default_config.deep_merge(overrides)
 

--- a/script/standard/test_all.rb
+++ b/script/standard/test_all.rb
@@ -12,8 +12,8 @@ end
 run_date = Date.new(2022, 4, 23)
 
 overrides = {
-  schools:  ['*'],
-  control: { cache_school: false }
+  schools:      ['*'],
+  cache_school: false
 }
 
 benchmark_overrides = overrides.merge(

--- a/script/standard/test_all.rb
+++ b/script/standard/test_all.rb
@@ -1,0 +1,57 @@
+# test report manager
+require 'require_all'
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
+require './script/report_config_support.rb'
+
+module Logging
+  @logger = Logger.new('log\logs.log')
+  logger.level = :error
+end
+
+run_date = Date.new(2022, 4, 23)
+
+overrides = {
+  schools:  ['*'],
+  control: { cache_school: false }
+}
+
+benchmark_overrides = overrides.merge(
+  {
+    calculate_and_save_variables: true,
+    asof_date:     run_date,
+    run_content: { asof_date: run_date }
+  }
+)
+
+alert_overrides = overrides.merge(alerts:   { alerts: nil, control: { asof_date: run_date} })
+
+chart_control = {
+  save_to_excel:  true,
+
+  compare_results: [
+    :summary,
+    :report_differences,
+    :report_differing_charts
+  ]
+}
+
+chart_overrides = {
+  charts:   { charts: RunCharts.standard_charts_for_school, control: chart_control }
+}.merge(overrides)
+
+scripts = {
+  'Management Summary Table' => RunManagementSummaryTable.default_config.deep_merge(overrides),
+  'Expert Analysis Pages'    => RunAdultDashboard.default_config.deep_merge(overrides),
+  'Benchmarks'               => RunBenchmarks.default_config.deep_merge(benchmark_overrides),
+  'Alerts'                   => RunAlerts.default_config.deep_merge(alert_overrides),
+  'Equivalences'             => RunEquivalences.default_config.deep_merge(overrides),
+  'Charts'                   => RunCharts.default_config.deep_merge(chart_overrides)
+}
+
+scripts.each do |name, script|
+  puts "*" * 200
+  STDERR.puts "Running: #{name}"
+  puts "*" * 200
+  RunTests.new(script).run
+end

--- a/test_support/logger_control.rb
+++ b/test_support/logger_control.rb
@@ -16,6 +16,10 @@ module Logging
       @history = StringIO.new "", "w"
     end
 
+    def file
+      @file
+    end
+
     def file=(filename_or_io)
       @file = filename_or_io.is_a?(IO) ? filename_or_io : File.open(filename_or_io, 'a+')
       @file.write @history.string if @history
@@ -35,6 +39,4 @@ module Logging
   @@es_logger_file = MyIO.new
   @@es_logger_file.file = STDOUT
   @logger = Logger.new(@@es_logger_file)
-
 end
-

--- a/test_support/run_benchmarks.rb
+++ b/test_support/run_benchmarks.rb
@@ -6,10 +6,11 @@ class RunBenchmarks
   FRONTEND_CSS = '<link rel="stylesheet" media="all" href="C:\Users\phili\OneDrive\ESDev\energy-sparks_analytics\InputData\application-1.css" />
   <link rel="stylesheet" media="screen" href="\Users\phili\OneDrive\ESDev\energy-sparks_analytics\InputData\application-2.css" />'
   attr_reader :control
-  def initialize(control, schools, source)
+  def initialize(control, schools, source, cache_school)
     @control = control
     @source = source
     @school_pattern_match = schools
+    @cache_school = cache_school
     @database = BenchmarkDatabase.new(control[:filename])
     @source_of_school_data = control[:source]
   end
@@ -64,7 +65,7 @@ class RunBenchmarks
   def run_alerts_to_update_database
     school_list = SchoolFactory.instance.school_file_list(@source, @school_pattern_match)
     school_list.sort.each do |school_name|
-      school = SchoolFactory.instance.load_school(@source, school_name)
+      school = SchoolFactory.instance.load_school(@source, school_name, cache: @cache_school)
       calculate_alerts(school, control[:asof_date])
     end
 

--- a/test_support/school_factory.rb
+++ b/test_support/school_factory.rb
@@ -11,6 +11,8 @@ class SchoolFactory
     @school_cache ||= {}
     return @school_cache[filename_prefix] if @school_cache.key?(filename_prefix)
 
+    garbage_collect(filename_prefix) unless cache
+
     school = load_and_build_school(source, filename_prefix, meter_attributes_overrides)
 
     @school_cache[filename_prefix] = school if cache
@@ -58,6 +60,11 @@ class SchoolFactory
     school = build_meter_collection(school, meter_attributes_overrides: meter_attributes_overrides)
     validate_and_aggregate(school, source)
     school
+  end
+
+  def garbage_collect(name)
+    puts "Garbage collecting"
+    GC.start
   end
 
   def validate_and_aggregate(school, source)

--- a/test_support/school_factory.rb
+++ b/test_support/school_factory.rb
@@ -63,7 +63,7 @@ class SchoolFactory
   end
 
   def garbage_collect(name)
-    puts "Garbage collecting"
+    puts 'Garbage collecting'
     GC.start
   end
 


### PR DESCRIPTION
Stopes paging and reduces memory usage for all_tests and all schools below 700MB. There is potentially more to be done, potential to keep usage below 300MB but would require changes to the application.