### PR TITLE
3x fixes for t&t charts, tables

### DIFF
--- a/app/models/meter_collection.rb
+++ b/app/models/meter_collection.rb
@@ -91,6 +91,10 @@ class MeterCollection
     end
   end
 
+  def target_school?
+    false
+  end
+
   def aggregate_meter(fuel_type)
     case fuel_type
     when :electricity

--- a/lib/dashboard/charting_and_reports/charts/aggregator_config.rb
+++ b/lib/dashboard/charting_and_reports/charts/aggregator_config.rb
@@ -151,6 +151,10 @@ class AggregatorConfig < OpenStruct
     dig(:target, :extend_chart_into_future) == true
   end
 
+  def truncate_before_start_date?
+    dig(:target, :truncate_before_start_date) == true
+  end
+
   def sort_by?
     !sort_by.nil?
   end

--- a/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
@@ -220,7 +220,7 @@ class ChartManager
     },
     targeting_and_tracking_weekly_electricity_one_year_column_deprecated: {
       name:           :targeting_and_tracking_weekly_electricity_one_year_column.to_s,
-      target:             {calculation_type: :day, extend_chart_into_future: true},
+      target:             {calculation_type: :day, extend_chart_into_future: true, truncate_before_start_date: true},
       inherits_from: :targeting_and_tracking_weekly_electricity_to_date_column
     },
 
@@ -273,7 +273,7 @@ class ChartManager
     # used by front end via targets_service.rb
     targeting_and_tracking_weekly_electricity_to_date_cumulative_line: {
       name:                         'Cumulative progress versus target',
-      target:                       {calculation_type: :day, extend_chart_into_future: true},
+      target:                       {calculation_type: :day, extend_chart_into_future: true, truncate_before_start_date: true},
       ignore_single_series_failure: true,
       inherits_from:                :targeting_and_tracking_weekly_electricity_one_year_cumulative_line
     },
@@ -284,17 +284,18 @@ class ChartManager
         ['Energy:<school_name>', 'actual']
       ],
       chart1_type:                  :line,
+      chart1_subtype:               nil,
       series_breakdown:             :none,
       x_axis:                       :week,
       nullify_trailing_zeros:       true,
       timescale:                    :up_to_a_year,
       ignore_single_series_failure: true,
-      target:                       {calculation_type: :day, extend_chart_into_future: true},
+      target:                       {calculation_type: :day, extend_chart_into_future: true, truncate_before_start_date: true},
       inherits_from:                :group_by_week_electricity
     },
     targeting_and_tracking_weekly_electricity_one_year_line: {
       name:           'Weekly progress versus target to date',
-      target:             {calculation_type: :day, extend_chart_into_future: false},
+      target:             {calculation_type: :day, extend_chart_into_future: false, truncate_before_start_date: true},
       inherits_from: :targeting_and_tracking_weekly_electricity_to_date_line
     },
     targeting_and_tracking_standard_group_by_week_electricity: {
@@ -303,7 +304,7 @@ class ChartManager
     },
     targeting_and_tracking_target_only_group_by_week_electricity: {
       name:          'Target only <%= meter.fuel_type %> group by week chart (<%= total_kwh %> kWh)',
-      target:        {calculation_type: :day, extend_chart_into_future: false, show_target_only: true},
+      target:        {calculation_type: :day, extend_chart_into_future: false, show_target_only: true, truncate_before_start_date: true},
       inherits_from: :targeting_and_tracking_standard_group_by_week_electricity
     },
     targeting_and_tracking_unscaled_target_group_by_week_electricity: {

--- a/lib/dashboard/modelling/targeting and tracking/target_dates.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_dates.rb
@@ -234,14 +234,24 @@ class TargetDates
 
   def calculate_target_start_date
     t_date = if @original_meter.annual_kwh_estimate.nan? &&
-      @target.first_target_date - DAYSINYEAR < @original_meter.amr_data.start_date
-      logger.info "Moving target start date forward to #{@original_meter.amr_data.start_date + DAYSINYEAR} as target not set"
-      [@original_meter.amr_data.start_date + DAYSINYEAR, @original_meter.amr_data.end_date - DAYSINYEAR].max
-    else
-      [@target.first_target_date, @original_meter.amr_data.end_date - DAYSINYEAR].max
-    end
+                @target.first_target_date - DAYSINYEAR < @original_meter.amr_data.start_date
+
+                td = [
+                  first_day_of_next_month(@original_meter.amr_data.start_date + DAYSINYEAR),
+                  @original_meter.amr_data.end_date - DAYSINYEAR
+                ].max
+                logger.info "Moving target start date forward to #{td} as target not set"
+                td
+              else
+                [@target.first_target_date, @original_meter.amr_data.end_date - DAYSINYEAR].max
+              end
+
     check_target_start_date_after_first_meter_date(t_date)
     t_date
+  end
+
+  def first_day_of_next_month(date)
+    date.day == 1 ? date : date.next_month.beginning_of_month
   end
 
   def check_target_start_date_after_first_meter_date(date)

--- a/lib/dashboard/modelling/targeting and tracking/target_school.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_school.rb
@@ -45,6 +45,10 @@ class TargetSchool < MeterCollection
     @name += ': target'
   end
 
+  def target_school?
+    true
+  end
+
   def reason_for_nil_meter(fuel_type)
     @meter_nil_reason[fuel_type]
   end

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -9,7 +9,7 @@ end
 overrides = {
   schools: ['*'], # ['bxxxxalli*', 'wimble*'],
   # adult_dashboard: { control: { pages: %i[boiler_control_morning_start_time], user: { user_role: :analytics, staff_role: nil } } }
-  adult_dashboard: { control: { pages: %i[ gas_target] } }
+  adult_dashboard: { control: { pages: %i[electric_target gas_target] } }
 }
 
 script = RunAdultDashboard.default_config.deep_merge(overrides)

--- a/script/standard/test_charts.rb
+++ b/script/standard/test_charts.rb
@@ -3,10 +3,10 @@ require_relative '../../lib/dashboard.rb'
 require_rel '../../test_support'
 
 charts = {
-  bm:   %i[group_by_week_electricity_unlimited]
+  bm:   %i[targeting_and_tracking_weekly_gas_to_date_cumulative_line targeting_and_tracking_weekly_gas_to_date_line targeting_and_tracking_weekly_gas_one_year_line]
 }
 
-charts = RunCharts.standard_charts_for_school
+no_charts = RunCharts.standard_charts_for_school
 
 # charts = RunCharts.targeting_and_tracking_charts
 


### PR DESCRIPTION
- only displays actual kWh usage on tables after target start date
- rounds future target start date to start of next month
- replicates table changes on charts
- drill down to day level untested, impact of nil chart points on front end untested