### PR TITLE
Unhandled x_axis drilldown config

### DIFF
--- a/lib/dashboard/charting_and_reports/charts/chart_drilldown.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_drilldown.rb
@@ -97,6 +97,8 @@ class ChartManager
   end
 
   def x_axis_drilldown(existing_x_axis_config)
+    return unless existing_x_axis_config
+
     case existing_x_axis_config
     when :year, :academicyear
       :week


### PR DESCRIPTION
We've been intermittently getting this error over the past few weeks.

See Rollbar:

https://rollbar.com/energysparks/EnergySparksProduction/items/1407/?utm_campaign=period_summary&utm_medium=email&utm_source=rollbar-notification&utm_content=show_recent_and_monthly_usage

https://rollbar.com/energysparks/EnergySparksProduction/items/1406/?item_page=0&item_count=100&#instances

https://rollbar.com/energysparks/EnergySparksProduction/items/1408/?item_page=0&item_count=100&#traceback

Most recently for "Castlefield Campus" who only completed onboarding on Friday.

Its possible this is a data related issue with determining the drill-down config. 