### PR TITLE
Fix bug in one_years_data?

### DIFF
--- a/lib/dashboard/modelling/electricity/electricity_baseload_analysis.rb
+++ b/lib/dashboard/modelling/electricity/electricity_baseload_analysis.rb
@@ -31,11 +31,12 @@ class ElectricityBaseloadAnalysis
   end
 
   def blended_baseload_tariff_rate_£_per_kwh(datatype, asof_date = amr_data.end_date)
-    scaled_annual_baseload_cost_£(datatype, asof_date) / annual_average_baseload_kwh(asof_date) 
+    scaled_annual_baseload_cost_£(datatype, asof_date) / annual_average_baseload_kwh(asof_date)
   end
 
   def one_years_data?(asof_date = amr_data.end_date)
-    amr_data.days > 364
+    start_date = @meter.amr_data.start_date
+    return (asof_date - 364) >= start_date
   end
 
   def scaled_annual_dates(asof_date)

--- a/spec/lib/dashboard/modelling/electricity/electricity_baseload_analysis_spec.rb
+++ b/spec/lib/dashboard/modelling/electricity/electricity_baseload_analysis_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe ElectricityBaseloadAnalysis do
+
+  let(:day_count)    { 365 }
+  let(:amr_data)    { build(:amr_data, :with_days, day_count: day_count) }
+  let(:meter)       { build(:meter, amr_data: amr_data) }
+  let(:analyser)    { ElectricityBaseloadAnalysis.new(meter) }
+
+  context '#one_years_data?' do
+    it 'returns true with a years worth of data' do
+      expect(analyser.one_years_data?).to be true
+    end
+    context 'with limited data' do
+      let(:day_count)    { 30 }
+      it 'returns false' do
+        expect(analyser.one_years_data?).to be false
+      end
+    end
+    context 'with historical asof_date' do
+      let(:day_count)    { 365 * 2 }
+      it 'returns true if there is a years worth of data before then' do
+        expect(analyser.one_years_data?(Date.today - 365)).to be true
+      end
+      it 'returns false if not enough data' do
+        expect(analyser.one_years_data?(Date.today - 500)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `ElectricityBaseloadAnalysis.one_years_data?` method has a bug. Currently it only checks to see if there's a years worth of data for a meter, rather than a years worth of data preceding the `asof_date` which is provided as a parameter.

This PR fixes the method so it behaves as expected. Unlikely to be a problem in production, encountered the issue whilst running some tests with older dates.