### PR TITLE
Fix aggregation multiple solar pv cost calcs

### DIFF
--- a/lib/dashboard/aggregation/amr_data.rb
+++ b/lib/dashboard/aggregation/amr_data.rb
@@ -142,7 +142,7 @@ class AMRData < HalfHourlyData
   end
 
   # performance benefit in collatin the information
-  private def calculate_information_date_range(start_date, end_date)
+  private def calculate_information_date_range_deprecated(start_date, end_date)
     kwh = kwh_date_range(start_date, end_date, :kwh)
     £   = kwh_date_range(start_date, end_date, :£)
     co2 = kwh_date_range(start_date, end_date, :co2)
@@ -156,9 +156,9 @@ class AMRData < HalfHourlyData
     }
   end
 
-  def information_date_range(start_date, end_date)
+  def information_date_range_deprecated(start_date, end_date)
     @cached_information ||= {}
-    @cached_information[start_date..end_date] ||= calculate_information_date_range(start_date, end_date)
+    @cached_information[start_date..end_date] ||= calculate_information_date_range_deprecated(start_date, end_date)
   end
 
   def blended_£_per_kwh_date_range(start_date, end_date)

--- a/lib/dashboard/charting_and_reports/old_advice/solar_pv_profit_loss.rb
+++ b/lib/dashboard/charting_and_reports/old_advice/solar_pv_profit_loss.rb
@@ -65,18 +65,15 @@ class SolarPVProfitLoss
     start_date = [end_date - 365, meter.amr_data.start_date].max
     days = end_date - start_date + 1
 
-    info = meter.amr_data.information_date_range(start_date, end_date)
-    
+    kwh = meter.amr_data.kwh_date_range(start_date, end_date, :kwh)
     {
       start_date:             start_date,
       end_date:               end_date,
-      kwh:                    info[:kwh].magnitude,
-      co2:                    info[:co2].magnitude,
-      £:                      info[:£].magnitude,
-      tariff_rate_£_per_kwh:  info[:blended_£_per_kwh].magnitude,
+      kwh:                    kwh.magnitude,
       days:                   days,
       period_description:     FormatEnergyUnit.format(:years, days / 365.0, :text)
     }
+    
   end
 
   private def period_description(days)

--- a/lib/dashboard/charting_and_reports/old_advice/solar_pv_profit_loss.rb
+++ b/lib/dashboard/charting_and_reports/old_advice/solar_pv_profit_loss.rb
@@ -66,6 +66,7 @@ class SolarPVProfitLoss
     days = end_date - start_date + 1
 
     kwh = meter.amr_data.kwh_date_range(start_date, end_date, :kwh)
+    
     {
       start_date:             start_date,
       end_date:               end_date,
@@ -73,7 +74,6 @@ class SolarPVProfitLoss
       days:                   days,
       period_description:     FormatEnergyUnit.format(:years, days / 365.0, :text)
     }
-    
   end
 
   private def period_description(days)

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -7,7 +7,7 @@ module Logging
   logger.level = :info
 end
 
-schools = ['derby-college-broomfield-hall*'] # ['king-j*', 'combe-d*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
+schools = ['derby-college-broomfield-hall*', 'halfway*', 'freshford*', 'long-fur*', 'combe*'] # ['king-j*', 'combe-d*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
 
 overrides = {
   schools: schools,

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -7,7 +7,7 @@ module Logging
   logger.level = :info
 end
 
-schools = ['fr*'] # ['king-j*', 'combe-d*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
+schools = ['derby-college-broomfield-hall*'] # ['king-j*', 'combe-d*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
 
 overrides = {
   schools: schools,
@@ -15,7 +15,7 @@ overrides = {
   no_adult_dashboard: { control: { user: { user_role: :analytics, staff_role: nil } } },
   adult_dashboard: {
     control: {
-      pages: %i[baseload],
+      pages: %i[solar_pv_group],
       no_pages: %i[electric_annual gas_annual gas_out_of_hours hotwater], # storage_heater
       compare_results: [ :summary, :report_differences],
       user: { user_role: :analytics, staff_role: nil }


### PR DESCRIPTION
Fixes an issue with solar pv costs when a school has multiple solar installations.

There still an underlying issue with the aggregation process around solar data, but at present we can't reliably produce cost information for those meters due to lack of information from schools.

So this issue bypasses that problem by only requesting the necessary kwh data.