### PR TITLE
Add a check to see if there is data, not just a key

### DIFF
--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -511,15 +511,15 @@ class AlertAnalysisBase < ContentBase
                   else
                     raise UnknownFuelTypeForBenchmarkAlert, "Unknown out of hours fuel type #{fuel_type}"
                   end
-    
-                  
+
+
     alert = alert_class.new(school)
 
     asof_date = [asof_date, alert.aggregate_meter.amr_data.end_date].min
 
     alert.analyse(asof_date)
 
-    alert       
+    alert
   end
 
   def self.all_alerts

--- a/lib/dashboard/charting_and_reports/old_advice/dashboard_analysis_advice.rb
+++ b/lib/dashboard/charting_and_reports/old_advice/dashboard_analysis_advice.rb
@@ -43,7 +43,7 @@ class DashboardChartAdviceBase
 =begin
     end
 =end
-  
+
   end
 
   def self.advice_factory_group(chart_type, school, chart_definition, charts)
@@ -753,7 +753,7 @@ class BenchmarkComparisonAdvice < DashboardChartAdviceBase
   end
 
   def actual_fuel_usage(fuel, benchmark_type)
-    return 0.0 unless @chart_data[:x_data].key?(fuel_to_s(fuel))
+    return 0.0 unless @chart_data[:x_data].key?(fuel_to_s(fuel)) && @chart_data[:x_data][fuel.to_s].sum > 0.0
 
     benchmark_data(fuel, benchmark_type, :£)
   end
@@ -1257,7 +1257,7 @@ class GasHeatingIntradayAdvice < DashboardChartAdviceBase
         <p>
         Does your school&apos;s boiler in the graph above do this?
         If it doesn't you might need to speak to your building manager
-        or caretaker and ask why? 
+        or caretaker and ask why?
         </p>
       <%= @body_end %>
     }.gsub(/^  /, '')
@@ -1511,7 +1511,7 @@ deprecated PH 22 Jul 2022
 
     logger.debug @school.name
     header_template = %{
-      <% if @add_extra_markup %>        
+      <% if @add_extra_markup %>
           <head><h2>Cusum analysis</h2>
           <body>
       <% end %>
@@ -1568,7 +1568,7 @@ class DayOfWeekAdvice < DashboardChartAdviceBase
     £current = kwh * @school.aggregated_heat_meters.amr_data.current_tariff_rate_£_per_kwh
     kwh_html      = FormatEnergyUnit.format(:kwh,      kwh,      :html)
     £current_html = FormatEnergyUnit.format(:£current, £current, :html)
-    
+
     "#{£current_html} (#{kwh_html})"
   end
 
@@ -2266,7 +2266,7 @@ class HotWaterAdvice < DashboardChartAdviceBase
           <%= advice.introductory_hot_water_text_3_circulatory_inefficiency %>
           <%= advice.introductory_hot_water_text_4_analysis_intro %>
           <%= advice.estimate_of_boiler_efficiency_header %>
-          <%= advice.estimate_of_boiler_efficiency_text_1_chart_explanation %> 
+          <%= advice.estimate_of_boiler_efficiency_text_1_chart_explanation %>
         <% end %>
       <%= @body_end %>
     }.gsub(/^  /, '')

--- a/lib/dashboard/charting_and_reports/old_advice/dashboard_analysis_advice.rb
+++ b/lib/dashboard/charting_and_reports/old_advice/dashboard_analysis_advice.rb
@@ -753,7 +753,7 @@ class BenchmarkComparisonAdvice < DashboardChartAdviceBase
   end
 
   def actual_fuel_usage(fuel, benchmark_type)
-    return 0.0 unless @chart_data[:x_data].key?(fuel_to_s(fuel)) && @chart_data[:x_data][fuel.to_s].sum > 0.0
+    return 0.0 unless @chart_data[:x_data].key?(fuel_to_s(fuel)) && @chart_data[:x_data][fuel_to_s(fuel)].sum > 0.0
 
     benchmark_data(fuel, benchmark_type, :£)
   end

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -7,7 +7,7 @@ module Logging
   logger.level = :info
 end
 
-schools = ['alder*'] # ['king-j*', 'combe-d*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
+schools = ['f*'] # ['king-j*', 'combe-d*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
 
 overrides = {
   schools: schools,
@@ -15,8 +15,8 @@ overrides = {
   no_adult_dashboard: { control: { user: { user_role: :analytics, staff_role: nil } } },
   adult_dashboard: {
     control: {
-      pages: %i[baseload],
-      no_pages: %i[benchmark electric_annual gas_annual electric_out_of_hours gas_out_of_hours hotwater], # storage_heater
+      pages: %i[benchmark],
+      no_pages: %i[electric_annual gas_annual gas_out_of_hours hotwater], # storage_heater
       compare_results: [ :summary, :report_differences],
       user: { user_role: :analytics, staff_role: nil }
     }


### PR DESCRIPTION
Add an extra guard clause when attempting to lookup benchmark data for the chart shown on the AdviceBenchmark page. 

The current check doesn't properly handle case when school has only electricity (or only gas).

Possible there are still other issues here, but this gets the advice to generate locally.