### PR TITLE
Fix TargetMeter.calculate_costs_for_meter

### DIFF
--- a/lib/dashboard/modelling/targeting and tracking/target_meter.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_meter.rb
@@ -247,7 +247,7 @@ class TargetMeter < Dashboard::Meter
 
   def calculate_costs_for_meter
     logger.info "Creating economic & accounting costs for target #{mpan_mprn} fuel #{fuel_type} from #{amr_data.start_date} to #{amr_data.end_date}"
-    @meter.amr_data.set_tariffs(meter)
+    amr_data.set_tariffs(self)
   end
 
   def debug(var, ap: false)

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -8,7 +8,7 @@ module Logging
 end
 
 asof_date = Date.new(2022, 11, 5)
-schools = ['king-james*', 'wybour*', 'penny*']
+schools = ['*']
 
 overrides = {
   schools:  schools,
@@ -16,7 +16,7 @@ overrides = {
   alerts:   { alerts: nil, control: { asof_date: asof_date} },
   alerts:   { alerts: [
     # AlertEnergyAnnualVersusBenchmark
-    AlertImpendingHoliday
+    AlertElectricityTarget1Week
     # AlertOutOfHoursElectricityUsage
     ],
   control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving], log: [:invalid_alerts] } },


### PR DESCRIPTION
Following changes to aggregation_mixin, update the calculate_costs_for_meter method.

