### PR TITLE
Sort out poor labelling of meter breakdown charts when there is solar

### DIFF
--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -331,7 +331,10 @@ module Dashboard
     end
 
     def analytics_name
-      name.present? ? "#{name} (#{mpxn})" : mpxn.to_s
+      return mxpn.to_s unless name.present?
+
+      bracketed_text = name.include?(mpxn.to_s) ? 'MPAN' : mpxn.to_s
+      "#{name} (#{bracketed_text})"
     end
 
     def display_meter_number

--- a/app/models/meter_collection.rb
+++ b/app/models/meter_collection.rb
@@ -15,7 +15,7 @@ class MeterCollection
   attr_reader :heat_meters, :electricity_meters, :storage_heater_meters
 
   # From school/building
-  attr_reader :floor_area, :number_of_pupils, :calculated_floor_area_pupil_numbers
+  attr_reader :floor_area, :number_of_pupils, :calculated_floor_area_pupil_numbers, :meter_identifier_lookup
 
   # Currently, but not always
   attr_reader :school, :name, :address, :postcode, :country, :funding_status, :urn, :area_name, :model_cache, :default_energy_purchaser
@@ -177,6 +177,19 @@ class MeterCollection
 
   def to_s
     'Meter Collection:' + name + ':' + all_meters.join(';')
+  end
+
+  def find_meter_by(identifier:)
+    identifier = identifier.to_s # ids coulld be integer or string
+    return @meter_identifier_lookup[identifier] if @meter_identifier_lookup.key?(identifier)
+
+    meter = search_meter_list_for_identifier(all_meters, identifier)
+    unless meter.nil?
+      @meter_identifier_lookup[identifier] = meter
+      return meter
+    end
+
+    nil
   end
 
   def meter?(identifier, search_sub_meters = false)

--- a/app/services/aggregation_service_solar_pv.rb
+++ b/app/services/aggregation_service_solar_pv.rb
@@ -249,7 +249,13 @@ class AggregateDataServiceSolar
 
   def assign_meter_names(pv_meter_map)
     pv_meter_map.each do |meter_type, meter|
-      meter.name = PVMap.meter_type_to_name_map[meter_type] unless not_a_meter?(meter)
+      next if not_a_meter?(meter)
+      
+      meter.name = if meter_type == :mains_plus_self_consume
+                     I18n.t('aggregation_service_solar_pv.mains_plus_self_consume', meter_mpan_mprn: meter.mpan_mprn)
+                   else
+                     PVMap.meter_type_to_name_map[meter_type] 
+                   end
     end
   end
 

--- a/app/services/aggregation_service_solar_pv.rb
+++ b/app/services/aggregation_service_solar_pv.rb
@@ -250,13 +250,25 @@ class AggregateDataServiceSolar
   def assign_meter_names(pv_meter_map)
     pv_meter_map.each do |meter_type, meter|
       next if not_a_meter?(meter)
-      
+
+      original_meter_name = original_meter_name_for(mpan_mprn)
       meter.name = if meter_type == :mains_plus_self_consume
-                     I18n.t('aggregation_service_solar_pv.mains_plus_self_consume', meter_mpan_mprn: meter.mpan_mprn)
+                     # I18n.t('aggregation_service_solar_pv.mains_plus_self_consume', meter_mpan_mprn: meter.mpan_mprn, default: nil) ||
+                     if original_meter_name.present?
+                       "#{original_meter_name} including onsite solar PV consumption (#{meter.mpan_mprn})"
+                     else
+                       "#{meter.mpan_mprn} including onsite solar PV consumption"
+                     end
                    else
                      PVMap.meter_type_to_name_map[meter_type] 
                    end
     end
+  end
+
+  def original_meter_name_for(mpan_mprn)
+    @electricity_meters.select do |electricity_meter| 
+      electricity_meter.mpan_mprn == meter.mpan_mprn
+    end&.first&.name
   end
 
   def make_all_amr_data_positive(amr_data)

--- a/app/services/aggregation_service_solar_pv.rb
+++ b/app/services/aggregation_service_solar_pv.rb
@@ -251,13 +251,13 @@ class AggregateDataServiceSolar
     pv_meter_map.each do |meter_type, meter|
       next if not_a_meter?(meter)
 
-      original_meter_name = original_meter_name_for(mpan_mprn)
       meter.name = if meter_type == :mains_plus_self_consume
+                     parent_meter_name = parent_meter_name_for(meter.mpan_mprn)
                      # I18n.t('aggregation_service_solar_pv.mains_plus_self_consume', meter_mpan_mprn: meter.mpan_mprn, default: nil) ||
-                     if original_meter_name.present?
-                       "#{original_meter_name} including onsite solar PV consumption (#{meter.mpan_mprn})"
+                     if parent_meter_name.present?
+                       "Meter #{parent_meter_name} including onsite solar PV consumption (#{meter.mpan_mprn.to_s})"
                      else
-                       "#{meter.mpan_mprn} including onsite solar PV consumption"
+                       "#{meter.mpan_mprn.to_s} including onsite solar PV consumption"
                      end
                    else
                      PVMap.meter_type_to_name_map[meter_type] 
@@ -265,9 +265,10 @@ class AggregateDataServiceSolar
     end
   end
 
-  def original_meter_name_for(mpan_mprn)
-    @electricity_meters.select do |electricity_meter| 
-      electricity_meter.mpan_mprn == meter.mpan_mprn
+  def parent_meter_name_for(mpan_mprn)
+    @electricity_meters.select do |electricity_meter|
+
+      electricity_meter.mpan_mprn == ('9' + mpan_mprn.to_s).to_i
     end&.first&.name
   end
 

--- a/config/locales/services/aggregation_service_solar_pv.yml
+++ b/config/locales/services/aggregation_service_solar_pv.yml
@@ -1,0 +1,4 @@
+---
+en:
+  aggregation_service_solar_pv:
+    mains_plus_self_consume: Meter %{meter_mpan_mprn} including onsite solar PV consumption

--- a/lib/dashboard/modelling/heating/heating_regression_model_fitter.rb
+++ b/lib/dashboard/modelling/heating/heating_regression_model_fitter.rb
@@ -148,7 +148,7 @@ class HeatingRegressionModelFitter
   def run_standard_chart_with_for_one_meter(chart_name, meter, number_of_meters = 1)
     chart_config = ChartManager::STANDARD_CHART_CONFIGURATION[chart_name].deep_dup
     chart_config[:meter_definition] = meter.id if number_of_meters > 1
-    chart_config[:name] += + ' ' + meter.name + ' ' + meter.mpan_mprn.to_s
+    chart_config[:name] += + ' ' + meter.name  + meter.mpan_mprn.to_s
     chart_results = @chart_manager.run_chart(chart_config, (chart_name.to_s + '_cloned').to_sym)
     chart_results
   end

--- a/lib/dashboard/modelling/solar/solar_pv_estimator.rb
+++ b/lib/dashboard/modelling/solar/solar_pv_estimator.rb
@@ -65,7 +65,7 @@ class ExistingSolarPVCapacityEstimator
 
   def original_electricity_meter(electricity_meter)
     if electricity_meter.sheffield_simulated_solar_pv_panels?
-      electricity_meter.sub_meters.find { |sub_meter| sub_meter.name == SolarPVPanels::ELECTRIC_CONSUMED_FROM_MAINS_METER_NAME }
+      electricity_meter.sub_meters.find { |sub_meter| sub_meter.name == 'testing 123' } #SolarPVPanels::ELECTRIC_CONSUMED_FROM_MAINS_METER_NAME }
     else
       electricity_meter
     end


### PR DESCRIPTION
The labelled of meter breakdown charts eg https://energysparks.uk/schools/sherborne-girls/analysis/2814945 is very unhelpful when the school has solar.  Instead of labelling the meter with solar as 'Electricity consumed including onsite solar PV  consumption' which gives no indication of what area of the school it is or which meter this PR updates the labelling scheme to <Meter name or number including onsite solar PV consumption> on the charts and in the table below to <Meter name including onsite solar PV consumption (MPAN)>

![Screenshot 2022-11-15 at 14 43 19](https://user-images.githubusercontent.com/25906/201948096-ea6b3a5c-2a1c-4ec2-9758-186d07651c33.png)
