### PR TITLE
Include baseload as % of annual usage

### DIFF
--- a/app/services/baseload/baseload_calculation_service.rb
+++ b/app/services/baseload/baseload_calculation_service.rb
@@ -47,14 +47,17 @@ module Baseload
     # average baseload for this school over the last year
     #
     # The usage returns include kwh, co2 emissions and £ costs.
+    # The percent value is % of total annual usage
     #
     # @return [CombinedUsageMetric] the calculated usage
-    def annual_baseload_usage
-      CombinedUsageMetric.new(
+    def annual_baseload_usage(include_percentage: false)
+      metric = CombinedUsageMetric.new(
         kwh: average_baseload_last_year_kwh,
         £: average_baseload_last_year_£,
         co2: average_baseload_last_year_co2
       )
+      metric.percent = baseload_percent_annual_consumption if include_percentage
+      metric
     end
 
     private
@@ -70,6 +73,10 @@ module Baseload
     def average_baseload_last_year_co2
       kwh = average_baseload_last_year_kwh
       kwh * co2_per_kwh
+    end
+
+    def baseload_percent_annual_consumption
+      @baseload_percent_annual_consumption ||= baseload_analysis.baseload_percent_annual_consumption(@asof_date)
     end
 
     def meter_collection

--- a/spec/app/services/baseload/baseload_calculation_service_spec.rb
+++ b/spec/app/services/baseload/baseload_calculation_service_spec.rb
@@ -33,6 +33,14 @@ describe Baseload::BaseloadCalculationService, type: :service do
       expect(usage.kwh).to round_to_two_digits(213001.8)
       expect(usage.co2).to round_to_two_digits(40321.91)
       expect(usage.£).to round_to_two_digits(31818.29)
+      expect(usage.percent).to be_nil
+    end
+    it 'includes percentage if needed' do
+      usage = service.annual_baseload_usage(include_percentage: true)
+      expect(usage.kwh).to round_to_two_digits(213001.8)
+      expect(usage.co2).to round_to_two_digits(40321.91)
+      expect(usage.£).to round_to_two_digits(31818.29)
+      expect(usage.percent).to round_to_two_digits(0.47)
     end
   end
 end


### PR DESCRIPTION
Optionally include baseload as a % of annual usage in the baseload calculation service.