### PR TITLE
Bump number of allowed missing profiles

### DIFF
--- a/lib/dashboard/modelling/targeting and tracking/target_meter.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_meter.rb
@@ -4,7 +4,7 @@ class TargetMeter < Dashboard::Meter
   class UnableToFindMatchingProfile < StandardError; end
   class UnableToCalculateTargetDates < StandardError; end
   class MissingGasEstimationAmrData < StandardError; end
-  MAX_MISSING_PROFILES_TO_IGNORE = 4
+  MAX_MISSING_PROFILES_TO_IGNORE = 6
   include Logging
   attr_reader :target, :feedback, :target_dates, :non_scaled_target_meter, :synthetic_meter
 


### PR DESCRIPTION
Increase number of missing intraday gas profiles that are allowed to be substituted with synthetic data before throwing an exception. Currently causing an issue with Cockton school. See notes on trello card.

As small number of additional synthetic days in the target estimates seems reasonable?