### PR TITLE
Humanize school type in benchmark comparison advice

### DIFF
--- a/lib/dashboard/charting_and_reports/old_advice/dashboard_analysis_advice.rb
+++ b/lib/dashboard/charting_and_reports/old_advice/dashboard_analysis_advice.rb
@@ -446,7 +446,7 @@ class BenchmarkComparisonAdvice < DashboardChartAdviceBase
         <body>
       <% end %>
       <p>
-        <%= @school.name %> is a <%= @school.school_type %> school near <%= address %>
+        <%= @school.name %> is a <%= @school.school_type.humanize.downcase %> school near <%= address %>
         with <%= @school.number_of_pupils %> pupils
         and a floor area of <%= @school.floor_area.round(0) %>m<sup>2</sup>.
       </p>


### PR DESCRIPTION
so the school type symbol `:mixed_primary_and_secondary` doesn't appear within the advice text with underscores we need to humanize (and downcase) the school type.