### PR TITLE
Misc school specific bug fixes oct 2022

### DIFF
--- a/lib/dashboard/advice/advice_base.rb
+++ b/lib/dashboard/advice/advice_base.rb
@@ -369,6 +369,9 @@ class AdviceBase < ContentBase
       #other errors that cause the advice class to fail to run. This is most likely visible
       #when displaying a page to users.
       alert.analyse(alert_asof_date, true)
+
+      next if alert.enough_data == :not_enough
+      
       variables.each do |to, from|
         #For each variable, copy the value from the alert class to this object
         #as an instance variable. Optionally renaming (from -> to)

--- a/lib/dashboard/advice/advice_electricity_base.rb
+++ b/lib/dashboard/advice/advice_electricity_base.rb
@@ -3,6 +3,6 @@ class AdviceElectricityBase < AdviceBase
     @school.aggregated_electricity_meters
   end
   def relevance
-    @school.aggregated_electricity_meters.nil? ? :never_relevant : :relevant
+    aggregate_meter.nil? ? :never_relevant : :relevant
   end
 end

--- a/lib/dashboard/advice/advice_gas_base.rb
+++ b/lib/dashboard/advice/advice_gas_base.rb
@@ -3,7 +3,7 @@ class AdviceGasBase < AdviceBase
     @school.aggregated_heat_meters
   end
   def relevance
-    @school.aggregated_heat_meters.nil? ? :never_relevant : :relevant
+    aggregate_meter.nil? ? :never_relevant : :relevant
   end
   def non_heating_only?
     aggregate_meter.non_heating_only?

--- a/lib/dashboard/advice/advice_recent_changes_4_weeks.rb
+++ b/lib/dashboard/advice/advice_recent_changes_4_weeks.rb
@@ -66,10 +66,17 @@ class AdviceElectricityRecent < AdviceRecentChangeBase
   def initialize(school)
     super(school, :electricity)
   end
+  # already set to this, but defin explicitly on this class to make clear
+  protected def aggregate_meter
+    @school.aggregated_electricity_meters
+  end
 end
 
 class AdviceGasRecent < AdviceRecentChangeBase
   def initialize(school)
     super(school, :gas)
+  end
+  protected def aggregate_meter
+    @school.aggregated_heat_meters
   end
 end

--- a/lib/dashboard/aggregation/amr_data_community_open_close_breakdown.rb
+++ b/lib/dashboard/aggregation/amr_data_community_open_close_breakdown.rb
@@ -277,7 +277,7 @@ class AMRDataCommunityOpenCloseBreakdown
     if data.first.is_a?(Array)
       AMRData.fast_add_multiple_x48_x_x48(data)
     else
-      data.sum
+      data.sum(0.0) # 0.0 because [].sum => Integer
     end
   end
 end

--- a/lib/dashboard/alerts/gas/alert_gas_model_base.rb
+++ b/lib/dashboard/alerts/gas/alert_gas_model_base.rb
@@ -127,7 +127,7 @@ class AlertGasModelBase < AlertGasOnlyBase
   end
 
   protected def enough_data_for_model_fit(asof_date = @asof_date)
-    # not sure caching is right here potentially for mismatch on asof_dates in analystics testing
+    # not sure caching is right here potentially for mismatch on asof_dates in analytics testing
     @heating_model = calculate_model(asof_date) if @heating_model.nil?
     @heating_model.enough_samples_for_good_fit
   rescue EnergySparksNotEnoughDataException, NoMethodError => e

--- a/lib/dashboard/alerts/gas/alert_model_cache_mixin.rb
+++ b/lib/dashboard/alerts/gas/alert_model_cache_mixin.rb
@@ -14,7 +14,7 @@ module AlertModelCacheMixin
   end
 
   protected def model_start_date(asof_date)
-    asof_date_minus_one_year(asof_date)
+    [asof_date_minus_one_year(asof_date), aggregate_meter.amr_data.start_date].max
   end
 
   protected def one_year_period(asof_date)

--- a/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
@@ -1149,7 +1149,7 @@ class ChartManager
       yaxis_units: :£
     },
     alert_gas_heating_season_intraday: {
-      inherits_from: :gas_heating_season_intraday,
+      inherits_from: :gas_heating_season_intraday_up_to_1_year,
       yaxis_units: :£
     },
     gas_intraday_schoolday_last_year: { # used by heating regression fitter

--- a/lib/dashboard/charting_and_reports/old_advice/heating_model_fitting_advice.rb
+++ b/lib/dashboard/charting_and_reports/old_advice/heating_model_fitting_advice.rb
@@ -651,9 +651,7 @@ class DashboardEnergyAdvice
     def model_results_html
       text = %{
         <h3>Results of model calculations:</h3>
-        <pre>
-          <%= model.non_heating_model.model_results.awesome_inspect %>
-        </pre>
+        <%= HtmlTableFormatting.new(['Variable', 'Value'], model.non_heating_model.model_results.to_a).html %>
       }
       ERB.new(text).result(binding)
     end

--- a/lib/dashboard/charting_and_reports/virtual_schools/average_school_calculator.rb
+++ b/lib/dashboard/charting_and_reports/virtual_schools/average_school_calculator.rb
@@ -17,6 +17,11 @@ class AverageSchoolCalculator
     holiday_type == :mayday ? :easter : holiday_type
   end
 
+  def self.remap_low_sample_holiday2(date)
+    # e.g. Llanmart had single day 19-Sep-2022 holiday
+    date.month == 9 ? :summer : nil
+  end
+
   private
 
   def calculate_school_amr_data(meter:, benchmark_type: :benchmark, pupils: @school.number_of_pupils, floor_area: @school.floor_area, degreeday_adjustment: true)
@@ -40,7 +45,7 @@ class AverageSchoolCalculator
       avg_kwh_x48_by_school_type = school_type_profiles_to_average_x48(date, benchmark_type, interpolators, meter.fuel_type)
 
       kWh_per_pupil_x48 = AMRData.fast_average_multiple_x48(avg_kwh_x48_by_school_type)
-      
+
       kWh_x48 = AMRData.fast_multiply_x48_x_scalar(kWh_per_pupil_x48, scale_by)
 
       average_amr_data.add(date, OneDayAMRReading.new(meter.mpxn, date, 'CAVG', nil, now, kWh_x48))
@@ -76,6 +81,8 @@ class AverageSchoolCalculator
     if daytype == :holiday
       holiday_type = Holidays.holiday_type(date)
       holiday_type = self.class.remap_low_sample_holiday(holiday_type)
+      holiday_type = self.class.remap_low_sample_holiday2(date) if holiday_type.nil?
+
       averaged_school_type_map(@school.school_type).map do |school_type|
         AverageSchoolData.new.raw_data[fuel_type][benchmark_type][school_type.to_sym][:holiday][holiday_type]
       end

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -7,12 +7,19 @@ module Logging
   logger.level = :info
 end
 
-schools = ['[o-z]*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
+schools = ['marksb*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
 
 overrides = {
   schools: schools,
   cache_school: false,
-  adult_dashboard: { control: { user: { user_role: :analytics, staff_role: nil } } },
+  no_adult_dashboard: { control: { user: { user_role: :analytics, staff_role: nil } } },
+  adult_dashboard: {
+    control: { 
+      pages: %i[benchmark],
+      compare_results: [ :summary, :report_differences],
+      user: { user_role: :analytics, staff_role: nil }
+    }
+  },
   # adult_dashboard: { control: { pages: %i[boiler_control_thermostatic], user: { user_role: :analytics, staff_role: nil } } }
   # adult_dashboard: { control: { pages: %i[boiler_control_morning_start_time], user: { user_role: :analytics, staff_role: nil } } }
   # adult_dashboard: { control: { pages: %i[electric_target gas_target] } }

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -7,7 +7,7 @@ module Logging
   logger.level = :info
 end
 
-schools = ['king-jam**'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
+schools = ['[o-z]*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
 
 overrides = {
   schools: schools,

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -7,13 +7,13 @@ module Logging
   logger.level = :info
 end
 
-schools = ['marksb*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
+schools = ['*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
 
 overrides = {
   schools: schools,
   cache_school: false,
   no_adult_dashboard: { control: { user: { user_role: :analytics, staff_role: nil } } },
-  adult_dashboard: {
+  no2_adult_dashboard: {
     control: { 
       pages: %i[benchmark],
       compare_results: [ :summary, :report_differences],

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -3,18 +3,18 @@ require_relative '../../lib/dashboard.rb'
 require_rel '../../test_support'
 
 module Logging
-  @logger = Logger.new(File.join('log', 'alert.log'))
+  @logger = Logger.new(File.join('log', "alert #{DateTime.now.strftime('%Y-%m-%d %H%M%S')}.log"))
   logger.level = :debug
 end
 
 asof_date = Date.new(2022, 10, 22)
-schools = ['*']
+schools = ['aught*']
 
 overrides = {
   schools:  schools,
   cache_school: false,
   alerts:   { alerts: nil, control: { asof_date: asof_date} },
-  no_alerts:   { alerts: [ AlertCommunityPreviousHolidayComparisonElectricity ], control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving], log: [:invalid_alerts] } },
+  alerts:   { alerts: [ AlertHeatingComingOnTooEarly ], control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving], log: [:invalid_alerts] } },
   no_alerts:   { alerts: [ AlertCommunityPreviousHolidayComparisonElectricity ], control: { asof_date: asof_date } }
 }
 

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -3,17 +3,19 @@ require_relative '../../lib/dashboard.rb'
 require_rel '../../test_support'
 
 module Logging
-  @logger = Logger.new(File.join('log', 'logs.log'))
-  logger.level = :error
+  @logger = Logger.new(File.join('log', 'alert.log'))
+  logger.level = :debug
 end
 
-asof_date = Date.new(2022, 7, 29)
-schools = ['king*']
+asof_date = Date.new(2022, 10, 22)
+schools = ['*']
 
 overrides = {
   schools:  schools,
+  cache_school: false,
   alerts:   { alerts: nil, control: { asof_date: asof_date} },
-  # alerts:   { alerts: [ AlertElectricityUsageDuringCurrentHoliday ], control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving], log: [:invalid_alerts] } }
+  no_alerts:   { alerts: [ AlertCommunityPreviousHolidayComparisonElectricity ], control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving], log: [:invalid_alerts] } },
+  no_alerts:   { alerts: [ AlertCommunityPreviousHolidayComparisonElectricity ], control: { asof_date: asof_date } }
 }
 
 script = RunAlerts.default_config.deep_merge(overrides)

--- a/script/standard/test_benchmarks.rb
+++ b/script/standard/test_benchmarks.rb
@@ -8,11 +8,11 @@ module Logging
   logger.level = :error
 end
 
-run_date = Date.new(2022, 8, 14)
+run_date = Date.new(2022, 10, 22)
 
 overrides = { 
-  schools: ['p*'], # ['shrew*', 'bathamp*'],
-  cache_school: true,
+  schools: ['*'], # ['shrew*', 'bathamp*'],
+  cache_school: false,
   benchmarks: {
     calculate_and_save_variables: false,
     asof_date: run_date,
@@ -23,7 +23,7 @@ overrides = {
       change_in_gas_holiday_consumption_previous_holiday
       change_in_gas_holiday_consumption_previous_years_holiday
     ],
-    pages: %i[
+    no_pages_1: %i[
       change_in_gas_holiday_consumption_previous_holiday
     ],
     run_content: { asof_date: run_date } # , filter: ->{ !gpyc_difp.nil? && !gpyc_difp.infinite?.nil? } }

--- a/script/standard/test_charts.rb
+++ b/script/standard/test_charts.rb
@@ -4,15 +4,15 @@ require_rel '../../test_support'
 
 module Logging
   @logger = Logger.new(File.join('log', 'test charts.log'))
-  logger.level = :error
+  logger.level = :debug
 end
 
 charts = {
   # bm:   %i[community_use_test_electricity management_dashboard_group_by_week_electricity]
-  solar: %i[solar_pv_single_day_adhoc_test]
+  solar: %i[management_dashboard_group_by_week_electricity]
 }
 
-charts = { adhoc: %i[group_by_week_gas_versus_benchmark intraday_line_school_days_gas_reduced_data_versus_benchmarks] }
+no_charts = { adhoc: %i[group_by_week_gas_versus_benchmark intraday_line_school_days_gas_reduced_data_versus_benchmarks] }
 
 no_charts = RunCharts.standard_charts_for_school
 
@@ -27,7 +27,7 @@ control = {
 }
 
 overrides = {
-  schools:  ['king-ja*'], # ['hugh*', 'herst*'], # ['tow*', 'st-julian-s-h*'], # ['chase-lane-target*'], # ['king-ja*', 'marksb*', 'long*'],
+  schools:  ['balfour*'], # ['hugh*', 'herst*'], # ['tow*', 'st-julian-s-h*'], # ['chase-lane-target*'], # ['king-ja*', 'marksb*', 'long*'],
   cache_school: false,
   charts:   { charts: charts, control: control }
 }

--- a/script/standard/test_charts.rb
+++ b/script/standard/test_charts.rb
@@ -9,7 +9,7 @@ end
 
 charts = {
   # bm:   %i[community_use_test_electricity management_dashboard_group_by_week_electricity]
-  solar: %i[management_dashboard_group_by_week_electricity]
+  solar: %i[alert_gas_heating_season_intraday ]
 }
 
 no_charts = { adhoc: %i[group_by_week_gas_versus_benchmark intraday_line_school_days_gas_reduced_data_versus_benchmarks] }
@@ -27,7 +27,7 @@ control = {
 }
 
 overrides = {
-  schools:  ['balfour*'], # ['hugh*', 'herst*'], # ['tow*', 'st-julian-s-h*'], # ['chase-lane-target*'], # ['king-ja*', 'marksb*', 'long*'],
+  schools:  ['aught*'], # ['hugh*', 'herst*'], # ['tow*', 'st-julian-s-h*'], # ['chase-lane-target*'], # ['king-ja*', 'marksb*', 'long*'],
   cache_school: false,
   charts:   { charts: charts, control: control }
 }

--- a/script/standard/test_management_summary_table.rb
+++ b/script/standard/test_management_summary_table.rb
@@ -10,7 +10,7 @@ module Logging
 end
 
 overrides = {
-  schools:  ['[m-z]*'],
+  schools:  ['*'],
   cache_school: false
 }
 

--- a/script/utilities/speed_test.rb
+++ b/script/utilities/speed_test.rb
@@ -1,6 +1,45 @@
 
 require 'benchmark'
 
+
+def create_dates
+  a = {}
+  (Date.new(2010,1,1)..Date.new(2020,1,1)).each do |date|
+    a[date] = 1
+  end
+  a
+end
+
+def slow(dates, date)
+  dates.delete(date)
+  a,b = dates.keys.minmax
+end
+
+def fast(dates, date)
+  dates.delete(date)
+  a = date if date < dates.keys.first
+  b = date if date > dates.keys.last
+end
+
+dates = create_dates
+date = Date.new(2015,1,1)
+
+bm = Benchmark.measure {
+  10000.times do |i|
+    slow(dates, date)
+  end
+}
+puts "slow dates method #{bm.to_s}"
+
+bm = Benchmark.measure {
+  10000.times do |i|
+    fast(dates, date)
+  end
+}
+puts "fast dates method #{bm.to_s}"
+
+exit
+
 puts "Reorg of x48 array for gmt/bst shifting"
 kwh = Array.new(48,0.0)
 bm = Benchmark.measure {

--- a/test_support/compare_content.rb
+++ b/test_support/compare_content.rb
@@ -11,7 +11,7 @@ class CompareContentResults
 
   def save_and_compare_content(page, content, merge_page = false)
     comparison_content = load_comparison_content(page, merge_page)
-    differences = compare_content(comparison_content, content)
+    differences = compare_content(comparison_content, content, page)
     save_new_content(page, content, merge_page)
     differences
   end
@@ -87,7 +87,7 @@ class CompareContentResults
     YAML::load_file(yaml_filename)
   end
 
-  def compare_content(comparison_content, new_content)
+  def compare_content(comparison_content, new_content, page)
     differences = []
     if comparison_content.length == new_content.length
       comparison_content.each_with_index do |comparison_component, index|
@@ -95,7 +95,7 @@ class CompareContentResults
       end
     else
       differences = new_content
-      puts "Components differ: #{comparison_content.length}/#{new_content.length}"
+      puts "Components differ: old: #{comparison_content.length} v. new: #{new_content.length} for #{page}"
     end
     differences.compact
   end

--- a/test_support/run_alerts.rb
+++ b/test_support/run_alerts.rb
@@ -163,7 +163,6 @@ class RunAlerts < RunAnalyticsTest
 
   def log_results(alert, control)
     msg = error_message(alert)
-
     if msg.nil?
       unless alert.make_available_to_users?
         log_result(alert, 'Not make_available_to_users after analysis')

--- a/test_support/run_charts.rb
+++ b/test_support/run_charts.rb
@@ -303,6 +303,7 @@ class RunAnalyticsTest
       end
     rescue EnergySparksNotEnoughDataException => e
       puts 'Chart failed: not enough data'
+      puts e.backtrace
       @failed_charts.push( { school_name: @school.name, chart_name: chart_name,  message: e.message, backtrace: e.backtrace, type: e.class.name } )
     rescue => e
       puts e.message


### PR DESCRIPTION
- fridge freezer baseload analysis - more tolerant of shortage of data
- Bramley School: thermostatic analysis - better invalidation of calculation when not enough winter samples
- LLan? School: Average, Benchmark, Exemplar school calculation tolerant of single day September holiday
- Balfour: correction of community breakdown issue: combination of Sheffield synthetic PV data, very large solar PV array compared with school causing noise in calculation, school specific fix == URN of school - needs revisiting - but time consuming as needs back testing versus other schools
- Balfour: Community Usage Comparison alerts - now tolerant of no usage during 1 of the holidays where no community usage
- Fix gas recent change relevance analysis: incorrect inheritance, inherited aggregate electricity meter test for gas, meaning gas only schools had no recent gas analysis: see LD Trello card
- Aughton: heating coming on too early, problem with model - not enough winter samples
- Model fitting expert analysis: converted non heating model parameters to table HTML for better visibility