### PR TITLE
Economic costs change over time

### DIFF
--- a/app/models/meter_attributes.rb
+++ b/app/models/meter_attributes.rb
@@ -457,6 +457,28 @@ class MeterAttributes
     )
   end
 
+  def self.default_economic_rates
+    MeterAttributeTypes::Hash.define(
+      required: true,
+      structure: {
+        per:  MeterAttributeTypes::Symbol.define(required: true, allowed_values: [:kwh]),
+        rate: MeterAttributeTypes::Float.define(required: true)
+      }
+    )
+  end
+
+  def self.default_economic_rates_by_time_of_day
+    MeterAttributeTypes::Hash.define(
+      required: false,
+      structure: {
+        per:  MeterAttributeTypes::Symbol.define(allowed_values: [:kwh]),
+        rate: MeterAttributeTypes::Float.define,
+        from: MeterAttributeTypes::TimeOfDay.define,
+        to:   MeterAttributeTypes::TimeOfDay.define
+      }
+    )
+  end
+
   class EconomicTariff < MeterAttributeTypes::AttributeBase
     id :economic_tariff
     key :economic_tariff
@@ -465,38 +487,27 @@ class MeterAttributes
 
     structure MeterAttributeTypes::Hash.define(
       structure: {
-        name:       MeterAttributeTypes::String.define,
-        rates:      MeterAttributeTypes::Hash.define(
-          required: true,
-          structure: {
-            rate: MeterAttributeTypes::Hash.define(
-              required: true,
-              structure: {
-                per:  MeterAttributeTypes::Symbol.define(required: true, allowed_values: [:kwh]),
-                rate: MeterAttributeTypes::Float.define(required: true)
-              }
-            ),
-            daytime_rate: MeterAttributeTypes::Hash.define(
-              required: false,
-              structure: {
-                per:  MeterAttributeTypes::Symbol.define(allowed_values: [:kwh]),
-                rate: MeterAttributeTypes::Float.define,
-                from: MeterAttributeTypes::TimeOfDay.define,
-                to:   MeterAttributeTypes::TimeOfDay.define
-              }
-            ),
-            nighttime_rate: MeterAttributeTypes::Hash.define(
-              required: false,
-              structure: {
-                per:  MeterAttributeTypes::Symbol.define(allowed_values: [:kwh]),
-                rate: MeterAttributeTypes::Float.define,
-                from: MeterAttributeTypes::TimeOfDay.define,
-                to:   MeterAttributeTypes::TimeOfDay.define
-              }
-            )
-          }
-        )
+        name:           MeterAttributeTypes::String.define,
+        rates:          MeterAttributes.default_economic_rates,
+        daytime_rate:   MeterAttributes.default_economic_rates_by_time_of_day,
+        nighttime_rate: MeterAttributes.default_economic_rates_by_time_of_day
+      }
+    )
+  end
 
+  class EconomicTariffChangeOverTime < MeterAttributeTypes::AttributeBase
+    id             :economic_tariff_change_over_time
+    aggregate_over :economic_tariff_change_over_time
+
+    name 'Economic tariff = changes over time'
+
+    structure MeterAttributeTypes::Hash.define(
+      structure: {
+        start_date:     MeterAttributeTypes::Date.define,
+        end_date:       MeterAttributeTypes::Date.define,
+        rates:          MeterAttributes.default_economic_rates,
+        daytime_rate:   MeterAttributes.default_economic_rates_by_time_of_day,
+        nighttime_rate: MeterAttributes.default_economic_rates_by_time_of_day
       }
     )
   end

--- a/app/models/meter_attributes.rb
+++ b/app/models/meter_attributes.rb
@@ -457,7 +457,7 @@ class MeterAttributes
     )
   end
 
-  def self.default_economic_rates
+  def self.default_economic_rate
     MeterAttributeTypes::Hash.define(
       required: true,
       structure: {
@@ -467,7 +467,7 @@ class MeterAttributes
     )
   end
 
-  def self.default_economic_rates_by_time_of_day
+  def self.default_economic_rate_by_time_of_day
     MeterAttributeTypes::Hash.define(
       required: false,
       structure: {
@@ -475,6 +475,17 @@ class MeterAttributes
         rate: MeterAttributeTypes::Float.define,
         from: MeterAttributeTypes::TimeOfDay.define,
         to:   MeterAttributeTypes::TimeOfDay.define
+      }
+    )
+  end
+
+  def self.default_economic_rates
+    MeterAttributeTypes::Hash.define(
+      required:       true,
+      structure: {
+        rate:           MeterAttributes.default_economic_rate,
+        daytime_rate:   MeterAttributes.default_economic_rate_by_time_of_day,
+        nighttime_rate: MeterAttributes.default_economic_rate_by_time_of_day
       }
     )
   end
@@ -487,10 +498,8 @@ class MeterAttributes
 
     structure MeterAttributeTypes::Hash.define(
       structure: {
-        name:           MeterAttributeTypes::String.define,
-        rates:          MeterAttributes.default_economic_rates,
-        daytime_rate:   MeterAttributes.default_economic_rates_by_time_of_day,
-        nighttime_rate: MeterAttributes.default_economic_rates_by_time_of_day
+        name:   MeterAttributeTypes::String.define,
+        rates:  MeterAttributes.default_economic_rates
       }
     )
   end
@@ -503,11 +512,10 @@ class MeterAttributes
 
     structure MeterAttributeTypes::Hash.define(
       structure: {
-        start_date:     MeterAttributeTypes::Date.define,
-        end_date:       MeterAttributeTypes::Date.define,
-        rates:          MeterAttributes.default_economic_rates,
-        daytime_rate:   MeterAttributes.default_economic_rates_by_time_of_day,
-        nighttime_rate: MeterAttributes.default_economic_rates_by_time_of_day
+        name:       MeterAttributeTypes::String.define,
+        start_date: MeterAttributeTypes::Date.define,
+        end_date:   MeterAttributeTypes::Date.define,
+        rates:      MeterAttributes.default_economic_rates
       }
     )
   end

--- a/app/models/tariffs/meter_tariff.rb
+++ b/app/models/tariffs/meter_tariff.rb
@@ -31,16 +31,15 @@ class MeterTariff
     @tariff[:rates][type][:from]..@tariff[:rates][type][:to]
   end
 
-  def rate(type)
+  def rate(_date, type)
     @tariff[:rates][type][:rate]
   end
 
-  def weighted_cost(kwh_x48, type)
-    weights = DateTimeHelper.weighted_x48_vector_single_range(times(type), rate(type))
+  def weighted_cost(_date, kwh_x48, type)
+    weights = DateTimeHelper.weighted_x48_vector_single_range(times(type), rate(_date, type))
     # NB old style tariffs have exclusive times
     AMRData.fast_multiply_x48_x_x48(weights, kwh_x48)
   end
-
 
   def self.format_time_range(rate)
     "#{rate[:from]} to #{rate[:to]}".freeze
@@ -48,6 +47,43 @@ class MeterTariff
 end
 
 class EconomicTariff < MeterTariff
+end
+
+class EconomicTariffChangeOverTime < MeterTariff
+  MIN_DEFAULT_START_DATE = Date.new(2010, 1, 1)
+  MAX_DEFAULT_END_DATE   = Date.new(2050, 1, 1)
+
+  def initialize(meter, tariffs)
+    @tariffs = default_missing_dates(meter, tariffs)
+  end
+
+  def rate(date, type)
+    tariff = find_tariff(date) # allow to blow up if nil returned unexpected to save test which would reduce performance
+    tariff.rate(nil, type)
+  end
+
+  def weighted_cost(date, kwh_x48, type)
+    tariff = find_tariff(date) # allow to blow up if nil returned unexpected to save test which would reduce performance
+    tariff.weighted_cost(nil, kwh_x48, type)
+  end
+
+  private
+
+  def find_tariff(date)
+    @tariffs.each do |date_range, tariff|
+      return tariff if date >= date_range.first && date <= date_range.last
+    end
+
+    nil # should fall over upstream
+  end
+
+  def default_missing_dates(meter,tariffs)
+    tariffs.map do |tariff|
+      tariff[:start_date] = MIN_DEFAULT_START_DATE unless tariff.key?(:start_date)
+      tariff[:end_date]   = MAX_DEFAULT_END_DATE   unless tariff.key?(:end_date)
+      [tariff[:start_date]..tariff[:end_date], EconomicTariff.new(meter, tariff)]
+    end.to_h
+  end
 end
 
 class AccountingTariff < EconomicTariff
@@ -366,7 +402,7 @@ class GenericAccountingTariff < AccountingTariff
     if tiered_rate_type?(type)
       calculate_tiered_costs_x48(type, kwh_x48)
     else
-      weights = DateTimeHelper.weighted_x48_vector_fast_inclusive(times(type), rate(type))
+      weights = DateTimeHelper.weighted_x48_vector_fast_inclusive(times(type), rate(nil, type))
       cost_x48 = AMRData.fast_multiply_x48_x_x48(weights, kwh_x48)
       { differential_rate_name(type) => cost_x48 }
     end

--- a/app/models/tariffs/meter_tariff_manager.rb
+++ b/app/models/tariffs/meter_tariff_manager.rb
@@ -37,15 +37,15 @@ class MeterTariffManager
     t = if differential_tariff_on_date?(date)
           {
             rates_x48: {
-              MeterTariff::NIGHTTIME_RATE => @economic_tariff.weighted_cost(kwh_x48, :nighttime_rate),
-              MeterTariff::DAYTIME_RATE   => @economic_tariff.weighted_cost(kwh_x48, :daytime_rate)
+              MeterTariff::NIGHTTIME_RATE => @economic_tariff.weighted_cost(date, kwh_x48, :nighttime_rate),
+              MeterTariff::DAYTIME_RATE   => @economic_tariff.weighted_cost(date, kwh_x48, :daytime_rate)
             },
             differential: true
           }
         else
           {
             rates_x48: {
-              MeterTariff::FLAT_RATE => AMRData.fast_multiply_x48_x_scalar(kwh_x48, @economic_tariff.rate(:rate))
+              MeterTariff::FLAT_RATE => AMRData.fast_multiply_x48_x_scalar(kwh_x48, @economic_tariff.rate(date, :rate))
             },
             differential: false
           }
@@ -176,7 +176,7 @@ class MeterTariffManager
   end
 
   def pre_process_tariff_attributes(meter)
-    @economic_tariff = EconomicTariff.new(meter, meter.attributes(:economic_tariff))
+    @economic_tariff = pre_process_economic_tariffs(meter)
     @accounting_tariffs = preprocess_accounting_tariffs(meter, meter.attributes(:accounting_tariffs), false) || []
     @default_accounting_tariffs = preprocess_accounting_tariffs(meter, meter.attributes(:accounting_tariffs), true) || []
     @accounting_tariffs += preprocess_generic_accounting_tariffs(meter, meter.attributes(:accounting_tariff_generic)) || []
@@ -185,6 +185,16 @@ class MeterTariffManager
     @differential_tariff_override = process_economic_tariff_override(meter.attributes(:economic_tariff_differential_accounting_tariff))
     @indicative_standing_charge = MeterIndicativeStandingCharge.new(meter, meter.attributes(:indicative_standing_charge))
     check_tariffs
+  end
+
+  def pre_process_economic_tariffs(meter)
+    if meter.attributes(:economic_tariff_change_over_time).nil? || meter.attributes(:economic_tariff_change_over_time).empty?
+      # pre October 2022 version of economic tariffs - same value for all time
+      EconomicTariff.new(meter, meter.attributes(:economic_tariff))
+    else
+      # post October 2022 version of economic tariffs - tariffs potentiall change with start, end_date over time
+      EconomicTariffChangeOverTime.new(meter, meter.attributes(:economic_tariff_change_over_time))
+    end
   end
 
   def process_economic_tariff_override(differential_overrides)

--- a/lib/dashboard/aggregation/costs.rb
+++ b/lib/dashboard/aggregation/costs.rb
@@ -16,7 +16,6 @@ class CostsBase < HalfHourlyData
     @fuel_type = meter.fuel_type
     @bill_component_types_internal = Hash.new(nil) # only interested in (quick access) to keys, so maintain as hash rather than array
     @post_aggregation_state = false
-    @calculated = {}
   end
 
   def bill_component_types
@@ -215,7 +214,7 @@ class CostsBase < HalfHourlyData
   end
 
   def calculated?(date)
-    @calculated[date] == true
+    !self[date].nil?
   end
 
   def date_exists?(date)

--- a/lib/dashboard/benchmarking/benchmark_content_general.rb
+++ b/lib/dashboard/benchmarking/benchmark_content_general.rb
@@ -344,7 +344,7 @@ module Benchmarking
           the school is unoccupied.
         </p>
         <p>
-          In general, in general with very few exceptions the baseload in the winter
+          In general, with very few exceptions the baseload in the winter
           should be very slimiar to the summer. In practice many school accidently
           leave electrically powered heating-related equipment on overnight whe
           the school is unoccupied.
@@ -370,7 +370,7 @@ module Benchmarking
           the school is unoccupied.
         </p>
         <p>
-          In general, in general with very few exceptions the baseload shouldn&apos;t
+          In general, with very few exceptions the baseload shouldn&apos;t
           vary between days of the week and even between weekdays and weekends.
         </p>
         <p>

--- a/lib/dashboard/benchmarking/benchmark_content_general.rb
+++ b/lib/dashboard/benchmarking/benchmark_content_general.rb
@@ -345,7 +345,7 @@ module Benchmarking
         </p>
         <p>
           In general, with very few exceptions the baseload in the winter
-          should be very slimiar to the summer. In practice many school accidently
+          should be very similar to the summer. In practice many school accidently
           leave electrically powered heating-related equipment on overnight whe
           the school is unoccupied.
         </p>

--- a/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
@@ -250,18 +250,18 @@ class ChartManager
     },
 
     test_economic_costs_electric_by_week_unlimited_£: {
-      name:             'By Week: Electricity Unlimited £',
+      name:             'By Week: <%= meter.fuel_type.capitalize %> Unlimited £',
       inherits_from:    :management_dashboard_group_by_week_electricity,
       yaxis_units:      :£,
       timescale:        nil
     },
     test_economic_costs_electric_by_week_unlimited_co2: {
-      name:             'By Week: Electricity Unlimited co2',
+      name:             'By Week: <%= meter.fuel_type.capitalize %> Unlimited co2',
       inherits_from:    :test_economic_costs_electric_by_week_unlimited_£,
       yaxis_units:      :co2,
     },
     test_economic_costs_electric_by_week_unlimited_kwh: {
-      name:             'By Week: Electricity Unlimited kwh',
+      name:             'By Week: <%= meter.fuel_type.capitalize %> Unlimited kwh',
       inherits_from:    :test_economic_costs_electric_by_week_unlimited_£,
       yaxis_units:      :kwh,
     },
@@ -271,31 +271,38 @@ class ChartManager
       yaxis_units:      :accounting_cost,
     },
     test_economic_costs_electric_by_week_unlimited_kwh_meter_breakdown: {
-      name:             'By Week: Electricity Unlimited meter breakdown',
+      name:             'By Week: <%= meter.fuel_type.capitalize %> Unlimited meter breakdown',
       inherits_from:    :group_by_week_electricity_meter_breakdown,
       yaxis_units:      :£,
       timescale:        nil
     },
+    test_economic_costs_electric_by_datetime_year_£: {
+      name:             'By Week: <%= meter.fuel_type.capitalize %> £ by datetime - 1 year',
+      inherits_from:    :test_economic_costs_electric_by_week_unlimited_£,
+      yaxis_units:      :£,
+      x_axis:           :datetime,
+      timescale:        :year
+    },
 
     test_economic_costs_gas_by_week_unlimited_£: {
-      name:             'By Week: Gas Unlimited £',
       inherits_from:    :test_economic_costs_electric_by_week_unlimited_£,
       meter_definition: :allheat,
     },
     test_economic_costs_gas_by_week_unlimited_co2: {
-      name:             'By Week: Gas Unlimited CO2',
       inherits_from:    :test_economic_costs_electric_by_week_unlimited_co2,
       meter_definition:  :allheat,
     },
     test_economic_costs_gas_by_week_unlimited_kwh: {
-      name:             'By Week: Gas Unlimited kWh',
       inherits_from:    :test_economic_costs_electric_by_week_unlimited_kwh,
       meter_definition: :allheat,
     },
     test_economic_costs_gas_by_week_unlimited_kwh_meter_breakdown: {
-      name:             'By Week: Gas Unlimited meter breakdown',
       inherits_from:    :test_economic_costs_electric_by_week_unlimited_kwh_meter_breakdown,
       meter_definition: :allheat,
+    },
+    test_economic_costs_gas_by_datetime_year_£: {
+      inherits_from:    :test_economic_costs_electric_by_datetime_year_£,
+      meter_definition: :allheat
     },
 
     targeting_and_tracking_weekly_electricity_to_date_column_deprecated: {

--- a/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
@@ -249,6 +249,55 @@ class ChartManager
       timescale:        :up_to_a_year
     },
 
+    test_economic_costs_electric_by_week_unlimited_£: {
+      name:             'By Week: Electricity Unlimited £',
+      inherits_from:    :management_dashboard_group_by_week_electricity,
+      yaxis_units:      :£,
+      timescale:        nil
+    },
+    test_economic_costs_electric_by_week_unlimited_co2: {
+      name:             'By Week: Electricity Unlimited co2',
+      inherits_from:    :test_economic_costs_electric_by_week_unlimited_£,
+      yaxis_units:      :co2,
+    },
+    test_economic_costs_electric_by_week_unlimited_kwh: {
+      name:             'By Week: Electricity Unlimited kwh',
+      inherits_from:    :test_economic_costs_electric_by_week_unlimited_£,
+      yaxis_units:      :kwh,
+    },
+    test_economic_costs_electric_by_week_unlimited_acc£: {
+      inherits_from:    :test_economic_costs_electric_by_week_unlimited_£,
+      series_breakdown: :daytype,
+      yaxis_units:      :accounting_cost,
+    },
+    test_economic_costs_electric_by_week_unlimited_kwh_meter_breakdown: {
+      name:             'By Week: Electricity Unlimited meter breakdown',
+      inherits_from:    :group_by_week_electricity_meter_breakdown,
+      yaxis_units:      :£,
+      timescale:        nil
+    },
+
+    test_economic_costs_gas_by_week_unlimited_£: {
+      name:             'By Week: Gas Unlimited £',
+      inherits_from:    :test_economic_costs_electric_by_week_unlimited_£,
+      meter_definition: :allheat,
+    },
+    test_economic_costs_gas_by_week_unlimited_co2: {
+      name:             'By Week: Gas Unlimited CO2',
+      inherits_from:    :test_economic_costs_electric_by_week_unlimited_co2,
+      meter_definition:  :allheat,
+    },
+    test_economic_costs_gas_by_week_unlimited_kwh: {
+      name:             'By Week: Gas Unlimited kWh',
+      inherits_from:    :test_economic_costs_electric_by_week_unlimited_kwh,
+      meter_definition: :allheat,
+    },
+    test_economic_costs_gas_by_week_unlimited_kwh_meter_breakdown: {
+      name:             'By Week: Gas Unlimited meter breakdown',
+      inherits_from:    :test_economic_costs_electric_by_week_unlimited_kwh_meter_breakdown,
+      meter_definition: :allheat,
+    },
+
     targeting_and_tracking_weekly_electricity_to_date_column_deprecated: {
       name:           :targeting_and_tracking_weekly_electricity_to_date_column.to_s,
       chart1_type:    :column,

--- a/script/standard/test_charts.rb
+++ b/script/standard/test_charts.rb
@@ -27,7 +27,7 @@ control = {
 }
 
 overrides = {
-  schools:  ['aught*'], # ['hugh*', 'herst*'], # ['tow*', 'st-julian-s-h*'], # ['chase-lane-target*'], # ['king-ja*', 'marksb*', 'long*'],
+  schools:  ['king-james*'], # ['hugh*', 'herst*'], # ['tow*', 'st-julian-s-h*'], # ['chase-lane-target*'], # ['king-ja*', 'marksb*', 'long*'],
   cache_school: false,
   charts:   { charts: charts, control: control }
 }

--- a/script/standard/test_dynamic_economic_costs.rb
+++ b/script/standard/test_dynamic_economic_costs.rb
@@ -36,7 +36,7 @@ control = {
 }
 
 overrides = {
-  schools:          ['king-james-*'],
+  schools:          ['king-james*'],
   cache_school:     false,
   economic_costs:   { charts: charts, control: control }
 }

--- a/script/standard/test_dynamic_economic_costs.rb
+++ b/script/standard/test_dynamic_economic_costs.rb
@@ -13,12 +13,15 @@ charts = {
     test_economic_costs_electric_by_week_unlimited_co2
     test_economic_costs_electric_by_week_unlimited_kwh
     test_economic_costs_electric_by_week_unlimited_kwh_meter_breakdown
+    electricity_cost_1_year_accounting_breakdown
+    test_economic_costs_electric_by_datetime_year_£
   ],
   gas: %i[
     test_economic_costs_gas_by_week_unlimited_£
     test_economic_costs_gas_by_week_unlimited_co2
     test_economic_costs_gas_by_week_unlimited_kwh
     test_economic_costs_gas_by_week_unlimited_kwh_meter_breakdown
+    gas_cost_1_year_accounting_breakdown
   ]
 }
 
@@ -33,7 +36,7 @@ control = {
 }
 
 overrides = {
-  schools:          ['*'],
+  schools:          ['king-james-*'],
   cache_school:     false,
   economic_costs:   { charts: charts, control: control }
 }

--- a/script/standard/test_dynamic_economic_costs.rb
+++ b/script/standard/test_dynamic_economic_costs.rb
@@ -1,0 +1,48 @@
+require 'require_all'
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
+
+module Logging
+  @logger = Logger.new(File.join('log', "economic costs #{DateTime.now.strftime('%Y-%m-%d %H%M%S')}.log"))
+  logger.level = :debug
+end
+
+charts = {
+  electricity: %i[
+    test_economic_costs_electric_by_week_unlimited_£
+    test_economic_costs_electric_by_week_unlimited_co2
+    test_economic_costs_electric_by_week_unlimited_kwh
+    test_economic_costs_electric_by_week_unlimited_kwh_meter_breakdown
+  ],
+  gas: %i[
+    test_economic_costs_gas_by_week_unlimited_£
+    test_economic_costs_gas_by_week_unlimited_co2
+    test_economic_costs_gas_by_week_unlimited_kwh
+    test_economic_costs_gas_by_week_unlimited_kwh_meter_breakdown
+  ]
+}
+
+control = {
+  save_to_excel:  true,
+
+  compare_results: [
+    :summary,
+    :report_differences,
+    :report_differing_charts
+  ]
+}
+
+overrides = {
+  schools:          ['*'],
+  cache_school:     false,
+  economic_costs:   { charts: charts, control: control }
+}
+
+script = RunAnalyticsTest.default_config.deep_merge(overrides)
+
+begin
+  RunTests.new(script).run
+rescue => e
+  puts e.message
+  puts e.backtrace
+end

--- a/script/utilities/speed_test.rb
+++ b/script/utilities/speed_test.rb
@@ -2,6 +2,107 @@
 require 'benchmark'
 
 
+economic_tariffs = [
+  {
+    start_date: Date.new(2016,1,1),
+    end_date:   Date.new(2020,1,1),
+    rate:       0.12
+  },
+  {
+    start_date: Date.new(2020, 1, 2),
+    end_date:   Date.new(2024, 1, 1),
+    rate:       0.30
+  },
+  {
+    start_date: Date.new(2024, 1, 2),
+    end_date:   Date.new(2050, 1, 1),
+    rate:       0.14
+  }
+]
+
+def find_tariff1(tariffs, date)
+  tariffs.find { |tariff| date >= tariff[:start_date] && date <= tariff[:end_date] }
+end
+
+economic_tariff_test_dates = [
+  Date.new(2017, 1, 1)..Date.new(2018, 1, 1),
+  Date.new(2022, 1, 1)..Date.new(2023, 1, 1)
+]
+
+dates = economic_tariff_test_dates.map(&:to_a).flatten
+
+puts "Dates: #{dates.length}"
+
+loops = 1 * 48
+
+economic_tariffs_before = { economic_tariff: 10.5 }
+bm = Benchmark.measure {
+  loops.times do |i|
+    dates.each do |date|
+      economic_tariffs_before[:economic_tariff]
+    end
+  end
+}
+
+puts "Economic tariff time (current) #{bm.to_s}"
+
+bm = Benchmark.measure {
+  loops.times do |i|
+    dates.each do |date|
+      find_tariff1(economic_tariffs, date)
+    end
+  end
+}
+
+puts "Economic tariff time (hash find) #{bm.to_s}"
+
+cache = {}
+bm = Benchmark.measure {
+  loops.times do |i|
+    dates.each do |date|
+      cache[date] ||= find_tariff1(economic_tariffs, date)
+    end
+  end
+}
+
+puts "Economic tariff time (hash find cache) #{bm.to_s}"
+
+times = dates.map(&:to_time)
+
+cache = {}
+bm = Benchmark.measure {
+  loops.times do |i|
+    times.each do |date|
+      cache[date] ||= find_tariff1(economic_tariffs, date.to_date)
+    end
+  end
+}
+
+puts "Economic tariff time (hash find time cache) #{bm.to_s}"
+
+puts "Economic tariff time (hash find) #{bm.to_s}"
+
+@d1_cache = { start_date: Date.new(2008,1,1), end_date: Date.new(2008,1,1), rate: nil }
+@v1 = 45.0
+
+cache = {}
+bm = Benchmark.measure {
+  loops.times do |i|
+    dates.each do |date|
+      if date >= @d1_cache[:start_date] && date <= @d1_cache[:end_date]
+        @d1_cache[:rate]
+      else
+        @d1_cache = find_tariff1(economic_tariffs, date)
+        puts date if @d1_cache.nil?
+        @d1_cache[:rate]
+      end
+    end
+  end
+}
+
+puts "Economic tariff time (hash find cache fast 1st key) #{bm.to_s}"
+
+exit
 def create_dates
   a = {}
   (Date.new(2010,1,1)..Date.new(2020,1,1)).each do |date|

--- a/test_support/compare_charts.rb
+++ b/test_support/compare_charts.rb
@@ -1,11 +1,11 @@
 class CompareChartResults
   attr_reader :control, :school_name
-  def initialize(control, school_name)
+  def initialize(control, school_name, directory_name: 'Charts')
     @control = control # [ :summary, :quick_comparison, :report_differing_charts, :report_differences ]
     @school_name = school_name
     @identical_result_count = 0
     @differing_results = {} # [chart_name] => differences
-    @directory_name = 'Charts'
+    @directory_name = directory_name
     @missing = []
   end
 

--- a/test_support/run_charts.rb
+++ b/test_support/run_charts.rb
@@ -79,7 +79,7 @@ class RunAnalyticsTest
     save_to_excel
     write_html
     report_calculation_time(control)
-    CompareChartResults.new(control[:compare_results], @school.name).compare_results(all_charts)
+    CompareChartResults.new(control[:compare_results], @school.name, directory_name: @results_sub_directory_type).compare_results(all_charts)
     log_all_results
   end
 
@@ -102,7 +102,7 @@ class RunAnalyticsTest
     end
     save_to_excel if control[:save_to_excel] == true
     report_calculation_time(control)
-    CompareChartResults.new(control[:compare_results], @school.name).compare_results(all_charts)
+    CompareChartResults.new(control[:compare_results], @school.name, directory_name: @results_sub_directory_type).compare_results(all_charts)
     log_all_results
   end
 

--- a/test_support/run_tests.rb
+++ b/test_support/run_tests.rb
@@ -40,6 +40,8 @@ class RunTests
         run_alerts(configuration[:alerts], configuration[:control])
       when :charts
         run_charts(configuration[:charts], configuration[:control])
+      when :economic_costs
+        run_economic_costs(configuration[:charts], configuration[:control])
       when :drilldown
         run_drilldown(configuration)
       when :specific_drilldowns
@@ -409,7 +411,11 @@ class RunTests
     RunCharts.report_failed_charts(failed_charts, control[:report_failed_charts]) if control.key?(:report_failed_charts)
   end
 
-  def run_charts(charts, control)
+  def run_economic_costs(charts, control)
+    run_charts(charts, control, dir_name: 'EconomicCosts')
+  end
+
+  def run_charts(charts, control, dir_name: 'Charts')
     logger.info '=' * 120
     logger.info 'RUNNING CHARTS'
     failed_charts = []
@@ -421,7 +427,7 @@ class RunTests
       reevaluate_log_filename
       school = load_school(school_name)
       start_profiler
-      charts_runner = RunCharts.new(school, results_sub_directory_type: 'Charts')
+      charts_runner = RunCharts.new(school, results_sub_directory_type: dir_name)
       charts_runner.run_structured_chart_list(charts, control)
       stop_profiler('charts')
       failed_charts += charts_runner.failed_charts


### PR DESCRIPTION
New meter attribute economic_tariff_change_over_time allows economic tariffs to change over time; previous economic_tariff meter attribute supported for backwards compatibility.