### PR TITLE
Fix series name in Energy Cost Advice Chart

### DIFF
--- a/lib/dashboard/charting_and_reports/charts/aggregator_multi_schools_periods.rb
+++ b/lib/dashboard/charting_and_reports/charts/aggregator_multi_schools_periods.rb
@@ -98,7 +98,7 @@ class AggregatorMultiSchoolsPeriods < AggregatorBase
 
       if index == 0
         results.x_axis = period_data.results.x_axis.map{ |month_year| month_year[0..2]} # MMM YYYY to MMM
-        time_description = number_of_periods <= 1 ? '' : (':' + time_description)
+        time_description = number_of_periods <= 1 ? '' : time_description
         results.bucketed_data[      time_description] = period_data.results.bucketed_data.values[0]
         results.bucketed_data_count[time_description] = period_data.results.bucketed_data_count.values[0]
       else      

--- a/lib/dashboard/charting_and_reports/charts/x_axis_bucketor.rb
+++ b/lib/dashboard/charting_and_reports/charts/x_axis_bucketor.rb
@@ -33,9 +33,9 @@ class XBucketBase
   def compact_date_range_description
     format = '%a%d%b%y'
     if data_start_date != data_end_date
-      data_start_date.strftime(format) + '-' + data_end_date.strftime(format)
+      I18n.l(data_start_date, format: format) + '-' + I18n.l(data_end_date, format: format)
     else
-      data_start_date.strftime(format)
+      I18n.l(data_start_date, format: format)
     end
   end
 

--- a/lib/dashboard/charting_and_reports/charts/x_axis_bucketor.rb
+++ b/lib/dashboard/charting_and_reports/charts/x_axis_bucketor.rb
@@ -31,7 +31,7 @@ class XBucketBase
   end
 
   def compact_date_range_description
-    format = '%a%d%b%y'
+    format = '%a %d %b %y'
     if data_start_date != data_end_date
       I18n.l(data_start_date, format: format) + '-' + I18n.l(data_end_date, format: format)
     else


### PR DESCRIPTION
This pr fixes the series name in the Energy Cost Advice Chart
see https://trello.com/c/9iirwVdt/2392-fix-series-name-in-energy-cost-advice-chart

after this fix
![Screenshot 2022-08-26 at 13 59 41](https://user-images.githubusercontent.com/25906/186909114-5ea2d7cb-0be1-4da7-8421-186fe695c89e.png)

