### PR TITLE
Fix for thermostatic charts

### DIFF
--- a/lib/dashboard/charting_and_reports/charts/series_data_manager.rb
+++ b/lib/dashboard/charting_and_reports/charts/series_data_manager.rb
@@ -408,7 +408,7 @@ module Series
 
     def predicted_amr_data_one_day(date)
       temperature = school.temperatures.average_temperature(date)
-      scale_datatype_from_kwh(heating_model.predicted_kwh(date, temperature))
+      scale_datatype_from_kwh(date, heating_model.predicted_kwh(date, temperature))
     end
 
     def scale_datatype_from_kwh(date, kwh)
@@ -711,7 +711,7 @@ module Series
 
     def day_breakdown(start_date, end_date)
       heating_data = default_breakdown
-  
+
       (start_date..end_date).each do |date|
         begin
           breakdown_data = heating_model.heating_breakdown(date, kwh_cost_or_co2)
@@ -775,7 +775,7 @@ module Series
     WASTEDHOTWATERUSAGE = 'Wasted Hot Water Usage'
     HOTWATERSERIESNAMES = [USEFULHOTWATERUSAGE, WASTEDHOTWATERUSAGE]
 
-    USEFULHOTWATERUSAGE_I18N_KEY = 'useful_hot_water_usage' 
+    USEFULHOTWATERUSAGE_I18N_KEY = 'useful_hot_water_usage'
     WASTEDHOTWATERUSAGE_I18N_KEY = 'wasted_hot_water_usage'
 
     def series_names;  HOTWATERSERIESNAMES; end
@@ -897,7 +897,7 @@ module Series
   class PredictedHeat < ModelManagerBase
     PREDICTEDHEAT = 'Predicted Heat'
     PREDICTEDHEAT_I18N_KEY = 'predicted_heat'
-    
+
     def series_names;  [PREDICTEDHEAT]; end
 
     def day_breakdown(d1, d2)


### PR DESCRIPTION
A [recent change](https://github.com/Energy-Sparks/energy-sparks_analytics/commit/65779f7f97ef19adc15849f56ef865d75dbf0597#diff-07bfcde2ea5fa51db9042ab04b678fe44c3c87daf3031bbdb10c576c8db9bd31R409) broke the `predicted_amr_data_one_day` method in SeriesDataManager.

This didn't show up in the analytics test suite because that method only seems to be called from `AggregatorTrendlines` which is used to add trend lines. Different code is called for rails vs the excel output. So the analytics test suite didn't fail, but the application charts are broken.

This PR fixes the method call.