### PR TITLE
Add a remove dates method to the half hourly data class

### DIFF
--- a/lib/dashboard/utilities/half_hourly_data.rb
+++ b/lib/dashboard/utilities/half_hourly_data.rb
@@ -30,12 +30,17 @@ class HalfHourlyData < Hash
     end
   end
 
-  def remove_date!(*dates)
+  def remove_dates!(*dates)
     dates.each do |date|
       self.delete(date)
-      set_min_max_date(date)
-      @cache_days_totals.delete(date)
     end
+
+    reset_min_max_date
+    self
+  end
+
+  def reset_min_max_date
+    @min_date,@max_date  = keys.minmax
   end
 
   def date_range

--- a/lib/dashboard/utilities/half_hourly_data.rb
+++ b/lib/dashboard/utilities/half_hourly_data.rb
@@ -30,6 +30,11 @@ class HalfHourlyData < Hash
     end
   end
 
+  def remove!(*dates)
+    dates.each { |date| delete(date) }
+    self
+  end
+
   def date_range
     start_date..end_date
   end

--- a/lib/dashboard/utilities/half_hourly_data.rb
+++ b/lib/dashboard/utilities/half_hourly_data.rb
@@ -30,9 +30,12 @@ class HalfHourlyData < Hash
     end
   end
 
-  def remove!(*dates)
-    dates.each { |date| delete(date) }
-    self
+  def remove_date!(*dates)
+    dates.each do |date|
+      self.delete(date)
+      set_min_max_date(date)
+      @cache_days_totals.delete(date)
+    end
   end
 
   def date_range

--- a/lib/dashboard/utilities/half_hourly_data.rb
+++ b/lib/dashboard/utilities/half_hourly_data.rb
@@ -31,16 +31,14 @@ class HalfHourlyData < Hash
   end
 
   def remove_dates!(*dates)
-    dates.each do |date|
-      self.delete(date)
-    end
+    dates.each { |date| delete(date) }
 
     reset_min_max_date
     self
   end
 
   def reset_min_max_date
-    @min_date,@max_date  = keys.minmax
+    @min_date,@max_date = keys.minmax
   end
 
   def date_range


### PR DESCRIPTION
This pr adds a new remove dates method to the half hourly data class so we can reject data for specific dates (ie. temperature and solar) if not needed for a given school.
This is related to:
https://github.com/Energy-Sparks/energy-sparks/pull/2105