### PR TITLE
Roundtripping benchmark values as json

### DIFF
--- a/lib/dashboard/benchmarking/benchmark_manager.rb
+++ b/lib/dashboard/benchmarking/benchmark_manager.rb
@@ -344,10 +344,17 @@ module Benchmarking
           chart_data[series_name] = data
           percent_type = %i[percent relative_percent percent_0dp relative_percent_0dp].include?(chart_columns_definitions[1][:units])
           chart_data[series_name].map! { |val| val.nil? ? nil : val * 100.0 } if percent_type
+          #when benchmark data is stored as json, TimeOfDay is stored as Strings.
+          #for the chart data we want the TimeOfDay objects so they can be converted to relative time
+          #so create objects if needed
+          if chart_columns_definitions[1][:units] == :timeofday
+            chart_data[series_name].map! { |val| val.is_a?(String) ? TimeOfDay.parse(val) : val }
+          end
         elsif axis == :y2 && self.class.y2_axis_column?(chart_columns_definitions[index])
           y2_data[series_name] = data
         end
       end
+
       [chart_data, y2_data]
     end
 

--- a/lib/dashboard/charting_and_reports/scalar/format_energy_unit.rb
+++ b/lib/dashboard/charting_and_reports/scalar/format_energy_unit.rb
@@ -133,9 +133,9 @@ class FormatEnergyUnit
     elsif unit == :comparison_percent
       format_comparison_percent(value, medium)
     elsif unit == :date
-      value.strftime('%A %e %b %Y')
+      value.is_a?(String) ? Date.parse(value).strftime('%A %e %b %Y') : value.strftime('%A %e %b %Y')
     elsif unit == :datetime
-      value.strftime('%A %e %b %Y %H:%M')
+      value.is_a?(String) ? DateTime.parse(value).strftime('%A %e %b %Y %H:%M') : value.strftime('%A %e %b %Y %H:%M')
     elsif unit == :timeofday || unit == :fuel_type
       value.to_s
     else

--- a/lib/dashboard/utilities/time_of_day.rb
+++ b/lib/dashboard/utilities/time_of_day.rb
@@ -75,6 +75,10 @@ class TimeOfDay
     to_s
   end
 
+  def to_json
+    to_s
+  end
+
   # returns the halfhour index in which the time of day starts,
   # plus the proportion of the way through the half hour bucket the time is
   # code a little obscure for performancce

--- a/lib/dashboard/utilities/time_of_day.rb
+++ b/lib/dashboard/utilities/time_of_day.rb
@@ -75,7 +75,10 @@ class TimeOfDay
     to_s
   end
 
-  def to_json
+  #override this to avoid using default ActiveSupport serialisation
+  #which will turn this into a hash of string values, rather than
+  #simple literal
+  def as_json(options={})
     to_s
   end
 

--- a/spec/lib/dashboard/charting_and_reports/scalar/format_energy_unit_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/scalar/format_energy_unit_spec.rb
@@ -64,4 +64,22 @@ describe FormatEnergyUnit do
     end
   end
 
+  context 'date formatting' do
+    it 'formats Dates' do
+      date = Date.new(2000,1,1)
+      expect(FormatEnergyUnit.format(:date, date, :text)).to eq "Saturday  1 Jan 2000"
+    end
+    it 'formats String as a date' do
+      expect(FormatEnergyUnit.format(:date, "2000-01-01", :text)).to eq "Saturday  1 Jan 2000"
+    end
+    it 'formats Date as a date time' do
+      date = Date.new(2000,1,1)
+      expect(FormatEnergyUnit.format(:datetime, date, :text)).to eq "Saturday  1 Jan 2000 00:00"
+      date = DateTime.new(2000,1,1,14,40)
+      expect(FormatEnergyUnit.format(:datetime, date, :text)).to eq "Saturday  1 Jan 2000 14:40"
+    end
+    it 'formats String as a date time' do
+      expect(FormatEnergyUnit.format(:datetime, "2000-01-01", :text)).to eq "Saturday  1 Jan 2000 00:00"
+    end
+  end
 end


### PR DESCRIPTION
When we move the benchmark storage to YAML, Dates, Symbols, TimeOfData produced as values of benchmarking variaables will be converted into string. This PR has some changes to support round-tripping

* Allow iso8601 strings to be parsed into dates and then formatted for display using FormatEnergyUnit
* Allow TimeOfDay to be converted into a JSON string that is compatible with its parse method
* When building chart data, rebuild the TimeOfDay objects if needed, so they can be properly reformatted as relative time by the frontend