### PR TITLE
Set github artifact retention period

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -86,4 +86,5 @@ jobs:
         path: |
           test_output
           !./test_output/MeterCollections
+          retention-days: 7
 


### PR DESCRIPTION
This sets the retention period to 7 days for all github action workflow artifacts (default is 90 days).  
See https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#configuring-a-custom-artifact-retention-period

