### PR TITLE
Use methods in baseload alerts to allow switching of locale

### DIFF
--- a/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
@@ -20,8 +20,6 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
   attr_reader :average_baseload_last_year_co2, :one_year_benchmark_by_pupil_co2, :one_year_exemplar_by_pupil_co2
   attr_reader :one_year_saving_versus_exemplar_co2, :one_year_baseload_per_pupil_co2, :one_year_baseload_per_floor_area_co2
 
-  attr_reader :summary
-
   def initialize(school, report_type = :baseloadbenchmark, meter = school.aggregated_electricity_meters)
     super(school, report_type, meter)
   end
@@ -242,8 +240,6 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
     @one_year_baseload_per_floor_area_£    = @average_baseload_last_year_£    / floor_area(asof_date - 365, asof_date)
     @one_year_baseload_per_floor_area_co2  = @average_baseload_last_year_co2  / floor_area(asof_date - 365, asof_date)
 
-    @summary = summary_text
-
     set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£, @one_year_saving_versus_exemplar_£), nil, @one_year_saving_versus_exemplar_co2)
 
     # rating: benchmark value = 4.0, exemplar = 10.0
@@ -266,7 +262,7 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
     Adjective.adjective_for(@one_year_saving_versus_exemplar_kwh, 0.0)
   end
 
-  def summary_text
+  def summary
     if @one_year_saving_versus_exemplar_£ > 0
       I18n.t("#{i18n_prefix}.summary.high", saving: FormatEnergyUnit.format(:£, @one_year_saving_versus_exemplar_£, :text))
     else

--- a/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
@@ -11,11 +11,9 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
 
   attr_reader :one_year_benchmark_by_pupil_kwh, :one_year_benchmark_by_pupil_£
   attr_reader :one_year_saving_versus_benchmark_kwh, :one_year_saving_versus_benchmark_£, :one_year_saving_versus_benchmark_co2
-  attr_reader :one_year_saving_versus_benchmark_adjective
 
   attr_reader :one_year_exemplar_by_pupil_kwh, :one_year_exemplar_by_pupil_£
   attr_reader :one_year_saving_versus_exemplar_kwh, :one_year_saving_versus_exemplar_£
-  attr_reader :one_year_saving_versus_exemplar_adjective
 
   attr_reader :one_year_baseload_per_pupil_kw, :one_year_baseload_per_pupil_kwh, :one_year_baseload_per_pupil_£
   attr_reader :one_year_baseload_per_floor_area_kw, :one_year_baseload_per_floor_area_kwh, :one_year_baseload_per_floor_area_£
@@ -223,7 +221,6 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
     @one_year_saving_versus_benchmark_kwh = @average_baseload_last_year_kwh - @one_year_benchmark_by_pupil_kwh
     @one_year_saving_versus_benchmark_£   = @one_year_saving_versus_benchmark_kwh * electricity_tariff
     @one_year_saving_versus_benchmark_co2 = @one_year_saving_versus_benchmark_kwh * blended_co2_per_kwh
-    @one_year_saving_versus_benchmark_adjective = Adjective.adjective_for(@one_year_saving_versus_benchmark_kwh, 0.0)
 
     @exemplar_per_pupil_kw = BenchmarkMetrics.exemplar_baseload_for_pupils(pupils(asof_date - 365, asof_date), school_type)
 
@@ -234,7 +231,6 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
     @one_year_saving_versus_exemplar_kwh  = @average_baseload_last_year_kwh - @one_year_exemplar_by_pupil_kwh
     @one_year_saving_versus_exemplar_£    = @one_year_saving_versus_exemplar_kwh * electricity_tariff
     @one_year_saving_versus_exemplar_co2  = @one_year_saving_versus_exemplar_kwh * blended_co2_per_kwh
-    @one_year_saving_versus_exemplar_adjective = Adjective.adjective_for(@one_year_saving_versus_exemplar_kwh, 0.0)
 
     @one_year_baseload_per_pupil_kw        = @average_baseload_last_year_kw   / pupils(asof_date - 365, asof_date)
     @one_year_baseload_per_pupil_kwh       = @average_baseload_last_year_kwh  / pupils(asof_date - 365, asof_date)
@@ -261,6 +257,14 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
     @bookmark_url = add_book_mark_to_base_url('ElectricityBaseload')
   end
   alias_method :analyse_private, :calculate
+
+  def one_year_saving_versus_benchmark_adjective
+    Adjective.adjective_for(@one_year_saving_versus_benchmark_kwh, 0.0)
+  end
+
+  def one_year_saving_versus_exemplar_adjective
+    Adjective.adjective_for(@one_year_saving_versus_exemplar_kwh, 0.0)
+  end
 
   def summary_text
     if @one_year_saving_versus_exemplar_£ > 0

--- a/lib/dashboard/alerts/electricity/baseload/alert_freezers_off_for_summer_holidays.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_freezers_off_for_summer_holidays.rb
@@ -10,7 +10,6 @@ class AlertSummerHolidayRefrigerationAnalysis < AlertElectricityOnlyBase
   attr_reader :summer_holiday_analysis_table
   attr_reader :holiday_reduction_£, :annualised_reduction_£, :reduction_kw
   attr_reader :reduction_rating, :turn_off_rating
-  attr_reader :summary
 
   def initialize(school)
     super(school, :heatingcomingontooearly)
@@ -111,8 +110,6 @@ class AlertSummerHolidayRefrigerationAnalysis < AlertElectricityOnlyBase
 
     @rating = [@turn_off_rating, @reduction_rating].min
 
-    @summary = summary_text
-
     @term = :longterm
     @bookmark_url = add_book_mark_to_base_url('HeatingComingOnTooEarly')
   end
@@ -120,7 +117,7 @@ class AlertSummerHolidayRefrigerationAnalysis < AlertElectricityOnlyBase
 
   private
 
-  def summary_text
+  def summary
     if @annualised_reduction_£ > 0
       I18n.t("#{i18n_prefix}.summary.high", saving: FormatEnergyUnit.format(:£, @annualised_reduction_£, :text))
     else

--- a/lib/dashboard/alerts/electricity/baseload/alert_intraweek_baseload_variation.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_intraweek_baseload_variation.rb
@@ -3,9 +3,7 @@ require_relative '../alert_electricity_only_base.rb'
 
 class AlertIntraweekBaseloadVariation < AlertBaseloadBase
   attr_reader :max_day_kw, :min_day_kw, :percent_intraday_variation
-  attr_reader :max_day_str, :min_day_str
   attr_reader :annual_cost_kwh, :annual_cost_£, :annual_co2
-  attr_reader :adjective
 
   def initialize(school, report_type = :intraweekbaseload, meter = school.aggregated_electricity_meters)
     super(school, report_type, meter)
@@ -120,12 +118,10 @@ class AlertIntraweekBaseloadVariation < AlertBaseloadBase
     days_kw = calculator.average_intraweek_schoolday_kw(asof_date)
 
     @min_day_kw = days_kw.values.min
-    min_day = days_kw.key(@min_day_kw)
-    @min_day_str = I18nHelper.day_name(min_day)
+    @min_day = days_kw.key(@min_day_kw)
 
     @max_day_kw = days_kw.values.max
-    max_day = days_kw.key(@max_day_kw)
-    @max_day_str = I18nHelper.day_name(max_day)
+    @max_day = days_kw.key(@max_day_kw)
 
     @percent_intraday_variation = (@max_day_kw - @min_day_kw) / @min_day_kw
 
@@ -140,8 +136,6 @@ class AlertIntraweekBaseloadVariation < AlertBaseloadBase
     set_savings_capital_costs_payback(Range.new(@annual_cost_£, @annual_cost_£), nil, @annual_co2)
 
     @rating = calculate_rating_from_range(0.1, 0.3, @percent_intraday_variation.magnitude)
-
-    @adjective = calculate_adjective
 
     @term = :longterm
   end
@@ -164,6 +158,18 @@ class AlertIntraweekBaseloadVariation < AlertBaseloadBase
         to save costs?
       </p>
     )
+  end
+
+  def min_day_str
+    I18nHelper.day_name(@min_day)
+  end
+
+  def max_day_str
+    I18nHelper.day_name(@max_day)
+  end
+
+  def adjective
+    calculate_adjective
   end
 
   def calculate_adjective


### PR DESCRIPTION
Alerts need to store "raw" data in their calculation methods, then return formatted text via methods.

Change two of the baseload alerts to do this, so that when we request the variables with different locales we get the expected output.