### PR TITLE
Organise weekly baseload analysis

### DIFF
--- a/app/services/baseload/baseload_calculation_service.rb
+++ b/app/services/baseload/baseload_calculation_service.rb
@@ -35,7 +35,7 @@ module Baseload
       when :year
         baseload_analysis.average_annual_baseload_kw(@asof_date)
       when :week
-        baseload_analysis.average_baseload_kw(@asof_date - 6, @asof_date)
+        baseload_analysis.average_baseload_last_week_kw(@asof_date)
       else
         raise "Invalid period"
       end

--- a/lib/dashboard/alerts/electricity/baseload/alert_change_in_electricity_baseload_short_term.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_change_in_electricity_baseload_short_term.rb
@@ -18,7 +18,7 @@ class AlertChangeInElectricityBaseloadShortTerm < AlertBaseloadBase
   attr_reader :last_year_baseload_co2, :last_week_baseload_co2, :next_year_change_in_baseload_co2, :next_year_change_in_baseload_absolute_co2
   attr_reader :cost_saving_through_1_kw_reduction_in_baseload_£
   attr_reader :next_year_change_in_baseload_£current
-  attr_reader :up_until_date, :from_date 
+  attr_reader :up_until_date, :from_date
 
   def initialize(school, report_type = :baseloadchangeshortterm, meter = school.aggregated_electricity_meters)
     super(school, report_type, meter)
@@ -178,11 +178,13 @@ class AlertChangeInElectricityBaseloadShortTerm < AlertBaseloadBase
   def calculate(asof_date)
     super(asof_date)
     @up_until_date = asof_date
-    @from_date = asof_date - 6
 
     @average_baseload_last_year_kw = average_baseload_kw(asof_date)
     @kw_value_at_10_percent_saving = @average_baseload_last_year_kw * 0.9
-    @average_baseload_last_week_kw = average_baseload(@from_date, asof_date)
+
+    @from_date = baseload_analysis.one_week_ago(asof_date)
+    @average_baseload_last_week_kw = baseload_analysis.average_baseload_last_week_kw(asof_date)
+
     @change_in_baseload_kw = @average_baseload_last_week_kw - @average_baseload_last_year_kw
     @predicted_percent_increase_in_usage = (@average_baseload_last_week_kw - @average_baseload_last_year_kw) / @average_baseload_last_year_kw
     @predicted_percent_increase_in_usage_absolute = @predicted_percent_increase_in_usage.magnitude

--- a/lib/dashboard/modelling/electricity/electricity_baseload_analysis.rb
+++ b/lib/dashboard/modelling/electricity/electricity_baseload_analysis.rb
@@ -17,7 +17,7 @@ class ElectricityBaseloadAnalysis
   end
 
   def average_baseload_last_week_kw(date)
-    return average_baseload_kw(one_week_ago(date), date)
+    average_baseload_kw(one_week_ago(date), date)
   end
 
   def average_annual_baseload_kw(asof_date)

--- a/lib/dashboard/modelling/electricity/electricity_baseload_analysis.rb
+++ b/lib/dashboard/modelling/electricity/electricity_baseload_analysis.rb
@@ -16,6 +16,10 @@ class ElectricityBaseloadAnalysis
     amr_data.average_baseload_kw_date_range(date1, date2, sheffield_solar_pv: @meter.sheffield_simulated_solar_pv_panels?)
   end
 
+  def average_baseload_last_week_kw(date)
+    return average_baseload_kw(one_week_ago(date), date)
+  end
+
   def average_annual_baseload_kw(asof_date)
     start_date, end_date, _scale_to_year = scaled_annual_dates(asof_date)
     average_baseload_kw(start_date, end_date)
@@ -55,6 +59,12 @@ class ElectricityBaseloadAnalysis
     scale_to_year = 365 / (end_date - start_date + 1)
 
     [start_date, end_date, scale_to_year.to_f]
+  end
+
+  #We use 6 rather than 7 days ago because of potential issue with schools
+  #with large intraweek variation in consumption
+  def one_week_ago(date)
+    date - 6
   end
 
   def baseload_economic_cost_date_range_£(d1, d2, datatype)

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -8,16 +8,29 @@ module Logging
 end
 
 asof_date = Date.new(2022, 2, 1)
-schools = ['king-james-e*', 'combe*', 'miller*']
+schools = ['a*']
 
 overrides = {
   schools:  schools,
   cache_school: false,
   alerts:   { alerts: nil, control: { asof_date: asof_date} },
   alerts:   { alerts: [
-    AlertElectricityLongTermTrend,
-    AlertGasLongTermTrend,
-    AlertStorageHeatersLongTermTrend
+    # AlertEnergyAnnualVersusBenchmark
+    # AlertSchoolWeekComparisonGas
+    # AlertOutOfHoursElectricityUsage
+    # AlertElectricityBaseloadVersusBenchmark
+    # AlertHeatingComingOnTooEarly
+    # AlertPreviousYearHolidayComparisonElectricity
+    # AlertSolarPVBenefitEstimator
+    # AlertElectricityAnnualVersusBenchmark
+    # AlertGasAnnualVersusBenchmark
+    # AlertEnergyAnnualVersusBenchmark
+    # AlertElectricityPeakKWVersusBenchmark,
+#    AlertElectricityBaseloadVersusBenchmark,
+#    AlertSeasonalBaseloadVariation,
+#    AlertIntraweekBaseloadVariation,
+    #AlertGasAnnualVersusBenchmark
+    AlertChangeInElectricityBaseloadShortTerm
     ],
   control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving html_template_variables], log: [:invalid_alerts] } },
   no_alerts:   { alerts: [ AlertCommunityPreviousHolidayComparisonElectricity ], control: { asof_date: asof_date } }


### PR DESCRIPTION
Adds a method to the ElectricityBaseloadAnalysis object for returning average baseload in last week.

Updated the new services and the existing alert to call this method, to ensure the logic remains consistent.

