### PR TITLE
Localise variables produced by baseload alerts

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -112,7 +112,8 @@ search:
 # - '{devise,simple_form}.*'
 
 ## Consider these keys used:
-# ignore_unused:
+ignore_unused:
+  - 'analytics.alert_*'
 # - 'activerecord.attributes.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'

--- a/config/locales/alerts/common/electricity/baseload.yml
+++ b/config/locales/alerts/common/electricity/baseload.yml
@@ -2,19 +2,19 @@
 en:
   analytics:
     alert_change_in_electricity_baseload_short_term:
-      timescale: "last week compared with average over last year"
-      analysis_description: "Recent change in baseload"
+      analysis_description: Recent change in baseload
+      timescale: last week compared with average over last year
     alert_electricity_baseload_versus_benchmark:
-      timescale: "last year"
       summary:
-        high: "Your baseload is high, reducing it could save %{saving}pa"
-        ok: "You are doing well - you are an exemplar school"
-    alert_summer_holiday_refrigeration_analysis:
-      timescale: "at least one summer holiday"
-      summary:
-        high: "You have the potential to save %{saving}pa from more efficient refrigeration"
-        ok: "Either you don't switch your fridges off over summer or they are very efficient"
+        high: Your baseload is high, reducing it could save %{saving}pa
+        ok: You are doing well - you are an exemplar school
+      timescale: last year
     alert_intraweek_baseload_variation:
-      timescale: "over the last year"
+      timescale: over the last year
     alert_seasonal_baseload_variation:
-      timescale: "over the last year"
+      timescale: over the last year
+    alert_summer_holiday_refrigeration_analysis:
+      summary:
+        high: You have the potential to save %{saving}pa from more efficient refrigeration
+        ok: Either you don't switch your fridges off over summer or they are very efficient
+      timescale: at least one summer holiday

--- a/config/locales/alerts/common/electricity/baseload.yml
+++ b/config/locales/alerts/common/electricity/baseload.yml
@@ -1,0 +1,20 @@
+---
+en:
+  analytics:
+    alert_change_in_electricity_baseload_short_term:
+      timescale: "last week compared with average over last year"
+      analysis_description: "Recent change in baseload"
+    alert_electricity_baseload_versus_benchmark:
+      timescale: "last year"
+      summary:
+        high: "Your baseload is high, reducing it could save %{saving}pa"
+        ok: "You are doing well - you are an exemplar school"
+    alert_summer_holiday_refrigeration_analysis:
+      timescale: "at least one summer holiday"
+      summary:
+        high: "You have the potential to save %{saving}pa from more efficient refrigeration"
+        ok: "Either you don't switch your fridges off over summer or they are very efficient"
+    alert_intraweek_baseload_variation:
+      timescale: "over the last year"
+    alert_seasonal_baseload_variation:
+      timescale: "over the last year"

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -117,7 +117,7 @@ en:
         - Last weeks half hourly gas consumption (kWh)
       alert_weekend_last_week_gas_datetime_£:
         title:
-        -
+        - 
       baseload:
         title:
         - Baseload kW
@@ -471,7 +471,7 @@ en:
         - 'By Week: Electricity (Meter Breakdown)'
       group_by_week_electricity_school_comparison_line:
         title:
-        -
+        - 
       group_by_week_electricity_simulator:
         title:
         - 'By Week: Electricity (Simulator)'

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -1,6 +1,12 @@
 ---
 en:
   analytics:
+    adjectives:
+      higher: higher
+      lower: lower
+      well: well
+      ok: ok
+      poorly: poorly
     aggregator:
       subttitle: "%{start_date} to %{end_date}"
     chart_configuration:
@@ -111,7 +117,7 @@ en:
         - Last weeks half hourly gas consumption (kWh)
       alert_weekend_last_week_gas_datetime_£:
         title:
-        - 
+        -
       baseload:
         title:
         - Baseload kW
@@ -465,7 +471,7 @@ en:
         - 'By Week: Electricity (Meter Breakdown)'
       group_by_week_electricity_school_comparison_line:
         title:
-        - 
+        -
       group_by_week_electricity_simulator:
         title:
         - 'By Week: Electricity (Simulator)'

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -4,9 +4,9 @@ en:
     adjectives:
       higher: higher
       lower: lower
-      well: well
       ok: ok
       poorly: poorly
+      well: well
     aggregator:
       subttitle: "%{start_date} to %{end_date}"
     chart_configuration:

--- a/config/locales/dates.yml
+++ b/config/locales/dates.yml
@@ -1,0 +1,11 @@
+---
+en:
+  analytics:
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -235,6 +235,7 @@ class AlertAnalysisBase < ContentBase
     valid_content? && meter_readings_up_to_date_enough?
   end
 
+  #unused method?
   def self.print_all_formatted_template_variable_values
     puts 'Available variables and values:'
     self.template_variables.each do |group_name, variable_group|

--- a/lib/dashboard/alerts/electricity/baseload/alert_baseload_base.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_baseload_base.rb
@@ -25,6 +25,10 @@ class AlertBaseloadBase < AlertElectricityOnlyBase
     end.to_h
   end
 
+  def timescale
+    I18n.t("#{i18n_prefix}.timescale")
+  end
+
   def commentary
     [ { type: :html,  content: 'No advice yet' } ]
   end

--- a/lib/dashboard/alerts/electricity/baseload/alert_change_in_electricity_baseload_short_term.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_change_in_electricity_baseload_short_term.rb
@@ -2,6 +2,7 @@
 require_relative '../alert_electricity_only_base.rb'
 
 class AlertChangeInElectricityBaseloadShortTerm < AlertBaseloadBase
+
   MAXBASELOADCHANGE = 1.15
 
   attr_reader :average_baseload_last_year_kw, :average_baseload_last_week_kw
@@ -122,12 +123,8 @@ class AlertChangeInElectricityBaseloadShortTerm < AlertBaseloadBase
     days_amr_data > 6 * 7 ? :enough : (days_amr_data > 3 * 7 ? :minimum_might_not_be_accurate : :not_enough)
   end
 
-  def timescale
-    'last week compared with average over last year'
-  end
-
   def analysis_description
-    'Recent change in baseload'
+    I18n.t("#{i18n_prefix}.analysis_description")
   end
 
   def commentary

--- a/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
@@ -170,14 +170,10 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
     :alert_1_year_baseload
   end
 
-  def timescale
-    'last year'
-  end
-
   def commentary
     [ { type: :html,  content: evaluation_html } ]
   end
-  
+
   def evaluation_html
     text = %(
               <% if average_baseload_last_year_kw < benchmark_per_pupil_kw %>
@@ -185,7 +181,7 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
                 <%= format_kw(average_baseload_last_year_kw) %> compared with a
                 well managed school of a similar size's
                 <%= format_kw(benchmark_per_pupil_kw) %> and
-                an examplar schools's 
+                an examplar schools's
                 <%= FormatEnergyUnit.format(:kw, @exemplar_per_pupil_kw) %>,
                 but there should still be opportunities to improve further.
               <% else %>
@@ -226,8 +222,8 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
 
     @one_year_saving_versus_benchmark_kwh = @average_baseload_last_year_kwh - @one_year_benchmark_by_pupil_kwh
     @one_year_saving_versus_benchmark_£   = @one_year_saving_versus_benchmark_kwh * electricity_tariff
-    @one_year_saving_versus_benchmark_co2 = @one_year_saving_versus_benchmark_kwh * blended_co2_per_kwh  
-    @one_year_saving_versus_benchmark_adjective = @one_year_saving_versus_benchmark_kwh > 0.0 ? 'higher' : 'lower'
+    @one_year_saving_versus_benchmark_co2 = @one_year_saving_versus_benchmark_kwh * blended_co2_per_kwh
+    @one_year_saving_versus_benchmark_adjective = @one_year_saving_versus_benchmark_kwh > 0.0 ? I18nHelper.adjective('higher') : I18nHelper.adjective('lower')
 
     @exemplar_per_pupil_kw = BenchmarkMetrics.exemplar_baseload_for_pupils(pupils(asof_date - 365, asof_date), school_type)
 
@@ -238,7 +234,7 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
     @one_year_saving_versus_exemplar_kwh  = @average_baseload_last_year_kwh - @one_year_exemplar_by_pupil_kwh
     @one_year_saving_versus_exemplar_£    = @one_year_saving_versus_exemplar_kwh * electricity_tariff
     @one_year_saving_versus_exemplar_co2  = @one_year_saving_versus_exemplar_kwh * blended_co2_per_kwh
-    @one_year_saving_versus_exemplar_adjective = @one_year_saving_versus_exemplar_kwh > 0.0 ? 'higher' : 'lower'
+    @one_year_saving_versus_exemplar_adjective = @one_year_saving_versus_exemplar_kwh > 0.0 ? I18nHelper.adjective('higher') : I18nHelper.adjective('lower')
 
     @one_year_baseload_per_pupil_kw        = @average_baseload_last_year_kw   / pupils(asof_date - 365, asof_date)
     @one_year_baseload_per_pupil_kwh       = @average_baseload_last_year_kwh  / pupils(asof_date - 365, asof_date)
@@ -268,10 +264,9 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
 
   def summary_text
     if @one_year_saving_versus_exemplar_£ > 0
-      'Your baseload is high, reducing it could save ' +
-      FormatEnergyUnit.format(:£, @one_year_saving_versus_exemplar_£, :text) + 'pa'
+      I18n.t("#{i18n_prefix}.summary.high", saving: FormatEnergyUnit.format(:£, @one_year_saving_versus_exemplar_£, :text))
     else
-      'You are doing well - you are an exemplar school'
+      I18n.t("#{i18n_prefix}.summary.ok")
     end
   end
 

--- a/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
@@ -223,7 +223,7 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
     @one_year_saving_versus_benchmark_kwh = @average_baseload_last_year_kwh - @one_year_benchmark_by_pupil_kwh
     @one_year_saving_versus_benchmark_£   = @one_year_saving_versus_benchmark_kwh * electricity_tariff
     @one_year_saving_versus_benchmark_co2 = @one_year_saving_versus_benchmark_kwh * blended_co2_per_kwh
-    @one_year_saving_versus_benchmark_adjective = @one_year_saving_versus_benchmark_kwh > 0.0 ? I18nHelper.adjective('higher') : I18nHelper.adjective('lower')
+    @one_year_saving_versus_benchmark_adjective = Adjective.adjective_for(@one_year_saving_versus_benchmark_kwh, 0.0)
 
     @exemplar_per_pupil_kw = BenchmarkMetrics.exemplar_baseload_for_pupils(pupils(asof_date - 365, asof_date), school_type)
 
@@ -234,7 +234,7 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
     @one_year_saving_versus_exemplar_kwh  = @average_baseload_last_year_kwh - @one_year_exemplar_by_pupil_kwh
     @one_year_saving_versus_exemplar_£    = @one_year_saving_versus_exemplar_kwh * electricity_tariff
     @one_year_saving_versus_exemplar_co2  = @one_year_saving_versus_exemplar_kwh * blended_co2_per_kwh
-    @one_year_saving_versus_exemplar_adjective = @one_year_saving_versus_exemplar_kwh > 0.0 ? I18nHelper.adjective('higher') : I18nHelper.adjective('lower')
+    @one_year_saving_versus_exemplar_adjective = Adjective.adjective_for(@one_year_saving_versus_exemplar_kwh, 0.0)
 
     @one_year_baseload_per_pupil_kw        = @average_baseload_last_year_kw   / pupils(asof_date - 365, asof_date)
     @one_year_baseload_per_pupil_kwh       = @average_baseload_last_year_kwh  / pupils(asof_date - 365, asof_date)

--- a/lib/dashboard/alerts/electricity/baseload/alert_freezers_off_for_summer_holidays.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_freezers_off_for_summer_holidays.rb
@@ -88,7 +88,7 @@ class AlertSummerHolidayRefrigerationAnalysis < AlertElectricityOnlyBase
   }.freeze
 
   def timescale
-    'at least one summer holiday'
+    I18n.t("#{i18n_prefix}.timescale")
   end
 
   def summer_holiday_analysis_table_html
@@ -122,10 +122,9 @@ class AlertSummerHolidayRefrigerationAnalysis < AlertElectricityOnlyBase
 
   def summary_text
     if @annualised_reduction_£ > 0
-      'You have the potential to save ' +
-      FormatEnergyUnit.format(:£, @annualised_reduction_£, :text) + 'pa from more efficient refrigeration'
+      I18n.t("#{i18n_prefix}.summary.high", saving: FormatEnergyUnit.format(:£, @annualised_reduction_£, :text))
     else
-      'Either you don\'t switch your firdges off over summer or they are very efficient'
+      I18n.t("#{i18n_prefix}.summary.ok")
     end
   end
 
@@ -137,7 +136,7 @@ class AlertSummerHolidayRefrigerationAnalysis < AlertElectricityOnlyBase
 
     years_no_drop = years_without_significant_drop(years_data)
     @turn_off_rating = calculate_rating_from_range(0, RATING_BASED_ON_YEARS_DATA, years_no_drop.length)
-    
+
     average_drop_value_£(years_data)
     @reduction_rating = calculate_rating_from_range(0, INEFFICIENT_APPLIANCES_KW, @reduction_kw)
   end
@@ -176,16 +175,16 @@ class AlertSummerHolidayRefrigerationAnalysis < AlertElectricityOnlyBase
 
   def format_for_table(value, unit, medium)
     return value if medium == :raw || unit == String
-    FormatEnergyUnit.format(unit, value, medium, false, true) 
+    FormatEnergyUnit.format(unit, value, medium, false, true)
   end
-  
+
   def summer_holiday_data
     @analysis_results ||= analysis_periods.map do |period_around_summer_holiday|
       @fridge_analysis.attempt_to_detect_refrigeration_being_turned_off_over_summer_holidays(period_around_summer_holiday, -MINIMUM_SUMMER_DROP_KW)
     end
   end
-  
+
   def summer_holidays_with_drop
-    summer_holiday_data.select{ |result| result[:change_in_baseload_kw] < -MINIMUM_SUMMER_DROP_KW } 
+    summer_holiday_data.select{ |result| result[:change_in_baseload_kw] < -MINIMUM_SUMMER_DROP_KW }
   end
 end

--- a/lib/dashboard/alerts/electricity/baseload/alert_intraweek_baseload_variation.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_intraweek_baseload_variation.rb
@@ -78,10 +78,6 @@ class AlertIntraweekBaseloadVariation < AlertBaseloadBase
     'Variation in baseload between days of week'
   end
 
-  def timescale
-    'over the last year'
-  end
-
   def commentary
     charts_and_html = []
     charts_and_html.push( { type: :html,  content: evaluation_html } )
@@ -123,15 +119,13 @@ class AlertIntraweekBaseloadVariation < AlertBaseloadBase
 
     days_kw = calculator.average_intraweek_schoolday_kw(asof_date)
 
-    day_strs = %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday]
-
     @min_day_kw = days_kw.values.min
     min_day = days_kw.key(@min_day_kw)
-    @min_day_str = day_strs[min_day]
+    @min_day_str = I18nHelper.day_name(min_day)
 
     @max_day_kw = days_kw.values.max
     max_day = days_kw.key(@max_day_kw)
-    @max_day_str = day_strs[max_day]
+    @max_day_str = I18nHelper.day_name(max_day)
 
     @percent_intraday_variation = (@max_day_kw - @min_day_kw) / @min_day_kw
 
@@ -174,11 +168,11 @@ class AlertIntraweekBaseloadVariation < AlertBaseloadBase
 
   def calculate_adjective
     if rating > 7
-      'well'
+      I18nHelper.adjective('well')
     elsif rating > 4
-      'ok'
+      I18nHelper.adjective('ok')
     else
-      'poorly'
+      I18nHelper.adjective('poorly')
     end
   end
 end

--- a/lib/dashboard/alerts/electricity/baseload/alert_seasonal_baseload_variation.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_seasonal_baseload_variation.rb
@@ -59,10 +59,6 @@ class AlertSeasonalBaseloadVariation < AlertBaseloadBase
     calculator.one_years_data? ? :enough : :not_enough
   end
 
-  def timescale
-    'over the last year'
-  end
-
   def analysis_description
     'Seasonal variation in baseload'
   end

--- a/lib/dashboard/charting_and_reports/content_base.rb
+++ b/lib/dashboard/charting_and_reports/content_base.rb
@@ -8,6 +8,10 @@ class ContentBase
     @today = ENV['ENERGYSPARKSTODAY'].nil? ? Date.today : Date.parse(ENV['ENERGYSPARKSTODAY'])
   end
 
+  def i18n_prefix
+    self.class.name.underscore
+  end
+
   def relevance
     @relevance
   end

--- a/lib/dashboard/charting_and_reports/content_base.rb
+++ b/lib/dashboard/charting_and_reports/content_base.rb
@@ -9,7 +9,7 @@ class ContentBase
   end
 
   def i18n_prefix
-    self.class.name.underscore
+    "analytics.#{self.class.name.underscore}"
   end
 
   def relevance

--- a/lib/dashboard/charting_and_reports/old_advice/adjectives.rb
+++ b/lib/dashboard/charting_and_reports/old_advice/adjectives.rb
@@ -20,4 +20,12 @@ class Adjective
     found = range_to_adjective_map.keys.find { |range| value.between?(range.first, range.last) }
     range_to_adjective_map[found]
   end
+
+  def self.adjective_for(result, greater_than_value = 0.0)
+    if result > greater_than_value
+      I18nHelper.adjective('higher')
+    else
+      I18nHelper.adjective('lower')
+    end
+  end
 end

--- a/lib/dashboard/utilities/i18n_helper.rb
+++ b/lib/dashboard/utilities/i18n_helper.rb
@@ -1,0 +1,9 @@
+class I18nHelper
+  def self.adjective(adjective)
+    I18n.t("analytics.adjectives.#{adjective}")
+  end
+
+  def self.day_name(idx)
+    I18n.t("analytics.day_names")[idx]
+  end
+end

--- a/spec/lib/dashboard/charting_and_reports/content_base_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/content_base_spec.rb
@@ -66,6 +66,11 @@ end
 
 describe ContentBase do
 
+  context '#i18n_prefix' do
+    it 'returns correct prefix' do
+      expect(CustomAlert.new.i18n_prefix).to eq "custom_alert"
+    end
+  end
   context 'when listing variables' do
     describe '#front_end_template_variables' do
       before(:each) do

--- a/spec/lib/dashboard/charting_and_reports/content_base_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/content_base_spec.rb
@@ -68,7 +68,7 @@ describe ContentBase do
 
   context '#i18n_prefix' do
     it 'returns correct prefix' do
-      expect(CustomAlert.new.i18n_prefix).to eq "custom_alert"
+      expect(CustomAlert.new.i18n_prefix).to eq "analytics.custom_alert"
     end
   end
   context 'when listing variables' do


### PR DESCRIPTION
* Extracts the `String` variables produced by the baseload alerts from the code into YAML files, all the others are largely handled by the `FormatEnergyUnit` class which will be further localised separately
* Adds a base class helper to `ContentBase` to help to standardised key names across the alert classes (have settled on `underscore` version of class name). This is potentially brittle if classes get renamed, but most of these classes can't be renamed without database updates in the application. This approach still allows the files to be reorganised. The alternative was to declare a constant on each class which felt redundant
* Changed code to lookup relevant variable text via the `I18n.t` helper. This is a mixture of words and short sentences
* Adds an `I18nHelper` class to support look up of common helper text, e.g adjectives and dates
* With the text extracted to the YAML files, it was possible to refactor the code to move the `timescale` method to `AlertBaseloadBase` avoiding need for every class to have it

I think we're going to inevitably have some words/phrases duplicated across the analytics and application, e.g. day names, etc. There's no way to share YAML both ways. I think this is probably acceptable as its a small amount of text.

The approach I'm taking here is to tackle a directory of alerts at a time. Checking the `TEMPLATE_VARIABLES` for each class to find any that are `Strings`. These generally need specially handling while the rest get formatted via `FormatEnergyUnit`.

To test the changes I've been running the `scripts/test_alerts.rb` script. I first ran this for a couple of schools without any changes, and am then re-running after refactoring. The script either produces errors or reports on any differences in the text.

So while there are no real rspec tests, there has been some manual testing.