### PR TITLE
Change series keys in TargetsProgress

### DIFF
--- a/app/services/targets_service.rb
+++ b/app/services/targets_service.rb
@@ -1,8 +1,9 @@
 class TargetsService
   include Logging
-  def initialize(aggregate_school, fuel_type)
+  def initialize(aggregate_school, fuel_type, period: :year)
     @aggregate_school = aggregate_school
     @fuel_type = set_fuel_type(fuel_type)
+    @period = period
   end
 
   def progress
@@ -217,7 +218,7 @@ class TargetsService
   end
 
   def data_headers
-    data[:current_year_date_ranges].map { |r| r.first.strftime('%b') }
+    data[:current_year_date_ranges].map { |r| Date.new(r.first.year, r.first.month, 1) }
   end
 
   def data_series(key)

--- a/spec/app/services/targets_progress_spec.rb
+++ b/spec/app/services/targets_progress_spec.rb
@@ -4,7 +4,7 @@ describe TargetsProgress do
 
   let(:january)                   { Date.new(Date.today.year, 1, 1) }
   let(:february)                  { Date.new(Date.today.year, 2, 1) }
-  let(:months)                    { [:january, :february] }
+  let(:months)                    { [january, february] }
   let(:fuel_type)                 { :electricity }
 
   let(:monthly_usage_kwh)         { [10,20] }
@@ -37,57 +37,57 @@ describe TargetsProgress do
 
   context '#monthly_targets_kwh' do
     it 'returns expected data' do
-      expect(progress.monthly_targets_kwh[:january]).to eq 8
-      expect(progress.monthly_targets_kwh[:february]).to eq 15
+      expect(progress.monthly_targets_kwh[january]).to eq 8
+      expect(progress.monthly_targets_kwh[february]).to eq 15
     end
   end
 
   context '#monthly_usage_kwh' do
     it 'returns expected data' do
-      expect(progress.monthly_usage_kwh[:january]).to eq 10
-      expect(progress.monthly_usage_kwh[:february]).to eq 20
+      expect(progress.monthly_usage_kwh[january]).to eq 10
+      expect(progress.monthly_usage_kwh[february]).to eq 20
     end
   end
 
   context '#monthly_performance' do
     it 'returns expected data' do
-      expect(progress.monthly_performance[:january]).to eq -0.25
-      expect(progress.monthly_performance[:february]).to eq 0.35
+      expect(progress.monthly_performance[january]).to eq -0.25
+      expect(progress.monthly_performance[february]).to eq 0.35
     end
   end
 
   context '#cumulative_usage_kwh' do
     it 'returns expected data' do
-      expect(progress.cumulative_usage_kwh[:january]).to eq 10
-      expect(progress.cumulative_usage_kwh[:february]).to eq 30
+      expect(progress.cumulative_usage_kwh[january]).to eq 10
+      expect(progress.cumulative_usage_kwh[february]).to eq 30
     end
   end
 
   context '#cumulative_targets_kwh' do
     it 'returns expected data' do
-      expect(progress.cumulative_targets_kwh[:january]).to eq 8
-      expect(progress.cumulative_targets_kwh[:february]).to eq 25
+      expect(progress.cumulative_targets_kwh[january]).to eq 8
+      expect(progress.cumulative_targets_kwh[february]).to eq 25
     end
   end
 
   context '#cumulative_performance' do
     it 'returns expected data' do
-      expect(progress.cumulative_performance[:january]).to eql -0.99
-      expect(progress.cumulative_performance[:february]).to eql 0.99
+      expect(progress.cumulative_performance[january]).to eql -0.99
+      expect(progress.cumulative_performance[february]).to eql 0.99
     end
   end
 
   context '#percentage_synthetic' do
     it 'returns expected data' do
-      expect(progress.percentage_synthetic[:january]).to eql 0.0
-      expect(progress.percentage_synthetic[:february]).to eql 0.5
+      expect(progress.percentage_synthetic[january]).to eql 0.0
+      expect(progress.percentage_synthetic[february]).to eql 0.5
     end
   end
 
   context '#partial_months' do
     it 'returns expected data' do
-      expect(progress.partial_months[:january]).to eq false
-      expect(progress.partial_months[:february]).to eq true
+      expect(progress.partial_months[january]).to eq false
+      expect(progress.partial_months[february]).to eq true
     end
   end
 
@@ -105,7 +105,7 @@ describe TargetsProgress do
 
   context '#months' do
     it 'returns expected data' do
-      expect(progress.months).to eq [:january, :february]
+      expect(progress.months).to eq [january, february]
     end
   end
 

--- a/spec/app/services/targets_progress_spec.rb
+++ b/spec/app/services/targets_progress_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe TargetsProgress do
 
-  let(:months)                    { ['jan', 'feb'] }
+  let(:january)                   { Date.new(Date.today.year, 1, 1) }
+  let(:february)                  { Date.new(Date.today.year, 2, 1) }
+  let(:months)                    { [:january, :february] }
   let(:fuel_type)                 { :electricity }
 
   let(:monthly_usage_kwh)         { [10,20] }
@@ -35,57 +37,57 @@ describe TargetsProgress do
 
   context '#monthly_targets_kwh' do
     it 'returns expected data' do
-      expect(progress.monthly_targets_kwh["jan"]).to eq 8
-      expect(progress.monthly_targets_kwh["feb"]).to eq 15
+      expect(progress.monthly_targets_kwh[:january]).to eq 8
+      expect(progress.monthly_targets_kwh[:february]).to eq 15
     end
   end
 
   context '#monthly_usage_kwh' do
     it 'returns expected data' do
-      expect(progress.monthly_usage_kwh["jan"]).to eq 10
-      expect(progress.monthly_usage_kwh["feb"]).to eq 20
+      expect(progress.monthly_usage_kwh[:january]).to eq 10
+      expect(progress.monthly_usage_kwh[:february]).to eq 20
     end
   end
 
   context '#monthly_performance' do
     it 'returns expected data' do
-      expect(progress.monthly_performance['jan']).to eq -0.25
-      expect(progress.monthly_performance['feb']).to eq 0.35
+      expect(progress.monthly_performance[:january]).to eq -0.25
+      expect(progress.monthly_performance[:february]).to eq 0.35
     end
   end
 
   context '#cumulative_usage_kwh' do
     it 'returns expected data' do
-      expect(progress.cumulative_usage_kwh["jan"]).to eq 10
-      expect(progress.cumulative_usage_kwh["feb"]).to eq 30
+      expect(progress.cumulative_usage_kwh[:january]).to eq 10
+      expect(progress.cumulative_usage_kwh[:february]).to eq 30
     end
   end
 
   context '#cumulative_targets_kwh' do
     it 'returns expected data' do
-      expect(progress.cumulative_targets_kwh["jan"]).to eq 8
-      expect(progress.cumulative_targets_kwh["feb"]).to eq 25
+      expect(progress.cumulative_targets_kwh[:january]).to eq 8
+      expect(progress.cumulative_targets_kwh[:february]).to eq 25
     end
   end
 
   context '#cumulative_performance' do
     it 'returns expected data' do
-      expect(progress.cumulative_performance['jan']).to eql -0.99
-      expect(progress.cumulative_performance['feb']).to eql 0.99
+      expect(progress.cumulative_performance[:january]).to eql -0.99
+      expect(progress.cumulative_performance[:february]).to eql 0.99
     end
   end
 
   context '#percentage_synthetic' do
     it 'returns expected data' do
-      expect(progress.percentage_synthetic['jan']).to eql 0.0
-      expect(progress.percentage_synthetic['feb']).to eql 0.5
+      expect(progress.percentage_synthetic[:january]).to eql 0.0
+      expect(progress.percentage_synthetic[:february]).to eql 0.5
     end
   end
 
   context '#partial_months' do
     it 'returns expected data' do
-      expect(progress.partial_months['jan']).to eq false
-      expect(progress.partial_months['feb']).to eq true
+      expect(progress.partial_months[:january]).to eq false
+      expect(progress.partial_months[:february]).to eq true
     end
   end
 
@@ -103,7 +105,7 @@ describe TargetsProgress do
 
   context '#months' do
     it 'returns expected data' do
-      expect(progress.months).to eq ['jan', 'feb']
+      expect(progress.months).to eq [:january, :february]
     end
   end
 

--- a/spec/app/services/targets_service_spec.rb
+++ b/spec/app/services/targets_service_spec.rb
@@ -7,6 +7,22 @@ describe TargetsService do
   let(:service)                 { TargetsService.new(meter_collection, fuel_type) }
 
   describe "#progress" do
+    let(:august) { Date.new(2021, 8, 1) }
+
+    let(:months) {[
+        Date.new(2020, 9, 1),
+        Date.new(2020, 10, 1),
+        Date.new(2020, 11, 1),
+        Date.new(2020, 12, 1),
+        Date.new(2021, 1, 1),
+        Date.new(2021, 2, 1),
+        Date.new(2021, 3, 1),
+        Date.new(2021, 4, 1),
+        Date.new(2021, 5, 1),
+        Date.new(2021, 6, 1),
+        Date.new(2021, 7, 1),
+        august
+    ]}
 
     def dates(first, last)
       Date.parse(first)..Date.parse(last)
@@ -52,31 +68,31 @@ describe TargetsService do
 
     context 'with full year of data' do
       it 'returns months' do
-        expect(service.progress.months).to include('Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec')
+        expect(service.progress.months).to match_array(months)
       end
 
       it 'returns monthly targets' do
-        expect(service.progress.monthly_targets_kwh['Aug']).to eq(2222.22)
+        expect(service.progress.monthly_targets_kwh[august]).to eq(2222.22)
       end
 
       it 'returns monthly usage' do
-        expect(service.progress.monthly_usage_kwh['Aug']).to eq(1111.11)
+        expect(service.progress.monthly_usage_kwh[august]).to eq(1111.11)
       end
 
       it 'returns monthly performance' do
-        expect(service.progress.monthly_performance['Aug']).to eq(77.77)
+        expect(service.progress.monthly_performance[august]).to eq(77.77)
       end
 
       it 'returns cumulative targets' do
-        expect(service.progress.cumulative_targets_kwh['Aug']).to eq(5555.55)
+        expect(service.progress.cumulative_targets_kwh[august]).to eq(5555.55)
       end
 
       it 'returns cumulative usage' do
-        expect(service.progress.cumulative_usage_kwh['Aug']).to eq(4444.44)
+        expect(service.progress.cumulative_usage_kwh[august]).to eq(4444.44)
       end
 
       it 'returns cumulative_performance' do
-        expect(service.progress.cumulative_performance['Aug']).to eq(88.88)
+        expect(service.progress.cumulative_performance[august]).to eq(88.88)
       end
 
       it 'returns fuel type' do
@@ -84,7 +100,7 @@ describe TargetsService do
       end
 
       it 'returns partial months' do
-        expect(service.progress.partial_months['Aug']).to eq(true)
+        expect(service.progress.partial_months[august]).to eq(true)
       end
 
       it 'returns current cumulative performance vs synthetic' do


### PR DESCRIPTION
The `TargetsProcess` class currently wraps a series of hashes keyed by month name. But the logic for creating this breaks when the underlying target calculation produces more than 12 months of data, as we end up with duplicate month names.

This PR changes how the class is keyed to instead key by the first of the relevant month. This allows us to still access the data by month and potentially format for display later.