### PR TITLE
Fix temperature range error for targets

### DIFF
--- a/lib/dashboard/data_sources/utilities/temperatures.rb
+++ b/lib/dashboard/data_sources/utilities/temperatures.rb
@@ -32,9 +32,7 @@ class Temperatures < HalfHourlyData
     while date >= start_date
       time_of_year_date_this_year = Date.new(date.year, time_of_year.month, time_of_year.day)
       if time_of_year_date_this_year.between?(start_date + days_either_side, end_date - days_either_side)
-        avg_temperatures += (-days_either_side..days_either_side).map do |offset|
-                                                                    average_temperature(time_of_year_date_this_year + offset)
-                                                                  end
+        avg_temperatures += (-days_either_side..days_either_side).map { |offset| average_temperature(time_of_year_date_this_year + offset) }
       end
       date = Date.new(date.year - 1, date.month, date.day)
     end

--- a/lib/dashboard/data_sources/utilities/temperatures.rb
+++ b/lib/dashboard/data_sources/utilities/temperatures.rb
@@ -1,6 +1,8 @@
 class Temperatures < HalfHourlyData
   include Logging
 
+  class MissingTemperatureDataError < StandardError; end
+
   FROSTPROTECTIONTEMPERATURE = 4.0
   def initialize(type)
     super(type)
@@ -39,8 +41,9 @@ class Temperatures < HalfHourlyData
     end
 
     if avg_temperatures.length.zero?
-      logger.info "No data for time of year #{time_of_year}, have temperatures between #{start_date} and #{end_date}"
-      nil
+      error_message = "No data for time of year #{time_of_year}, have temperatures between #{start_date} and #{end_date}"
+      logger.info error_message
+      raise MissingTemperatureDataError, error_message
     else
       avg_temperatures.sum / avg_temperatures.length
     end

--- a/lib/dashboard/data_sources/utilities/temperatures.rb
+++ b/lib/dashboard/data_sources/utilities/temperatures.rb
@@ -31,15 +31,19 @@ class Temperatures < HalfHourlyData
 
     while date >= start_date
       time_of_year_date_this_year = Date.new(date.year, time_of_year.month, time_of_year.day)
+
       if time_of_year_date_this_year.between?(start_date + days_either_side, end_date - days_either_side)
         avg_temperatures += (-days_either_side..days_either_side).map { |offset| average_temperature(time_of_year_date_this_year + offset) }
       end
       date = Date.new(date.year - 1, date.month, date.day)
     end
 
-    logger.info "No data for time of year #{time_of_year}, have temperatures between #{start_date} and #{end_date}" if avg_temperatures.length == 0
-
-    avg_temperatures.sum / avg_temperatures.length
+    if avg_temperatures.length.zero?
+      logger.info "No data for time of year #{time_of_year}, have temperatures between #{start_date} and #{end_date}"
+      nil
+    else
+      avg_temperatures.sum / avg_temperatures.length
+    end
   end
 
   def average_temperature_in_date_range(start_date, end_date)

--- a/lib/dashboard/data_sources/utilities/temperatures.rb
+++ b/lib/dashboard/data_sources/utilities/temperatures.rb
@@ -32,7 +32,9 @@ class Temperatures < HalfHourlyData
     while date >= start_date
       time_of_year_date_this_year = Date.new(date.year, time_of_year.month, time_of_year.day)
       if time_of_year_date_this_year.between?(start_date + days_either_side, end_date - days_either_side)
-        avg_temperatures += (-days_either_side..days_either_side).map { |offset| average_temperature(time_of_year_date_this_year + offset) }
+        avg_temperatures += (-days_either_side..days_either_side).map do |offset|
+                                                                    average_temperature(time_of_year_date_this_year + offset)
+                                                                  end
       end
       date = Date.new(date.year - 1, date.month, date.day)
     end

--- a/lib/dashboard/modelling/targeting and tracking/target_meter_temperature_compensated.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_meter_temperature_compensated.rb
@@ -65,7 +65,7 @@ class TargetMeterTemperatureCompensatedDailyDayTypeBase < TargetMeterDailyDayTyp
     if past_target
       temperatures.average_temperature(target_date)
     else
-      temperatures.average_temperature_for_time_of_year(time_of_year: TimeOfYear.to_toy(synthetic_date), days_either_side: 4)
+      temperatures.average_temperature_for_time_of_year(time_of_year: TimeOfYear.to_toy(synthetic_date), days_either_side: 0)
     end
   end
 

--- a/lib/dashboard/modelling/targeting and tracking/target_meter_temperature_compensated.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_meter_temperature_compensated.rb
@@ -65,7 +65,7 @@ class TargetMeterTemperatureCompensatedDailyDayTypeBase < TargetMeterDailyDayTyp
     if past_target
       temperatures.average_temperature(target_date)
     else
-      temperatures.average_temperature_for_time_of_year(time_of_year: TimeOfYear.to_toy(synthetic_date), days_either_side: 0)
+      temperatures.average_temperature_for_time_of_year(time_of_year: TimeOfYear.to_toy(synthetic_date), days_either_side: 4)
     end
   end
 

--- a/lib/dashboard/modelling/targeting and tracking/target_meter_temperature_compensated.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_meter_temperature_compensated.rb
@@ -2,6 +2,7 @@ class TargetMeterTemperatureCompensatedDailyDayTypeBase < TargetMeterDailyDayTyp
   DEGREEDAY_BASE_TEMPERATURE = 15.5
   RECOMMENDED_HEATING_ON_TEMPERATURE = 14.5
   WITHIN_TEMPERATURE_RANGE = 3.0
+  TARGET_TEMPERATURE_DAYS_EITHER_SIDE = 4
 
   def target_degreedays_average_in_date_range(d1, d2)
     d_days = 0.0
@@ -65,7 +66,7 @@ class TargetMeterTemperatureCompensatedDailyDayTypeBase < TargetMeterDailyDayTyp
     if past_target
       temperatures.average_temperature(target_date)
     else
-      temperatures.average_temperature_for_time_of_year(time_of_year: TimeOfYear.to_toy(synthetic_date), days_either_side: 4)
+      temperatures.average_temperature_for_time_of_year(time_of_year: TimeOfYear.to_toy(synthetic_date), days_either_side: TARGET_TEMPERATURE_DAYS_EITHER_SIDE)
     end
   end
 

--- a/lib/dashboard/utilities/half_hourly_data.rb
+++ b/lib/dashboard/utilities/half_hourly_data.rb
@@ -102,9 +102,7 @@ class HalfHourlyData < Hash
   def missing_dates
     dates = []
     (@min_date..@max_date).each do |date|
-      if !date_missing?(date)
-        dates.push(date)
-      end
+      dates << date if date_missing?(date)
     end
     dates
   end


### PR DESCRIPTION
New error occurring since we further reduced the window for schedule data:
https://rollbar.com/energysparks/EnergySparksTestEnvironment/items/2287/?item_page=0&item_count=100&#instances
This is from this code in [the temperatures class](https://github.com/Energy-Sparks/energy-sparks_analytics/blob/master/lib/dashboard/data_sources/utilities/temperatures.rb#L42). The code checks for a zero value in the previous line and logs if that happens, but then does a divide by zero.

The root cause though is [this line](https://github.com/Energy-Sparks/energy-sparks_analytics/blob/master/lib/dashboard/modelling/targeting%20and%20tracking/target_meter_temperature_compensated.rb#L68). It attempts to calculate an average temperature around a day (TimeOfYear) using 4 days either side.

There's an error when it attempts to calculate the average temperature for 2nd Feb as there isn't 4 days before this date available.

This PR:
- [x] sets a new constant for the days either side value (also used by the main application - see below)
- [x] raises an error when average temperature data is missing instead of raising for a divide by zero
- [x] Fixes a bug in `HalfHourlyData#missing_dates` so that it returns dates that are missing, not a collection of dates for which there is data

Note: there is a related pr/fix on the application side in https://github.com/Energy-Sparks/energy-sparks/pull/2160/files that looks for the newly defined `TARGET_TEMPERATURE_DAYS_EITHER_SIDE` constant (or defaults to 4) so we always pull in maximum meter date - 4 days.