### PR TITLE
Allow benchmark charts to work with single fuel types

### DIFF
--- a/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
@@ -104,7 +104,9 @@ class ChartManager
       yaxis_units:      :£
     },
     benchmark_electric_only_one_year_kwh: {
-      inherits_from:    :benchmark_electric_only_£,
+      inherits_from:    :benchmark,
+      meter_definition: :allelectricity,
+      restrict_y1_axis: nil,
       timescale:        :year,
       yaxis_units:      :kwh
     },
@@ -115,7 +117,9 @@ class ChartManager
       yaxis_units:      :£
     },
     benchmark_gas_only_one_year_kwh: {
-      inherits_from:    :benchmark_gas_only_£,
+      inherits_from:    :benchmark,
+      meter_definition: :allheat,
+      restrict_y1_axis: nil,
       timescale:        :year,
       yaxis_units:      :kwh
     },

--- a/lib/dashboard/charting_and_reports/charts/series_data_manager.rb
+++ b/lib/dashboard/charting_and_reports/charts/series_data_manager.rb
@@ -847,6 +847,15 @@ module Series
     SOLARPV_I18N_KEY          = 'solar_pv' # think unused?
 
     def series_names
+      #If the chart config specifies a specific meter then we should only
+      #add series for that fuel type. Otherwise assume all fuel types are
+      #required.
+      #
+      #This was added to allow the benchmarking charts to work with specific
+      #fuel types
+      return [GAS] if @chart_config[:meter_definition] == :allheat
+      return [ELECTRICITY] if @chart_config[:meter_definition] == :allelectricity
+      return [STORAGEHEATERS] if @chart_config[:meter_definition] == :storage_heater_meter
       aggregate_meters.keys
     end
 


### PR DESCRIPTION
There's an issue with the `benchmark_*` charts at the moment which is triggered when schools have limited data for specific fuel types.

For example, if a school has one years of gas data, but only 6 months of electricity, then the `benchmark_*` charts won't run as the charts include all fuel types by default (`meter_definition: :all`).

However the problem still exists if you change the the meter definition, e.g. to `meter_definition: :allheat`. In this case I would expect that the chart would use only the aggregated gas data.

Debugging shows that a `series_breakdown: :fuel` causes the `MultipleFuels` model to add series for both gas and electricity data (and storage heaters if available). This causes the problem as there may not be enough electricity data to properly generate the chart.

Setting `series_breakdown: nil` avoids the error, but this then stops the benchmarks being injected into the chart. This is because `AggregatorBenchmark` looks for the named fuel type series ('gas', 'electricity') to determine whether to inject the benchmarks.

This PR provides a small update to `MultipleFuels`. It will now check the `meter_definition` config and return just a single fuel type if that has been configured. Otherwise the behaviour falls back to existing behaviour.

This allows the creation of a single fuel type benchmark chart without requiring a `filter`, e.g:

```
    benchmark_gas_only_one_year_kwh: {
      inherits_from:    :benchmark,
      meter_definition: :allheat,
      restrict_y1_axis: nil,
      timescale:        :year,
      yaxis_units:      :kwh
    }
```

As a side effect this fixes up the existing pupil dashboard charts for schools that have limited data for one fuel type. Currently these charts, e.g. (`pupil_dashboard_gas_benchmark`) are failing to run and then not showing to users because of this bug. Regenerating the school with this PR makes an additional benchmark chart available.





