### PR TITLE
Fix incorrect school type on AdviceBaseload page

### DIFF
--- a/lib/dashboard/charting_and_reports/virtual_schools/average_school_data_interpretation.rb
+++ b/lib/dashboard/charting_and_reports/virtual_schools/average_school_data_interpretation.rb
@@ -32,9 +32,9 @@ class AverageSchoolData
     html = %(
       <p>
         A &apos;benchmark&apos; school represents the
-        <%= average_school_percent_html(:benchmark) %> best ranked <%= school.school_type.humanize.downcase %> schools
+        <%= average_school_percent_html(:benchmark) %> best ranked <%= school.school_type.humanize(capitalize: false) %> schools
         and &apos;exemplar&apos; the
-        <%= average_school_percent_html(:exemplar) %> best <%= school.school_type.humanize.downcase %> schools.
+        <%= average_school_percent_html(:exemplar) %> best <%= school.school_type.humanize(capitalize: false) %> schools.
       </p>
     )
     ERB.new(html).result(binding)

--- a/lib/dashboard/charting_and_reports/virtual_schools/average_school_data_interpretation.rb
+++ b/lib/dashboard/charting_and_reports/virtual_schools/average_school_data_interpretation.rb
@@ -32,9 +32,9 @@ class AverageSchoolData
     html = %(
       <p>
         A &apos;benchmark&apos; school represents the
-        <%= average_school_percent_html(:benchmark) %> best ranked <%= school.school_type.to_s %> schools
+        <%= average_school_percent_html(:benchmark) %> best ranked <%= school.school_type.humanize.downcase %> schools
         and &apos;exemplar&apos; the
-        <%= average_school_percent_html(:exemplar) %> best <%= school.school_type.to_s %> schools.
+        <%= average_school_percent_html(:exemplar) %> best <%= school.school_type.humanize.downcase %> schools.
       </p>
     )
     ERB.new(html).result(binding)

--- a/lib/dashboard/charting_and_reports/virtual_schools/average_school_data_interpretation.rb
+++ b/lib/dashboard/charting_and_reports/virtual_schools/average_school_data_interpretation.rb
@@ -32,12 +32,16 @@ class AverageSchoolData
     html = %(
       <p>
         A &apos;benchmark&apos; school represents the
-        <%= average_school_percent_html(:benchmark) %> best ranked <%= school.school_type.humanize(capitalize: false) %> schools
+        <%= average_school_percent_html(:benchmark) %> best ranked <%= humanize_symbol(school.school_type) %> schools
         and &apos;exemplar&apos; the
-        <%= average_school_percent_html(:exemplar) %> best <%= school.school_type.humanize(capitalize: false) %> schools.
+        <%= average_school_percent_html(:exemplar) %> best <%= humanize_symbol(school.school_type) %> schools.
       </p>
     )
     ERB.new(html).result(binding)
+  end
+
+  def humanize_symbol(symbol)
+    symbol.is_a?(Symbol) ? symbol.to_s.split('_').join(' ') : symbol
   end
 
   def addendum_to_benchmark_and_exemplar_charts

--- a/lib/dashboard/charting_and_reports/virtual_schools/average_school_data_interpretation.rb
+++ b/lib/dashboard/charting_and_reports/virtual_schools/average_school_data_interpretation.rb
@@ -29,19 +29,17 @@ class AverageSchoolData
   end
 
   def benchmark_and_exemplar_rankings(school)
+    humanized_school_type = school.school_type.to_s.split('_').join(' ')
+
     html = %(
       <p>
         A &apos;benchmark&apos; school represents the
-        <%= average_school_percent_html(:benchmark) %> best ranked <%= humanize_symbol(school.school_type) %> schools
+        <%= average_school_percent_html(:benchmark) %> best ranked #{humanized_school_type} schools
         and &apos;exemplar&apos; the
-        <%= average_school_percent_html(:exemplar) %> best <%= humanize_symbol(school.school_type) %> schools.
+        <%= average_school_percent_html(:exemplar) %> best #{humanized_school_type} schools.
       </p>
     )
     ERB.new(html).result(binding)
-  end
-
-  def humanize_symbol(symbol)
-    symbol.is_a?(Symbol) ? symbol.to_s.split('_').join(' ') : symbol
   end
 
   def addendum_to_benchmark_and_exemplar_charts


### PR DESCRIPTION
This pr fixes the school type string formatting on the advice base load page (specifically for `mixed primary and secondary` which currently shows as `mixed_primary_and_secondary`)
