### PR TITLE
Test harness helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,11 +30,15 @@ gem 'ruby-limiter', '~> 1.1.0'
 gem 'pry-byebug'
 gem 'hashdiff', '~> 1.0.0'
 
-# For profiling code
-gem 'ruby-prof'
-gem "benchmark-memory"
-
 gem 'dotenv'
+
+group :development do
+  gem 'aws-sdk-s3'
+
+  # For profiling code
+  gem 'ruby-prof'
+  gem "benchmark-memory"
+end
 
 # For tests
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,22 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     amazing_print (1.2.2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.592.0)
+    aws-sdk-core (3.131.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.525.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.57.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.114.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.5.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     backports (3.23.0)
     benchmark-memory (0.2.0)
       memory_profiler (~> 1)
@@ -91,6 +107,7 @@ GEM
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     interpolate (0.3.0)
+    jmespath (1.6.1)
     mechanize (2.8.4)
       addressable (~> 2.8)
       domain_name (~> 0.5, >= 0.5.20190701)
@@ -216,6 +233,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 6.0.0)
+  aws-sdk-s3
   benchmark-memory
   bundler-audit
   chroma

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require 'dotenv/load'
+
+require 'rake/clean'
+
+CLEAN.include ['coverage', 'log/*']

--- a/rakelib/testing.rake
+++ b/rakelib/testing.rake
@@ -60,6 +60,7 @@ namespace :testing do
     require 'aws-sdk-s3'
     args.with_defaults(schools: '')
     bucket = ENV['UNVALIDATED_SCHOOL_CACHE_BUCKET']
+    $stderr.puts "Downloading list of files from #{bucket}"
     client = Aws::S3::Client.new
     resp = client.list_objects_v2({
         bucket: bucket,
@@ -67,6 +68,7 @@ namespace :testing do
     })
     resp.contents.each do |entry|
       filename = "#{ENV['ANALYTICSTESTDIR']}/MeterCollections/#{entry.key}"
+      $stderr.puts "Saving data to #{filename}"
       File.open(filename, 'w') do |file|
         resp = client.get_object({ bucket: bucket, key: entry.key }, target: file)
       end

--- a/rakelib/testing.rake
+++ b/rakelib/testing.rake
@@ -54,4 +54,22 @@ namespace :testing do
     end
   end
 
+  desc 'download unvalidated data, specify school name prefix with parameter'
+  task :download_unvalidated_data, :schools do |t,args|
+    fail "Set test directory and bucket environment variables" unless ENV["ANALYTICSTESTDIR"] && ENV['UNVALIDATED_SCHOOL_CACHE_BUCKET']
+    require 'aws-sdk-s3'
+    args.with_defaults(schools: '')
+    bucket = ENV['UNVALIDATED_SCHOOL_CACHE_BUCKET']
+    client = Aws::S3::Client.new
+    resp = client.list_objects_v2({
+        bucket: bucket,
+        prefix: "unvalidated-data-" + args.schools,
+    })
+    resp.contents.each do |entry|
+      filename = "#{ENV['ANALYTICSTESTDIR']}/MeterCollections/#{entry.key}"
+      File.open(filename, 'w') do |file|
+        resp = client.get_object({ bucket: bucket, key: entry.key }, target: file)
+      end
+    end
+  end
 end

--- a/rakelib/testing.rake
+++ b/rakelib/testing.rake
@@ -1,0 +1,57 @@
+namespace :testing do
+
+  desc 'initialise test harness directories'
+  task :init do
+    FileUtils.mkdir_p('log')
+    if ENV['ANALYTICSTESTDIR']
+      FileUtils.mkdir_p(ENV['ANALYTICSTESTDIR'])
+      FileUtils.mkdir_p(File.join(ENV['ANALYTICSTESTDIR'], 'MeterCollections'))
+    else
+      fail "Set the ANALYTICSTESTDIR environment variable and re-run"
+    end
+  end
+
+  desc 'delete contents of the New, Results and log directories'
+  task :clean_results do
+    if ENV['ANALYTICSTESTDIR']
+      ['New', 'Results', 'log'].each do |dir|
+        Rake::Cleaner.cleanup_files(FileList["#{ENV['ANALYTICSTESTDIR']}/*/#{dir}/*"])
+      end
+    end
+  end
+
+  desc 'delete contents of the New directories'
+  task :clean_new do
+    if ENV['ANALYTICSTESTDIR']
+      Rake::Cleaner.cleanup_files(FileList["#{ENV['ANALYTICSTESTDIR']}/*/New/*"])
+    end
+  end
+
+  desc 'delete contents of the Base directories'
+  task :clean_base do
+    if ENV['ANALYTICSTESTDIR']
+      Rake::Cleaner.cleanup_files(FileList["#{ENV['ANALYTICSTESTDIR']}/*/Base/*"])
+    end
+  end
+
+  desc 'delete all recent and previous outputs'
+  task :clean_outputs => [:clean_results, :clean_base]
+
+  desc 'delete EVERYTHING in the test directory, including data'
+  task :clobber do
+    if ENV['ANALYTICSTESTDIR']
+      Rake::Cleaner.cleanup_files(FileList["#{ENV['ANALYTICSTESTDIR']}/**/*"])
+    end
+  end
+
+  desc 'copy Base to New'
+  task :copy_new_to_base do
+    if ENV['ANALYTICSTESTDIR']
+      Dir.glob("#{ENV['ANALYTICSTESTDIR']}/*").each do |dir|
+        $stderr.puts "Copying #{dir}/New to /Base"
+        FileUtils.cp_r "#{dir}/New/.", "#{dir}/Base" if File.directory?("#{dir}/New")
+      end
+    end
+  end
+
+end

--- a/script/deprecated/run_alerts_deprecated.rb
+++ b/script/deprecated/run_alerts_deprecated.rb
@@ -129,14 +129,14 @@ class RunAlerts2
 
   def full_filename(filename, base)
     if base
-      @comparison_directory + '\\' + filename
+      @comparison_directory + '/' + filename
     else
-      @output_directory + '\\' + filename
+      @output_directory + '/' + filename
     end
   end
 
   def yaml_filename(alert_type, output_type, asof_date)
-    "#{@school.name} #{asof_date.strftime('%Y%m%d')} #{alert_type} #{output_type}.yml" 
+    "#{@school.name} #{asof_date.strftime('%Y%m%d')} #{alert_type} #{output_type}.yml"
   end
 
   def save_and_compare(alert_class, alert, control, asof_date)
@@ -234,12 +234,12 @@ class RunAlerts2
   end
 
   def run_charts(alert)
-    return if alert.front_end_template_chart_data.empty? 
+    return if alert.front_end_template_chart_data.empty?
     control = {
       charts: [ adhoc_worksheet: { name: 'Test', charts: [ alert.front_end_template_chart_data ] } ],
       control: {
         report_failed_charts:   :summary,
-        compare_results:        [ :summary, :report_differing_charts, :report_differences ] 
+        compare_results:        [ :summary, :report_differing_charts, :report_differences ]
       }
     }
     charts = RunCharts.new(@school)
@@ -260,7 +260,7 @@ class RunAlerts2
     print_banner("asof date: #{asof_date.strftime('%a %d-%m-%Y')}", 0)
 
     failed_alerts = []
- 
+
     generate_charts = false
     # excel_charts = ReportConfigSupport.new if generate_charts
 
@@ -302,7 +302,7 @@ class RunAlerts2
             puts "#{alert_class}: Not make_available_to_users after analysis"
             next
           end
-          raw_data = alert.raw_variables_for_saving          
+          raw_data = alert.raw_variables_for_saving
           if control.key?(:benchmark_alert)
             new_data = alert.benchmark_template_data
             alert_short_code = alert_class.short_code

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -3,7 +3,7 @@ require_relative '../../lib/dashboard.rb'
 require_all './test_support/'
 
 module Logging
-  @logger = Logger.new('log\logs.log')
+  @logger = Logger.new(File.join('log', 'logs.log'))
   logger.level = :error
 end
 

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -3,7 +3,7 @@ require_relative '../../lib/dashboard.rb'
 require_rel '../../test_support'
 
 module Logging
-  @logger = Logger.new('log\logs.log')
+  @logger = Logger.new(File.join('log', 'logs.log'))
   logger.level = :error
 end
 

--- a/script/standard/test_all.rb
+++ b/script/standard/test_all.rb
@@ -5,7 +5,7 @@ require_rel '../../test_support'
 require './script/report_config_support.rb'
 
 module Logging
-  @logger = Logger.new('log\logs.log')
+  @logger = Logger.new(File.join('log', 'logs.log'))
   logger.level = :error
 end
 

--- a/script/standard/test_all_short.rb
+++ b/script/standard/test_all_short.rb
@@ -13,7 +13,7 @@ script = {
   schools:                  ['*'],
   source:                   :unvalidated_meter_data,
   logger2:                  { name: "./log/reports %{school_name} %{time}.log", format: "%{datetime} %{severity.ljust(5, ' ')}: %{msg}\n" },
-  
+
   management_summary_table:          {
     control: {
       combined_html_output_file:     "Management Summary Table #{Date.today}",
@@ -75,7 +75,7 @@ script = {
         {schoolweek: 0},
         {schoolweek: -1},
         {month: 0},
-        {month: -1}                    
+        {month: -1}
       ],
       compare_results: [
         { comparison_directory: ENV['ANALYTICSTESTRESULTDIR'] + '\Equivalences\Base\\' },

--- a/script/standard/test_charts.rb
+++ b/script/standard/test_charts.rb
@@ -3,7 +3,7 @@ require_relative '../../lib/dashboard.rb'
 require_rel '../../test_support'
 
 module Logging
-  @logger = Logger.new('log\logs.log')
+  @logger = Logger.new(File.join('log', 'logs.log'))
   logger.level = :error
 end
 

--- a/test_support/compare_charts.rb
+++ b/test_support/compare_charts.rb
@@ -63,7 +63,7 @@ class CompareChartResults
     chart
   end
 
-  
+
   def remove_volatile_html(html, start_match, end_match)
     start_index = html.index(start_match)
     end_index = html.index(end_match)
@@ -119,7 +119,7 @@ class CompareChartResults
   def yml_filepath(full_path, chart_name)
     Dir.mkdir(full_path) unless File.exist?(full_path)
     extension = control_contains?(:name_extension) ? ('- ' + hash_controls[:name_extension].to_s) : ''
-    yaml_filename = full_path + '\\' + @school_name + '-' + chart_name.to_s + extension + '.yaml'
+    yaml_filename = full_path + '/' + @school_name + '-' + chart_name.to_s + extension + '.yaml'
     yaml_filename.length > 259 ? shorten_filename(yaml_filename) : yaml_filename
   end
 

--- a/test_support/compare_content.rb
+++ b/test_support/compare_content.rb
@@ -43,7 +43,7 @@ class CompareContentResults
       filename = File.join(output_directory, "#{school_or_type} #{page}.yaml".strip)
       save_yaml_file(filename, content)
     else
-      split_content = split_content(content) 
+      split_content = split_content(content)
       split_content.each do |key, contents|
         filename = File.join(output_directory, "#{school_or_type} #{page} #{key}.yaml".strip)
         save_yaml_file(filename, contents)
@@ -67,7 +67,7 @@ class CompareContentResults
         full_filename = File.join(comparison_directory, filename)
         content[index_string.to_i] = { type: key.to_sym, content: load_yaml_file(full_filename) }
       end
-    end 
+    end
     content
   end
 
@@ -110,7 +110,7 @@ class CompareContentResults
       if comparison_component != new_component
         if @control[:compare_results].include?(:report_differences)
           puts "Differs: #{index}"
-          h_diff = Hashdiff.diff(comparison_component, new_component, use_lcs: false, :numeric_tolerance => 0.000001) 
+          h_diff = Hashdiff.diff(comparison_component, new_component, use_lcs: false, :numeric_tolerance => 0.000001)
           puts "'Difference:"
           puts h_diff
           puts 'Original:'
@@ -165,7 +165,7 @@ class CompareContentResults
     # puts "Removing volatile content"
     content = content.deep_dup
     if content[:content].is_a?(Hash)
-      content[:content] = content[:content].except(:calculation_time) 
+      content[:content] = content[:content].except(:calculation_time)
       unless content[:content][:advice_header].nil?
         content[:content][:advice_header] = remove_volatile_html(content[:content][:advice_header])
       end
@@ -280,7 +280,7 @@ class CompareContent2 < CompareContentResults
   end
 
   def yaml_filename(directory, type)
-    directory + '\\' + @school_name + ' ' + type + '.yaml'
+    directory + '/' + @school_name + ' ' + type + '.yaml'
   end
 
   def load_yaml(filename)
@@ -318,7 +318,7 @@ class CompareContent2 < CompareContentResults
 
   def detailed_differences(type, benchmark, new_content, tolerance)
     tolerance ||= { use_lcs: false, :numeric_tolerance => 0.000001 }
-    h_diff = Hashdiff.diff(benchmark, new_content, tolerance) 
+    h_diff = Hashdiff.diff(benchmark, new_content, tolerance)
     puts "'Difference for #{type}:"
     puts h_diff
   end


### PR DESCRIPTION
* Fix up some more paths used for writing out logs and output, so they work on Linux
* Add Rakefile with tasks to support working with the test harness, these replicate and expand on the `.bat` files in the `scripts` directory.
* Add S3 client to allow downloading of data from the command-line

Running `rake -T` gives:

```
rake clean                                       # Remove any temporary products
rake clobber                                     # Remove any generated files
rake testing:clean_base                          # delete contents of the Base directories
rake testing:clean_new                           # delete contents of the New directories
rake testing:clean_outputs                       # delete all recent and previous outputs
rake testing:clean_results                       # delete contents of the New, Results and log directories
rake testing:clobber                             # delete EVERYTHING in the test directory, including data
rake testing:copy_new_to_base                    # copy Base to New
rake testing:download_unvalidated_data[schools]  # download unvalidated data, specify school name prefix with parameter
rake testing:init                                # initialise test harness directories
``` 

The tasks rely on setting of several environment variables. These will be loaded from `.env` if not set elsewhere.

```
ANALYTICSTESTDIR=TEST_DIR
AWS_ACCESS_KEY_ID=
AWS_SECRET_ACCESS_KEY=
AWS_DEFAULT_REGION=
UNVALIDATED_SCHOOL_CACHE_BUCKET=
```

The `ANALYTICSTESTDIR` is used as base directory for deleting, copying and saving files. The others provide credentials necessary for downloading data from S3.

Download data for all schools:

```
rake testing:download_unvalidated_data
```

Download data for schools with id starting with "bath"

```
rake testing:download_unvalidated_data['bath']
```
