### PR TITLE
reinstate bump to 1st of month t&t date no est.

### DIFF
--- a/lib/dashboard/modelling/targeting and tracking/target_dates.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_dates.rb
@@ -234,14 +234,24 @@ class TargetDates
 
   def calculate_target_start_date
     t_date = if @original_meter.annual_kwh_estimate.nan? &&
-      @target.first_target_date - DAYSINYEAR < @original_meter.amr_data.start_date
-      logger.info "Moving target start date forward to #{@original_meter.amr_data.start_date + DAYSINYEAR} as target not set"
-      [@original_meter.amr_data.start_date + DAYSINYEAR, @original_meter.amr_data.end_date - DAYSINYEAR].max
-    else
-      [@target.first_target_date, @original_meter.amr_data.end_date - DAYSINYEAR].max
-    end
+                @target.first_target_date - DAYSINYEAR < @original_meter.amr_data.start_date
+
+                td = [
+                  first_day_of_next_month(@original_meter.amr_data.start_date + DAYSINYEAR),
+                  @original_meter.amr_data.end_date - DAYSINYEAR
+                ].max
+                logger.info "Moving target start date forward to #{td} as target not set"
+                td
+              else
+                [@target.first_target_date, @original_meter.amr_data.end_date - DAYSINYEAR].max
+              end
+
     check_target_start_date_after_first_meter_date(t_date)
     t_date
+  end
+
+  def first_day_of_next_month(date)
+    date.day == 1 ? date : date.next_month.beginning_of_month
   end
 
   def check_target_start_date_after_first_meter_date(date)


### PR DESCRIPTION
Branch name is a misnomer, should be Chase Lane.
This is essentially a reinstatement of branch [bump-target-start-date-of-school-with-no-annual-estimate-to-1st-full-month](https://github.com/Energy-Sparks/energy-sparks_analytics/tree/bump-target-start-date-of-school-with-no-annual-estimate-to-1st-full-month) which seems to have got lost somewhere in recent git updates. Limited testing, but was tested previously. Rleased prior to testing to confirm this is what is wanted/needed.
