### PR TITLE
I18n Gas & storage heater alerts

### DIFF
--- a/config/locales/alerts/gas/boilercontrol.yml
+++ b/config/locales/alerts/gas/boilercontrol.yml
@@ -16,5 +16,5 @@ en:
       timescale: this holiday
     alert_heating_sensitivity_advice:
       timescale: year
-    alert_heating_on_non_school_days:
-      timescale: 1 year
+    alert_optimum_start_analysis:
+      timescale: last year

--- a/config/locales/alerts/gas/boilercontrol.yml
+++ b/config/locales/alerts/gas/boilercontrol.yml
@@ -1,15 +1,16 @@
 ---
 en:
   analytics:
+    alert_turn_heating_off:
+      timescale: next week
     alert_heating_coming_on_too_early:
       timescale: 7 days
     alert_heating_hot_water_on_during_holiday_base:
-      timescale: this holiday
+      both: the hot water has been left on on %{hotwater_days} days and the heating on %{heating_days} days
       heating_not_on: Well done you have used no gas this holiday.
+      only_heating: the heating has been left on on %{heating_days} days
+      only_hotwater: the hot water has been left on on %{hotwater_days} days
       summary: |
         Your %{heating_type} has been left on over the %{holiday_name} holiday. Up
         until %{date} %{left_on_message} costing %{cost}, and a projected %{project_cost} by the end of the holiday.
-      only_hotwater: "the hot water has been left on on %{hotwater_days} days"
-      only_heating: "the heating has been left on on %{heating_days} days"
-      both: "the hot water has been left on on %{hotwater_days} days and
-      the heating on %{heating_days} days"
+      timescale: this holiday

--- a/config/locales/alerts/gas/boilercontrol.yml
+++ b/config/locales/alerts/gas/boilercontrol.yml
@@ -18,3 +18,7 @@ en:
       timescale: year
     alert_optimum_start_analysis:
       timescale: last year
+    alert_seasonal_heating_school_days:
+      timescale: 1 year
+    alert_thermostatic_control:
+      timescale: 1 year

--- a/config/locales/alerts/gas/boilercontrol.yml
+++ b/config/locales/alerts/gas/boilercontrol.yml
@@ -14,3 +14,5 @@ en:
         Your %{heating_type} has been left on over the %{holiday_name} holiday. Up
         until %{date} %{left_on_message} costing %{cost}, and a projected %{project_cost} by the end of the holiday.
       timescale: this holiday
+    alert_heating_sensitivity_advice:
+      timescale: year

--- a/config/locales/alerts/gas/boilercontrol.yml
+++ b/config/locales/alerts/gas/boilercontrol.yml
@@ -1,0 +1,15 @@
+---
+en:
+  analytics:
+    alert_heating_coming_on_too_early:
+      timescale: 7 days
+    alert_heating_hot_water_on_during_holiday_base:
+      timescale: this holiday
+      heating_not_on: Well done you have used no gas this holiday.
+      summary: |
+        Your %{heating_type} has been left on over the %{holiday_name} holiday. Up
+        until %{date} %{left_on_message} costing %{cost}, and a projected %{project_cost} by the end of the holiday.
+      only_hotwater: "the hot water has been left on on %{hotwater_days} days"
+      only_heating: "the heating has been left on on %{heating_days} days"
+      both: "the hot water has been left on on %{hotwater_days} days and
+      the heating on %{heating_days} days"

--- a/config/locales/alerts/gas/boilercontrol.yml
+++ b/config/locales/alerts/gas/boilercontrol.yml
@@ -16,3 +16,5 @@ en:
       timescale: this holiday
     alert_heating_sensitivity_advice:
       timescale: year
+    alert_heating_on_non_school_days:
+      timescale: 1 year

--- a/config/locales/alerts/gas/boilercontrol.yml
+++ b/config/locales/alerts/gas/boilercontrol.yml
@@ -1,8 +1,6 @@
 ---
 en:
   analytics:
-    alert_turn_heating_off:
-      timescale: next week
     alert_heating_coming_on_too_early:
       timescale: 7 days
     alert_heating_hot_water_on_during_holiday_base:
@@ -22,3 +20,5 @@ en:
       timescale: 1 year
     alert_thermostatic_control:
       timescale: 1 year
+    alert_turn_heating_off:
+      timescale: next week

--- a/config/locales/alerts/gas/boilercontrol.yml
+++ b/config/locales/alerts/gas/boilercontrol.yml
@@ -4,10 +4,10 @@ en:
     alert_heating_coming_on_too_early:
       timescale: 7 days
     alert_heating_hot_water_on_during_holiday_base:
-      both: the hot water has been left on on %{hotwater_days} days and the heating on %{heating_days} days
+      both: the hot water has been left on on %{hotwater_days} and the heating on %{heating_days}
       heating_not_on: Well done you have used no gas this holiday.
-      only_heating: the heating has been left on on %{heating_days} days
-      only_hotwater: the hot water has been left on on %{hotwater_days} days
+      only_heating: the heating has been left on on %{heating_days}
+      only_hotwater: the hot water has been left on on %{hotwater_days}
       summary: |
         Your %{heating_type} has been left on over the %{holiday_name} holiday. Up
         until %{date} %{left_on_message} costing %{cost}, and a projected %{project_cost} by the end of the holiday.

--- a/config/locales/alerts/gas/gas.yml
+++ b/config/locales/alerts/gas/gas.yml
@@ -1,0 +1,7 @@
+---
+en:
+  analytics:
+    alert_gas_annual_versus_benchmark:
+      timescale: last year
+    alert_weekend_gas_consumption_short_term:
+      timescale: last weekend

--- a/config/locales/alerts/gas/gas.yml
+++ b/config/locales/alerts/gas/gas.yml
@@ -1,6 +1,8 @@
 ---
 en:
   analytics:
+    alert_change_in_daily_gas_short_term:
+      timescale: week (school days only)
     alert_gas_annual_versus_benchmark:
       timescale: last year
     alert_weekend_gas_consumption_short_term:

--- a/config/locales/alerts/gas/hotwater.yml
+++ b/config/locales/alerts/gas/hotwater.yml
@@ -1,0 +1,7 @@
+---
+en:
+  analytics:
+    alert_hot_water_efficiency:
+      timescale: year
+    alert_hot_water_insulation_advice:
+      timescale: last year

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -2,8 +2,20 @@
 en:
   analytics:
     adjectives:
+      very_poor: very poor
+      poor: poor
+      below_average: below average
+      just_below_average: just below average
+      about_average: about average
+      above_average: above average
+      excellent: excellent
+      perfect: perfect
+      good: good
+      better_than_average: better than average
+      worse_than_average: worse than average
       about: about
       above: above
+      bad: bad
       below: below
       down: down
       higher: higher

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -33,13 +33,13 @@ en:
     aggregator:
       subttitle: "%{start_date} to %{end_date}"
     common:
-      gas_boiler: gas boiler
-      storage_heaters: storage_heaters
       electricity: electricity
       gas: gas
+      gas_boiler: gas boiler
       holiday: holiday
       pa: "%{cost}pa"
       school_day: school day
+      storage_heaters: storage_heaters
       weekend: weekend
     holidays:
       autumn_half_term: Autumn half term

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -33,6 +33,8 @@ en:
     aggregator:
       subttitle: "%{start_date} to %{end_date}"
     common:
+      gas_boiler: gas boiler
+      storage_heaters: storage_heaters
       electricity: electricity
       gas: gas
       holiday: holiday

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -2,34 +2,34 @@
 en:
   analytics:
     adjectives:
-      very_poor: very poor
-      poor: poor
-      below_average: below average
-      just_below_average: just below average
-      about_average: about average
-      above_average: above average
-      excellent: excellent
-      perfect: perfect
-      good: good
-      better_than_average: better than average
-      worse_than_average: worse than average
       about: about
+      about_average: about average
       above: above
+      above_average: above average
       bad: bad
       below: below
+      below_average: below average
+      better_than_average: better than average
       down: down
+      excellent: excellent
+      good: good
       higher: higher
       increase: increase
       just_above: just above
       just_below: just below
+      just_below_average: just below average
       lower: lower
       ok: ok
+      perfect: perfect
+      poor: poor
       poorly: poorly
       reduction: reduction
       significantly_above: significantly above
       significantly_below: significantly below
       up: up
+      very_poor: very poor
       well: well
+      worse_than_average: worse than average
     aggregator:
       subttitle: "%{start_date} to %{end_date}"
     common:

--- a/lib/dashboard/advice/advice_seasonal_gas_boiler_control.rb
+++ b/lib/dashboard/advice/advice_seasonal_gas_boiler_control.rb
@@ -18,16 +18,16 @@ class AdviceGasBoilerSeasonalControl  < AdviceBoilerHeatingBase
   end
 
   def self.warm_weather_on_days_adjective(days)
-    warm_weather_on_days_rating(days)[:adjective]
+    I18nHelper.adjective( warm_weather_on_days_rating(days)[:adjective] )
   end
 
   def self.warm_weather_on_days_rating(days)
     range = {
-      0..6     => { adjective: 'excellent',      rating_value: 10  },
-      6..11    => { adjective: 'good',           rating_value:  8  },
-      12..16   => { adjective: 'above average',  rating_value:  4  },
-      17..24   => { adjective: 'poor',           rating_value:  2  },
-      25..365  => { adjective: 'very poor',      rating_value:  0  }
+      0..6     => { adjective: :excellent,      rating_value: 10  },
+      6..11    => { adjective: :good,           rating_value:  8  },
+      12..16   => { adjective: :above_average,  rating_value:  4  },
+      17..24   => { adjective: :poor,           rating_value:  2  },
+      25..365  => { adjective: :very_poor,      rating_value:  0  }
     }
 
     range.select { |k, _v| k.cover?(days.to_i) }.values.first

--- a/lib/dashboard/alerts/gas/alert_change_in_daily_gas_short_term.rb
+++ b/lib/dashboard/alerts/gas/alert_change_in_daily_gas_short_term.rb
@@ -125,7 +125,7 @@ class AlertChangeInDailyGasShortTerm < AlertGasModelBase
   end
 
   def timescale
-    'week (school days only)'
+    I18n.t("#{i18n_prefix}.timescale")
   end
 
   def enough_data

--- a/lib/dashboard/alerts/gas/alert_weekend_gas_consumption_short_term.rb
+++ b/lib/dashboard/alerts/gas/alert_weekend_gas_consumption_short_term.rb
@@ -20,9 +20,9 @@ class AlertWeekendGasConsumptionShortTerm < AlertGasModelBase
   protected def max_days_out_of_date_while_still_relevant
     21
   end
-  
+
   def timescale
-    'last weekend'
+    I18n.t("#{i18n_prefix}.timescale")
   end
 
   def enough_data

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_coming_on_too_early.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_coming_on_too_early.rb
@@ -10,7 +10,7 @@ class AlertHeatingComingOnTooEarly < AlertGasModelBase
 
   attr_reader :one_year_optimum_start_saving_kwh, :one_year_optimum_start_saving_£, :one_year_optimum_start_saving_co2
   attr_reader :percent_of_annual_gas, :avg_week_start_time
-  
+
   def initialize(school)
     super(school, :heatingcomingontooearly)
   end
@@ -64,7 +64,7 @@ class AlertHeatingComingOnTooEarly < AlertGasModelBase
   }.freeze
 
   def timescale
-    '7 days'
+    I18n.t("#{i18n_prefix}.timescale")
   end
 
   def enough_data

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_hotwater_on_during_holiday.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_hotwater_on_during_holiday.rb
@@ -148,22 +148,22 @@ class AlertHeatingHotWaterOnDuringHolidayBase < AlertGasModelBase
     if @rating == 0.0
       if @heating_days_so_far_this_holiday == 0
         left_on_message = I18n.t("#{i18n_prefix}.only_hotwater",
-          hotwater_days: @hotwater_days_so_far_this_holiday)
+          hotwater_days: FormatUnit.format(:days, @hotwater_days_so_far_this_holiday))
       elsif @hotwater_days_so_far_this_holiday == 0
         left_on_message = I18n.t("#{i18n_prefix}.only_heating",
-          heating_days: @heating_days_so_far_this_holiday)
+          heating_days: FormatUnit.format(:days, @heating_days_so_far_this_holiday))
       else
         left_on_message = I18n.t("#{i18n_prefix}.only_heating",
-          hotwater_days: @hotwater_days_so_far_this_holiday,
-          heating_days: @heating_days_so_far_this_holiday)
+          hotwater_days: FormatUnit.format(:days, @hotwater_days_so_far_this_holiday),
+          heating_days: FormatUnit.format(:days, @heating_days_so_far_this_holiday))
       end
       I18n.t("#{i18n_prefix}.summary",
         heating_type: heating_type,
         holiday_name: holiday_name,
         date: I18n.l(@asof_date, format: '%A %e %b %Y'),
         left_on_message: left_on_message,
-        cost: FormatEnergyUnit.format(:£, @holiday_usage_to_date_£, :html),
-        project_cost: FormatEnergyUnit.format(:£, @holiday_projected_usage_£, :html)
+        cost: FormatUnit.format(:£, @holiday_usage_to_date_£, :html),
+        project_cost: FormatUnit.format(:£, @holiday_projected_usage_£, :html)
       )
       else
         #TODO: message refers to using no gas, but this text also used for storage heaters

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_off.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_off.rb
@@ -43,7 +43,7 @@ class AlertTurnHeatingOff < AlertGasModelBase
     historic_meter_years: {
       description: 'period of historic analysis up to 12 months available e.g. 6 months',
       units:  :years
-    }, 
+    },
     future_degree_days: {
       description: 'degree days in horizon period',
       units:  :temperature
@@ -96,16 +96,20 @@ class AlertTurnHeatingOff < AlertGasModelBase
       description: 'days since last meter reading date',
       units:  Integer
     },
+    days_ago: {
+      description: 'days since last meter read, including day/days',
+      unit: String
+    },
     days_ago_plural: {
       description: 'set to s if days since last meter reading date > 1 so can say day or days ago',
       units:  String
     }
   }
-  
+
   # ================================== Control Variables =========================================
 
   def timescale
-    'next week'
+    I18n.t("#{i18n_prefix}.timescale")
   end
 
   def enough_data
@@ -160,10 +164,14 @@ class AlertTurnHeatingOff < AlertGasModelBase
   end
   alias_method :analyse_private, :calculate
 
+  def days_ago
+    FormatUnit.format(:days, @days_since_last_meter_reading_date)
+  end
 
   def set_up_to_dateness_of_meter
     @last_meter_reading_date = aggregate_meter.amr_data.end_date
     @days_since_last_meter_reading_date = (@today - @last_meter_reading_date).to_i
+    #DONT USE
     @days_ago_plural = @days_since_last_meter_reading_date == 1 ? '' : 's'
   end
 
@@ -237,9 +245,9 @@ class AlertTurnHeatingOff < AlertGasModelBase
   def analysis_horizon_date(asof_date)
     case asof_date.wday
     when 0, 6
-      asof_date.next_occurring(:saturday) 
+      asof_date.next_occurring(:saturday)
     when 1..5
-      asof_date.next_occurring(:saturday).next_occurring(:saturday) 
+      asof_date.next_occurring(:saturday).next_occurring(:saturday)
     end
   end
 

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_temperature_change_advice.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_temperature_change_advice.rb
@@ -19,7 +19,7 @@ class AlertHeatingSensitivityAdvice < AlertGasModelBase
   end
 
   def timescale
-    'year'
+    I18n.t("#{i18n_prefix}.timescale")
   end
 
   def enough_data

--- a/lib/dashboard/alerts/gas/boiler control/alert_non_school_heating_day.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_non_school_heating_day.rb
@@ -7,7 +7,6 @@ class AlertHeatingOnNonSchoolDays < AlertHeatingDaysBase
 
   attr_reader :number_of_non_heating_days_last_year, :average_number_of_non_heating_days_last_year
   attr_reader :exemplar_number_of_non_heating_days_last_year
-  attr_reader :non_heating_day_adjective
   attr_reader :total_kwh_on_unoccupied_days, :kwh_below_frost_on_unoccupied_days, :one_year_saving_kwh
   attr_reader :below_frost_£, :unoccupied_above_frost_£, :total_on_unoccupied_days_£, :total_on_unoccupied_days_co2
   attr_reader :unoccupied_above_frost_co2
@@ -18,7 +17,7 @@ class AlertHeatingOnNonSchoolDays < AlertHeatingDaysBase
   end
 
   def timescale
-    '1 year'
+    I18n.t("#{i18n_prefix}.timescale")
   end
 
   def self.template_variables
@@ -91,7 +90,6 @@ class AlertHeatingOnNonSchoolDays < AlertHeatingDaysBase
     @number_of_non_heating_days_last_year = days
 
     @average_number_of_non_heating_days_last_year = statistics.average_non_school_day_heating_days
-    @non_heating_day_adjective = statistics.non_school_heating_day_adjective(days)
 
     @kwh_below_frost_on_unoccupied_days, @total_kwh_on_unoccupied_days = calculate_heating_off_statistics(asof_date)
     @one_year_saving_kwh = @total_kwh_on_unoccupied_days - @kwh_below_frost_on_unoccupied_days
@@ -114,4 +112,10 @@ class AlertHeatingOnNonSchoolDays < AlertHeatingDaysBase
     @bookmark_url = add_book_mark_to_base_url('HeatingOnSchoolDays')
   end
   alias_method :analyse_private, :calculate
+
+  def non_heating_day_adjective
+    return "" if @number_of_non_heating_days_last_year.nil?
+    AnalyseHeatingAndHotWater::HeatingModel.non_school_heating_day_adjective(@number_of_non_heating_days_last_year)
+  end
+
 end

--- a/lib/dashboard/alerts/gas/boiler control/alert_non_school_heating_day.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_non_school_heating_day.rb
@@ -3,10 +3,14 @@
 require_relative '../alert_gas_model_base.rb'
 
 # alerts for leaving the heating on for too long over winter holidays and weekends
+#NOTE: this doesn't seem to be setup in the application, as its not registered
+#in the database. Should it be removed?
+#Was removed from live system around 2022-04-11
 class AlertHeatingOnNonSchoolDays < AlertHeatingDaysBase
 
   attr_reader :number_of_non_heating_days_last_year, :average_number_of_non_heating_days_last_year
   attr_reader :exemplar_number_of_non_heating_days_last_year
+  attr_reader :non_heating_day_adjective
   attr_reader :total_kwh_on_unoccupied_days, :kwh_below_frost_on_unoccupied_days, :one_year_saving_kwh
   attr_reader :below_frost_£, :unoccupied_above_frost_£, :total_on_unoccupied_days_£, :total_on_unoccupied_days_co2
   attr_reader :unoccupied_above_frost_co2
@@ -17,7 +21,7 @@ class AlertHeatingOnNonSchoolDays < AlertHeatingDaysBase
   end
 
   def timescale
-    I18n.t("#{i18n_prefix}.timescale")
+    '1 year'
   end
 
   def self.template_variables
@@ -90,6 +94,7 @@ class AlertHeatingOnNonSchoolDays < AlertHeatingDaysBase
     @number_of_non_heating_days_last_year = days
 
     @average_number_of_non_heating_days_last_year = statistics.average_non_school_day_heating_days
+    @non_heating_day_adjective = statistics.non_school_heating_day_adjective(days)
 
     @kwh_below_frost_on_unoccupied_days, @total_kwh_on_unoccupied_days = calculate_heating_off_statistics(asof_date)
     @one_year_saving_kwh = @total_kwh_on_unoccupied_days - @kwh_below_frost_on_unoccupied_days
@@ -112,10 +117,4 @@ class AlertHeatingOnNonSchoolDays < AlertHeatingDaysBase
     @bookmark_url = add_book_mark_to_base_url('HeatingOnSchoolDays')
   end
   alias_method :analyse_private, :calculate
-
-  def non_heating_day_adjective
-    return "" if @number_of_non_heating_days_last_year.nil?
-    AnalyseHeatingAndHotWater::HeatingModel.non_school_heating_day_adjective(@number_of_non_heating_days_last_year)
-  end
-
 end

--- a/lib/dashboard/alerts/gas/boiler control/alert_optimum_start_analysis.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_optimum_start_analysis.rb
@@ -4,7 +4,7 @@ require_relative '../alert_gas_model_base.rb'
 class AlertOptimumStartAnalysis < AlertGasModelBase
   attr_reader :regression_start_time, :optimum_start_sensitivity, :regression_r2
   attr_reader :average_start_time, :start_time_standard_devation, :average_start_time_hh_mm
-  
+
   def initialize(school)
     super(school, :optimumstartanalysis)
     @relevance = :never_relevant if @relevance != :never_relevant && non_heating_only
@@ -49,7 +49,7 @@ class AlertOptimumStartAnalysis < AlertGasModelBase
   }.freeze
 
   def timescale
-    'last year'
+    I18n.t("#{i18n_prefix}.timescale")
   end
 
   def enough_data

--- a/lib/dashboard/alerts/gas/boiler control/alert_school_heating_days.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_school_heating_days.rb
@@ -3,6 +3,10 @@ require_relative '../alert_gas_model_base.rb'
 require_relative './alert_heating_day_base.rb'
 
 # alerts for leaving the heating on for too long over winter
+#
+#NOTE: this doesn't seem to be setup in the application, as its not registered
+#in the database. Should it be removed?
+#Was removed from live system around 2022-04-11
 class AlertHeatingOnSchoolDays < AlertHeatingDaysBase
 
   attr_reader :number_of_heating_days_last_year, :average_number_of_heating_days_last_year

--- a/lib/dashboard/alerts/gas/boiler control/alert_seasonal_heating_schooldays.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_seasonal_heating_schooldays.rb
@@ -4,7 +4,7 @@ require_relative './alert_heating_day_base.rb'
 
 # alert for leaving heating on in warm weather
 class AlertSeasonalHeatingSchoolDays < AlertHeatingDaysBase
-  attr_reader :percent_of_annual_gas, :percent_of_annual_heating, :warm_weather_heating_days_adjective
+  attr_reader :percent_of_annual_gas, :percent_of_annual_heating
   attr_reader :heating_percent_of_total_gas
 
   def initialize(school, type = :heating_on_days)
@@ -13,7 +13,7 @@ class AlertSeasonalHeatingSchoolDays < AlertHeatingDaysBase
   end
 
   def timescale
-    '1 year'
+    I18n.t("#{i18n_prefix}.timescale")
   end
 
   def self.template_variables
@@ -67,6 +67,11 @@ class AlertSeasonalHeatingSchoolDays < AlertHeatingDaysBase
     @term = :longterm
   end
   alias_method :analyse_private, :calculate
+
+  def warm_weather_heating_days_adjective
+    return "" if @warm_weather_heating_days_all_days_days.nil?
+    AdviceGasBoilerSeasonalControl.warm_weather_on_days_adjective(@warm_weather_heating_days_all_days_days)
+  end
 
   def self.dynamic_template_variables
     heating_types = {
@@ -142,7 +147,6 @@ class AlertSeasonalHeatingSchoolDays < AlertHeatingDaysBase
     all_kwh = @cold_and_warm_weather_heating_days_all_days_kwh + @hot_water_and_kitchen_all_days_kwh
     @percent_of_annual_gas = percent(@warm_weather_heating_days_all_days_kwh, all_kwh)
     @percent_of_annual_heating = percent(@warm_weather_heating_days_all_days_kwh, @cold_and_warm_weather_heating_days_all_days_kwh)
-    @warm_weather_heating_days_adjective = AdviceGasBoilerSeasonalControl.warm_weather_on_days_rating(@warm_weather_heating_days_all_days_days)[:adjective]
     @heating_percent_of_total_gas = @cold_and_warm_weather_heating_days_all_days_kwh / all_kwh
   end
 end

--- a/lib/dashboard/alerts/gas/boiler control/alert_thermostatic_control.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_thermostatic_control.rb
@@ -12,13 +12,13 @@ class AlertThermostaticControl < AlertGasModelBase
   end
 
   def timescale
-    '1 year'
+    I18n.t("#{i18n_prefix}.timescale")
   end
 
   def enough_data
     enough_data_for_model_fit ? :enough : :not_enough
   end
-  
+
   def self.template_variables
     specific = {'Thermostatic Control' => TEMPLATE_VARIABLES}
     specific.merge(self.superclass.template_variables)
@@ -68,7 +68,7 @@ class AlertThermostaticControl < AlertGasModelBase
   def thermostatic_chart
     :thermostatic
   end
-  
+
   def r2
     @r2 ||= @heating_model.average_heating_school_day_r2
   end

--- a/lib/dashboard/alerts/gas/hot water/alert_hot_water_efficiency.rb
+++ b/lib/dashboard/alerts/gas/hot water/alert_hot_water_efficiency.rb
@@ -8,12 +8,12 @@ class AlertHotWaterEfficiency < AlertGasModelBase
   attr_reader :benchmark_gas_better_control_saving_£, :benchmark_point_of_use_electric_saving_£, :electric_hot_water_saving_co2
 
   def initialize(school)
-    super(school, :hotwaterefficiency) 
+    super(school, :hotwaterefficiency)
     @relevance = :never_relevant if @relevance != :never_relevant && heating_only # set before calculation
   end
 
   def timescale
-    'year'
+    I18n.t("#{i18n_prefix}.timescale")
   end
 
   def enough_data
@@ -42,7 +42,7 @@ class AlertHotWaterEfficiency < AlertGasModelBase
       description: 'Current v. Improved Control v. Point of Use Electric cost-benefit table',
       units: :table,
       header: ['Choice', 'Annual kWh', 'Annual Cost £', 'Annual CO2/kg',
-               'Efficiency', 'Saving £', 'Saving £ percent', 'Saving CO2', 
+               'Efficiency', 'Saving £', 'Saving £ percent', 'Saving CO2',
                'Saving CO2 percent', 'Capital Cost', 'Payback (years)'],
       column_types: [String, {kwh: :gas}, :£, :co2,
                       :percent, :£, :percent, :co2,

--- a/lib/dashboard/alerts/gas/hot water/alert_poorly_insulated_hotwater.rb
+++ b/lib/dashboard/alerts/gas/hot water/alert_poorly_insulated_hotwater.rb
@@ -45,7 +45,7 @@ class AlertHotWaterInsulationAdvice < AlertGasModelBase
   }.freeze
 
   def timescale
-    'last year'
+    I18n.t("#{i18n_prefix}.timescale")
   end
 
   def enough_data
@@ -74,7 +74,7 @@ class AlertHotWaterInsulationAdvice < AlertGasModelBase
 
   private def calculate_annual_hotwater_poor_insulation_heatloss_estimate(asof_date)
     start_date = model_start_date(asof_date)
-    savings_kwh, savings_percent = 
+    savings_kwh, savings_percent =
       heating_model.hot_water_poor_insulation_cost_kwh(start_date, asof_date)
     @annual_hotwater_poor_insulation_heatloss_estimate_£ = savings_kwh * ConvertKwh.scale_unit_from_kwh(:£, :gas)
     @annual_hotwater_poor_insulation_heatloss_estimate_co2 = savings_kwh * EnergyEquivalences::UK_GAS_CO2_KG_KWH

--- a/lib/dashboard/alerts/storage heaters/alert_storage_heaters.rb
+++ b/lib/dashboard/alerts/storage heaters/alert_storage_heaters.rb
@@ -12,7 +12,7 @@ class AlertStorageHeaterAnnualVersusBenchmark < AlertGasAnnualVersusBenchmark
   include ElectricityCostCo2Mixin
   def initialize(school)
     super(school, :storage_heater_annual_benchmark)
-    @relevance = @school.storage_heaters? ? :relevant : :never_relevant 
+    @relevance = @school.storage_heaters? ? :relevant : :never_relevant
   end
 
   private def dd_adj(asof_date)
@@ -40,7 +40,7 @@ class AlertStorageHeaterOutOfHours < AlertOutOfHoursGasUsage
     super(school, 'electricity', BenchmarkMetrics::PERCENT_STORAGE_HEATER_OUT_OF_HOURS_BENCHMARK,
           :storageheateroutofhours,
           '', :allstorageheater, 0.2, 0.5)
-    @relevance = @school.storage_heaters? ? :relevant : :never_relevant 
+    @relevance = @school.storage_heaters? ? :relevant : :never_relevant
   end
 
   def breakdown_chart
@@ -61,7 +61,7 @@ class AlertSeasonalHeatingSchoolDaysStorageHeaters < AlertSeasonalHeatingSchoolD
   include ElectricityCostCo2Mixin
   def initialize(school)
     super(school, :storage_heater_heating_days)
-    @relevance = @school.storage_heaters? ? :relevant : :never_relevant 
+    @relevance = @school.storage_heaters? ? :relevant : :never_relevant
   end
 
   def heating_on_off_chart
@@ -84,7 +84,7 @@ class AlertHeatingOnSchoolDaysStorageHeaters < AlertHeatingOnSchoolDays
   include ElectricityCostCo2Mixin
   def initialize(school)
     super(school, :storage_heater_heating_days)
-    @relevance = @school.storage_heaters? ? :relevant : :never_relevant 
+    @relevance = @school.storage_heaters? ? :relevant : :never_relevant
   end
 
   def heating_on_off_chart
@@ -97,7 +97,7 @@ class AlertStorageHeatersLongTermTrend < AlertGasLongTermTrend
   include ElectricityCostCo2Mixin
   def initialize(school)
     super(school, :storage_heater_heating_days)
-    @relevance = @school.storage_heaters? ? :relevant : :never_relevant 
+    @relevance = @school.storage_heaters? ? :relevant : :never_relevant
   end
 
   def self.template_variables
@@ -152,11 +152,11 @@ class AlertStorageHeaterHeatingOnDuringHoliday < AlertHeatingHotWaterOnDuringHol
   include ElectricityCostCo2Mixin
   def initialize(school)
     super(school, :storage_heaters)
-    @relevance = @school.storage_heaters? ? :relevant : :never_relevant 
+    @relevance = @school.storage_heaters? ? :relevant : :never_relevant
   end
 
   def heating_type
-    'storage_heaters'
+    I18n.t("analytics.common.storage_heaters")
   end
 
   def aggregate_meter

--- a/lib/dashboard/alerts/storage heaters/alert_storage_heaters.rb
+++ b/lib/dashboard/alerts/storage heaters/alert_storage_heaters.rb
@@ -79,6 +79,9 @@ class AlertTurnHeatingOffStorageHeaters < AlertTurnHeatingOff
   end
 end
 
+#NOTE: this doesn't seem to be setup in the application, as its not registered
+#in the database. Should it be removed?
+#Was removed from live system around 2022-04-11 and replaced by above
 class AlertHeatingOnSchoolDaysStorageHeaters < AlertHeatingOnSchoolDays
   include AlertGasToStorageHeaterSubstitutionMixIn
   include ElectricityCostCo2Mixin

--- a/lib/dashboard/modelling/heating/heating_regression_models.rb
+++ b/lib/dashboard/modelling/heating/heating_regression_models.rb
@@ -120,7 +120,7 @@ module AnalyseHeatingAndHotWater
           @override_regression_model = nil
           @reason = nil
           @fitting = nil
-        else 
+        else
           @override_best_model_type = overrides.fetch(:override_best_model_type, nil)
           @override_regression_model = overrides.fetch(:override_model, nil)
           @reason = overrides.fetch(:reason, nil)
@@ -276,21 +276,21 @@ module AnalyseHeatingAndHotWater
     # based on analysis of 31 schools from 16Feb2019
     def self.r2_statistics
       { # r2 range => stats, rating
-        0.0...0.1 => { percent: 0.06,   rating: 'very poor',          rating_value: 0 },
-        0.1...0.2 => { percent: 0.03,   rating: 'very poor',          rating_value: 1 },
-        0.2...0.3 => { percent: 0.03,   rating: 'very poor',          rating_value: 2 },
-        0.3...0.4 => { percent: 0.02,   rating: 'poor',               rating_value: 4 },
-        0.4...0.5 => { percent: 0.13,   rating: 'below average',      rating_value: 5 },
-        0.5...0.6 => { percent: 0.23,   rating: 'just below average', rating_value: 7 },
-        0.6...0.7 => { percent: 0.16,   rating: 'about average',      rating_value: 7 },
-        0.7...0.8 => { percent: 0.23,   rating: 'above average',      rating_value: 8 },
-        0.8...0.9 => { percent: 0.10,   rating: 'excellent',          rating_value: 9 },
-        0.9..1.0  => { percent: 0.00,   rating: 'perfect',            rating_value: 10 }
+        0.0...0.1 => { percent: 0.06,   rating: :very_poor,          rating_value: 0 },
+        0.1...0.2 => { percent: 0.03,   rating: :very_poor,          rating_value: 1 },
+        0.2...0.3 => { percent: 0.03,   rating: :very_poor,          rating_value: 2 },
+        0.3...0.4 => { percent: 0.02,   rating: :poor,               rating_value: 4 },
+        0.4...0.5 => { percent: 0.13,   rating: :below_average,      rating_value: 5 },
+        0.5...0.6 => { percent: 0.23,   rating: :just_below_average, rating_value: 7 },
+        0.6...0.7 => { percent: 0.16,   rating: :about_average,      rating_value: 7 },
+        0.7...0.8 => { percent: 0.23,   rating: :above_average,      rating_value: 8 },
+        0.8...0.9 => { percent: 0.10,   rating: :excellent,          rating_value: 9 },
+        0.9..1.0  => { percent: 0.00,   rating: :perfect,            rating_value: 10 }
       }
     end
 
     def self.r2_rating_adjective(r2)
-      find_r2_rating(r2, :rating)
+      I18nHelper.adjective( find_r2_rating(r2, :rating) )
     end
 
     def self.r2_rating_out_of_10(r2)
@@ -318,19 +318,19 @@ module AnalyseHeatingAndHotWater
     # based on analysis of 31 schools from 16Feb2019
     def self.school_heating_days_statistics
       { # days range => stats, rating
-        0...90    => { percent: 0.10,   rating: 'perfect',              rating_value: 10 },
-        90...100  => { percent: 0.20,   rating: 'excellent',            rating_value: 10 },
-        100...110 => { percent: 0.07,   rating: 'good',                 rating_value: 9 },
-        110...120 => { percent: 0.23,   rating: 'better than average',  rating_value: 7 },
-        120...130 => { percent: 0.23,   rating: 'about average',        rating_value: 4 },
-        130...140 => { percent: 0.10,   rating: 'worse than average',   rating_value: 3 },
-        140...150 => { percent: 0.0,    rating: 'poor',                 rating_value: 2 },
-        150..365  => { percent: 0.10,   rating: 'very poor',            rating_value: 0 },
+        0...90    => { percent: 0.10,   rating: :perfect,              rating_value: 10 },
+        90...100  => { percent: 0.20,   rating: :excellent,            rating_value: 10 },
+        100...110 => { percent: 0.07,   rating: :good,                 rating_value: 9 },
+        110...120 => { percent: 0.23,   rating: :better_than_average,  rating_value: 7 },
+        120...130 => { percent: 0.23,   rating: :about_average,        rating_value: 4 },
+        130...140 => { percent: 0.10,   rating: :worse_than_average,   rating_value: 3 },
+        140...150 => { percent: 0.0,    rating: :poor,                 rating_value: 2 },
+        150..365  => { percent: 0.10,   rating: :very_poor,            rating_value: 0 },
       }
     end
 
     def self.school_heating_day_adjective(days)
-      find_school_day_rating(days, :rating)
+      I18nHelper.adjective( find_school_day_rating(days, :rating) )
     end
 
     def self.school_day_heating_rating_out_of_10(days)
@@ -349,22 +349,22 @@ module AnalyseHeatingAndHotWater
     # based on analysis of 31 schools from 16Feb2019
     def self.non_school_heating_days_statistics
       { # days range => stats, rating
-        0...5     => { percent: 0.07,   rating: 'perfect',              rating_value: 10  },
-        5...10    => { percent: 0.11,   rating: 'excellent',            rating_value:  9  },
-        10...15   => { percent: 0.04,   rating: 'good',                 rating_value:  8  },
-        15...20   => { percent: 0.11,   rating: 'better than average',  rating_value:  7  },
-        20...25   => { percent: 0.29,   rating: 'about average',        rating_value:  6  },
-        25...30   => { percent: 0.14,   rating: 'worse than average',   rating_value:  5  },
-        30...35   => { percent: 0.0,    rating: 'poor',                 rating_value:  4  },
-        35...40   => { percent: 0.07,   rating: 'poor',                 rating_value:  3  },
-        40...50   => { percent: 0.04,   rating: 'very poor',            rating_value:  2  },
-        50...70   => { percent: 0.07,   rating: 'very poor',            rating_value:  1  },
-        70...300  => { percent: 0.07,   rating: 'bad',                  rating_value:  0  }
+        0...5     => { percent: 0.07,   rating: :perfect,              rating_value: 10  },
+        5...10    => { percent: 0.11,   rating: :excellent,            rating_value:  9  },
+        10...15   => { percent: 0.04,   rating: :good,                 rating_value:  8  },
+        15...20   => { percent: 0.11,   rating: :better_than_average,  rating_value:  7  },
+        20...25   => { percent: 0.29,   rating: :about_average,        rating_value:  6  },
+        25...30   => { percent: 0.14,   rating: :worse_than_average,   rating_value:  5  },
+        30...35   => { percent: 0.0,    rating: :poor,                 rating_value:  4  },
+        35...40   => { percent: 0.07,   rating: :poor,                 rating_value:  3  },
+        40...50   => { percent: 0.04,   rating: :very_poor,            rating_value:  2  },
+        50...70   => { percent: 0.07,   rating: :very_poor,            rating_value:  1  },
+        70...300  => { percent: 0.07,   rating: :bad,                  rating_value:  0  }
       }
     end
 
     def self.non_school_heating_day_adjective(days)
-      non_find_school_day_rating(days, :rating)
+      I18nHelper.adjective( non_find_school_day_rating(days, :rating) )
     end
 
     def self.non_school_day_heating_rating_out_of_10(days)
@@ -727,7 +727,7 @@ module AnalyseHeatingAndHotWater
         'School Heating Days'         =>    [number_of_heating_school_days, :integer],
         'Non School Day Heating Days' =>    [number_of_non_school_heating_days, :integer],
         'Days of meter readings'      =>    [(@amr_data.end_date - @amr_data.start_date + 1).to_i, :integer],
-        'Model calculation time (ms)' =>    [(@model_calculation_time * 1000.0).to_i, :integer], 
+        'Model calculation time (ms)' =>    [(@model_calculation_time * 1000.0).to_i, :integer],
       }
 
       results.merge!(regression_model_configuration)
@@ -996,7 +996,7 @@ module AnalyseHeatingAndHotWater
           kitchen_model(date)
         elsif @meter.hot_water_only?
           summer_model(date)
-        else 
+        else
           heating_on?(date) ? winter_model(date) : summer_model(date)
         end
       logger.info "Missing model type for date #{date}" if model_type.nil?
@@ -1320,7 +1320,7 @@ module AnalyseHeatingAndHotWater
     def community_use_model_scaling_factor(date, community_use)
       @community_use_model_scaling_factors ||= calculate_community_use_model_scaling_factors(community_use)
       raise ScalingModelCalculationDoesntCoverAllModelTypes, "Extend sd, ed calc below to cover #{date}" unless @community_use_model_scaling_factors.key?(model_type?(date))
-      @community_use_model_scaling_factors[model_type?(date)] 
+      @community_use_model_scaling_factors[model_type?(date)]
     end
 
     def no_scaling_models

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -8,7 +8,7 @@ module Logging
 end
 
 asof_date = Date.new(2022, 7, 29)
-schools = ['*']
+schools = ['king*']
 
 overrides = {
   schools:  schools,

--- a/spec/lib/dashboard/advice/advice_seasonal_gas_boiler_control_spec.rb
+++ b/spec/lib/dashboard/advice/advice_seasonal_gas_boiler_control_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe AdviceGasBoilerSeasonalControl do
+
+  context '#warm_weather_on_days_adjective' do
+    it 'returns expected ratings' do
+      expect(described_class.warm_weather_on_days_adjective(1)).to eq 'excellent'
+      expect(described_class.warm_weather_on_days_adjective(7)).to eq 'good'
+      expect(described_class.warm_weather_on_days_adjective(14)).to eq 'above average'
+      expect(described_class.warm_weather_on_days_adjective(20)).to eq 'poor'
+      expect(described_class.warm_weather_on_days_adjective(100)).to eq 'very poor'
+    end
+  end
+end

--- a/spec/lib/dashboard/modelling/heating/heating_model_spec.rb
+++ b/spec/lib/dashboard/modelling/heating/heating_model_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+
+describe AnalyseHeatingAndHotWater::HeatingModel do
+
+  context '#school_heating_day_adjective' do
+    it 'finds the right adjective' do
+      expect(described_class.school_heating_day_adjective(50)).to eq 'perfect'
+      expect(described_class.school_heating_day_adjective(95)).to eq 'excellent'
+      expect(described_class.school_heating_day_adjective(105)).to eq 'good'
+      expect(described_class.school_heating_day_adjective(115)).to eq 'better than average'
+      expect(described_class.school_heating_day_adjective(125)).to eq 'about average'
+      expect(described_class.school_heating_day_adjective(135)).to eq 'worse than average'
+      expect(described_class.school_heating_day_adjective(145)).to eq 'poor'
+      expect(described_class.school_heating_day_adjective(200)).to eq 'very poor'
+    end
+  end
+
+  context '#school_day_heating_rating_out_of_10' do
+    it 'finds the right rating' do
+      expect(described_class.school_day_heating_rating_out_of_10(50)).to eq 10
+      expect(described_class.school_day_heating_rating_out_of_10(95)).to eq 10
+      expect(described_class.school_day_heating_rating_out_of_10(105)).to eq 9
+      expect(described_class.school_day_heating_rating_out_of_10(115)).to eq 7
+      expect(described_class.school_day_heating_rating_out_of_10(125)).to eq 4
+      expect(described_class.school_day_heating_rating_out_of_10(135)).to eq 3
+      expect(described_class.school_day_heating_rating_out_of_10(145)).to eq 2
+      expect(described_class.school_day_heating_rating_out_of_10(200)).to eq 0
+    end
+  end
+
+  context '#non_school_heating_day_adjective' do
+    it 'finds the right adjective' do
+      expect(described_class.non_school_heating_day_adjective(1)).to eq 'perfect'
+      expect(described_class.non_school_heating_day_adjective(6)).to eq 'excellent'
+      expect(described_class.non_school_heating_day_adjective(12)).to eq 'good'
+      expect(described_class.non_school_heating_day_adjective(17)).to eq 'better than average'
+      expect(described_class.non_school_heating_day_adjective(22)).to eq 'about average'
+      expect(described_class.non_school_heating_day_adjective(28)).to eq 'worse than average'
+      expect(described_class.non_school_heating_day_adjective(32)).to eq 'poor'
+      expect(described_class.non_school_heating_day_adjective(38)).to eq 'poor'
+      expect(described_class.non_school_heating_day_adjective(42)).to eq 'very poor'
+      expect(described_class.non_school_heating_day_adjective(55)).to eq 'very poor'
+      expect(described_class.non_school_heating_day_adjective(100)).to eq 'bad'
+    end
+  end
+
+  context '#non_school_day_heating_rating_out_of_10' do
+    it 'finds the right rating' do
+      expect(described_class.non_school_day_heating_rating_out_of_10(1)).to eq 10
+      expect(described_class.non_school_day_heating_rating_out_of_10(6)).to eq 9
+      expect(described_class.non_school_day_heating_rating_out_of_10(12)).to eq 8
+      expect(described_class.non_school_day_heating_rating_out_of_10(17)).to eq 7
+      expect(described_class.non_school_day_heating_rating_out_of_10(22)).to eq 6
+      expect(described_class.non_school_day_heating_rating_out_of_10(28)).to eq 5
+      expect(described_class.non_school_day_heating_rating_out_of_10(32)).to eq 4
+      expect(described_class.non_school_day_heating_rating_out_of_10(38)).to eq 3
+      expect(described_class.non_school_day_heating_rating_out_of_10(42)).to eq 2
+      expect(described_class.non_school_day_heating_rating_out_of_10(55)).to eq 1
+      expect(described_class.non_school_day_heating_rating_out_of_10(100)).to eq 0
+    end
+  end
+
+  context '#r2_rating_adjective' do
+    it 'finds the right adjective' do
+      expect(described_class.r2_rating_adjective(0.05)).to eq 'very poor'
+      expect(described_class.r2_rating_adjective(0.15)).to eq 'very poor'
+      expect(described_class.r2_rating_adjective(0.25)).to eq 'very poor'
+      expect(described_class.r2_rating_adjective(0.35)).to eq 'poor'
+      expect(described_class.r2_rating_adjective(0.45)).to eq 'below average'
+      expect(described_class.r2_rating_adjective(0.55)).to eq 'just below average'
+      expect(described_class.r2_rating_adjective(0.65)).to eq 'about average'
+      expect(described_class.r2_rating_adjective(0.75)).to eq 'above average'
+      expect(described_class.r2_rating_adjective(0.85)).to eq 'excellent'
+      expect(described_class.r2_rating_adjective(0.95)).to eq 'perfect'
+    end
+  end
+
+  context '#r2_rating_out_of_10' do
+    it 'finds the right rating' do
+      expect(described_class.r2_rating_out_of_10(0.05)).to eq 0
+      expect(described_class.r2_rating_out_of_10(0.15)).to eq 1
+      expect(described_class.r2_rating_out_of_10(0.25)).to eq 2
+      expect(described_class.r2_rating_out_of_10(0.35)).to eq 4
+      expect(described_class.r2_rating_out_of_10(0.45)).to eq 5
+      expect(described_class.r2_rating_out_of_10(0.55)).to eq 7
+      expect(described_class.r2_rating_out_of_10(0.65)).to eq 7
+      expect(described_class.r2_rating_out_of_10(0.75)).to eq 8
+      expect(described_class.r2_rating_out_of_10(0.85)).to eq 9
+      expect(described_class.r2_rating_out_of_10(0.95)).to eq 10
+    end
+  end
+
+end


### PR DESCRIPTION
Localise the strings produced as template variables from the gas and storage heater alerts.

Involves:

* replacing member variables with methods, so they can be called with a different locale
* turning ERB templates into I18n.t calls
* adding a couple of specs for helper methods that were returning strings and ratings,

Also adds comments to a couple of alerts that are no longer needed.

Dev checklist.

* [x] storage heaters
* [x] main gas alerts
* [x] hot water
* [x] boiler control