### PR TITLE
Add rspec tests for variable generation

### DIFF
--- a/lib/dashboard/charting_and_reports/content_base.rb
+++ b/lib/dashboard/charting_and_reports/content_base.rb
@@ -320,7 +320,7 @@ class ContentBase
     text_template_variables.select { |type, _value| lookup[type][:units] == var_type }
   end
 
-  # returns :enough, :not_enough, :minimum_might_not_be_qaccurate
+  # returns :enough, :not_enough, :minimum_might_not_be_accurate
   # depending on whether there is enough data to provide the alert
   def enough_data
     raise EnergySparksAbstractBaseClass.new('Error: incorrect attempt to use abstract base class for enough_data template variable ' + self.class.name)

--- a/lib/dashboard/charting_and_reports/content_base.rb
+++ b/lib/dashboard/charting_and_reports/content_base.rb
@@ -50,6 +50,7 @@ class ContentBase
     formatted_template_variables(:html)
   end
 
+  #only called via the test framework
   def format_variables_as_html
     scalars, tables = variable_list(true, :html, true)
 
@@ -183,9 +184,17 @@ class ContentBase
   end
 
   def front_end_template_data
+    #flatten list of variable names, to ignore groups
     lookup = flatten_template_variables
+
+    #generate hash of unformatted variable values
     raw_data = raw_template_variables
+
+    #generate formatted template variable values
     list = text_template_variables.reject { |type, _value| [:chart, :table, TrueClass].include?(lookup[type][:units]) }
+
+    #generates high/low value versions of some variables
+    #e.g. end up with capital_cost, capital_cost_low, capital_cost_high
     list.merge(convert_range_template_data_to_high_low(list, lookup, raw_data))
   end
 
@@ -233,6 +242,8 @@ class ContentBase
     v1 / v2
   end
 
+  #For variables that indicate a range, then generate _high and _low value versions
+  #of the template data
   private def convert_range_template_data_to_high_low(template_data, lookup, raw_data)
     new_data = {}
     template_data.each do |type, data| # front end want ranges as seperate high/low symbol-value pairs
@@ -250,6 +261,7 @@ class ContentBase
     new_data
   end
 
+  #only used via test framework
   def raw_variables_for_saving
     raw = {}
     unformatted_template_variables.each do |type, data|
@@ -308,7 +320,7 @@ class ContentBase
     text_template_variables.select { |type, _value| lookup[type][:units] == var_type }
   end
 
-  # returns :enough, :not_enough, :minimum_might_not_be_accurate
+  # returns :enough, :not_enough, :minimum_might_not_be_qaccurate
   # depending on whether there is enough data to provide the alert
   def enough_data
     raise EnergySparksAbstractBaseClass.new('Error: incorrect attempt to use abstract base class for enough_data template variable ' + self.class.name)
@@ -350,7 +362,12 @@ class ContentBase
     [10.0 * [(actual_value - bad_value) / (good_value - bad_value), 0.0].max, 10.0].min.round(1)
   end
 
+  #this is called multiple times during life-time so cache the results
   protected def flatten_template_variables
+    @flattened_variables ||= create_flattened_variables
+  end
+
+  private def create_flattened_variables
     list = {}
     self.class.template_variables.each do |_group_name, variable_group|
       variable_group.each do |type, data|

--- a/spec/lib/dashboard/charting_and_reports/content_base_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/content_base_spec.rb
@@ -1,0 +1,202 @@
+require 'spec_helper'
+require 'dashboard'
+class CustomAlert < ContentBase
+  #Test access to instance variables
+  attr_reader :a_number, :a_cost, :a_priority
+
+  TEMPLATE_VARIABLES = {
+    a_number: {
+      description: 'A number',
+      units: Integer
+    },
+    some_string: {
+      description: 'A string',
+      units: String
+    },
+    a_cost: {
+      description: 'A GBP value',
+      units: :£
+    },
+    a_range: {
+      description: 'A GBP range',
+      units: :£_range
+    },
+    stripped: {
+      description: 'stripped',
+      units: TrueClass
+    },
+    date: {
+      description: 'mapped to native type',
+      units: Date
+    },
+    a_table: {
+      description: 'a table',
+      units: :table,
+      header: ['x', 'y'],
+      column_types: [String, :£]
+    },
+    a_chart: {
+      description: 'a chart',
+      units: :chart
+    },
+    a_priority: {
+      description: 'priority',
+      units: Integer,
+      priority_code: "XYZ"
+    }
+  }
+
+  def initialize(number: 100, cost: 50)
+    @a_number = number
+    @a_cost = cost
+    @a_priority = number * 2
+  end
+
+  #Test calling methods dynamically
+  def some_string
+    "Returned via method"
+  end
+
+  #ContentBase doesn't implement this, so sub-classes must
+  def self.template_variables
+    { 'Custom Alert' => TEMPLATE_VARIABLES }
+  end
+
+end
+
+describe ContentBase do
+
+  context 'when listing variables' do
+    describe '#front_end_template_variables' do
+      before(:each) do
+        @variables = CustomAlert.front_end_template_variables
+      end
+
+      it 'produces basic variables' do
+       expect(@variables).to match({
+         'Custom Alert' => a_hash_including(
+           a_cost: {
+             description: 'A GBP value',
+             units: :£
+           }
+         )})
+      end
+
+      it 'converts some units' do
+        expect(@variables).to match({
+          'Custom Alert' => a_hash_including(
+            a_number: {
+              description: 'A number',
+              units: :integer
+            },
+            a_priority: {
+              description: 'priority',
+              priority_code: "XYZ",
+              units: :integer
+            },
+            some_string: {
+              description: 'A string',
+              units: :string
+            },
+            date: {
+              description: 'mapped to native type',
+              units: :date
+            }
+          )})
+      end
+
+      it 'adds variables for ranges' do
+        expect(@variables).to match({
+          'Custom Alert' => a_hash_including(
+            a_range_low: {
+              description: 'A GBP range low',
+              units: :£
+            },
+            a_range_high: {
+              description: 'A GBP range high',
+              units: :£
+            }
+          )})
+      end
+
+      it 'strips other variables' do
+        expect(@variables['Custom Alert']).to_not have_key(:a_chart)
+        expect(@variables['Custom Alert']).to_not have_key(:a_table)
+        expect(@variables['Custom Alert']).to_not have_key(:stripped)
+      end
+    end
+
+    describe '#priority_template_variables' do
+      before(:each) do
+        @variables = CustomAlert.priority_template_variables
+      end
+      it 'returns only the priority variables' do
+        expect(@variables).to eq({
+          a_priority: {
+            description: 'priority',
+            units: :integer,
+            priority_code: "XYZ"
+          }
+          })
+      end
+    end
+
+    describe '#front_end_template_charts' do
+      before(:each) do
+        @charts = CustomAlert.front_end_template_charts
+      end
+      it 'returns only charts' do
+        expect(@charts).to eq(
+          a_chart: {
+            description: 'a chart',
+            units: :chart
+          }
+        )
+      end
+    end
+
+    describe '#front_end_template_tables' do
+      before(:each) do
+        @tables = CustomAlert.front_end_template_tables
+      end
+      it 'returns only tables' do
+        expect(@tables).to eq(
+          a_table: {
+            description: 'a table',
+            units: :table,
+            header: ['x', 'y'],
+            column_types: [String, :£]
+          }
+        )
+      end
+    end
+  end
+
+  context 'when returning data' do
+    describe '#front_end_template_data' do
+      before(:each) do
+       @template_data = CustomAlert.new.front_end_template_data
+      end
+      it 'returns the expected values' do
+        expect(@template_data).to eq({
+            a_cost: "£50",
+            a_number: "100",
+            a_priority: "200",
+            some_string: "Returned via method"
+        })
+      end
+    end
+
+    describe '#priority_template_data' do
+      before(:each) do
+        @template_data = CustomAlert.new.priority_template_data
+      end
+      it 'returns the expected values' do
+        expect(@template_data).to eq({
+            a_priority: 200
+        })
+      end
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'simplecov'
+require 'pry'
 SimpleCov.start do
   add_group "Models", "app/models"
   add_group "Services", "app/services"


### PR DESCRIPTION
Adds some rspec tests to exercise the behaviour in the `ContentBase` class that:

* produces lists of variable names and config, for use by the front end
* generates the variables that are stored by the application

This will allow us to later add some tests for the localisation support.