### PR TITLE
Add missing benchmark co2 values

### DIFF
--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -496,7 +496,6 @@ class AlertAnalysisBase < ContentBase
     asof_date = [asof_date, alert.aggregate_meter.amr_data.end_date].min
 
     alert.analyse(asof_date)
-
     alert
   end
 

--- a/lib/dashboard/alerts/electricity/alert_electricity_annual_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/alert_electricity_annual_versus_benchmark.rb
@@ -271,6 +271,8 @@ class AlertElectricityAnnualVersusBenchmark < AlertElectricityOnlyBase
     @one_year_benchmark_by_pupil_kwh            = BenchmarkMetrics.benchmark_annual_electricity_usage_kwh(school_type, pup)
     @one_year_benchmark_by_pupil_£current       = @one_year_benchmark_by_pupil_kwh * @current_rate_£_per_kwh
     @one_year_benchmark_by_pupil_£              = @one_year_benchmark_by_pupil_kwh * @historic_rate_£_per_kwh
+    @one_year_benchmark_by_pupil_co2 = @one_year_benchmark_by_pupil_kwh * blended_co2_per_kwh
+
     @one_year_saving_versus_benchmark_kwh       = @last_year_kwh - @one_year_benchmark_by_pupil_kwh
     @one_year_saving_versus_benchmark_£         = @one_year_saving_versus_benchmark_kwh * @historic_rate_£_per_kwh
     @one_year_saving_versus_benchmark_£current  = @one_year_saving_versus_benchmark_kwh * @current_rate_£_per_kwh
@@ -278,10 +280,12 @@ class AlertElectricityAnnualVersusBenchmark < AlertElectricityOnlyBase
     @one_year_saving_versus_benchmark_kwh       = @one_year_saving_versus_benchmark_kwh.magnitude
     @one_year_saving_versus_benchmark_£         = @one_year_saving_versus_benchmark_£.magnitude
     @one_year_saving_versus_benchmark_£current  = @one_year_saving_versus_benchmark_£current.magnitude
+    @one_year_saving_versus_benchmark_co2 = @one_year_saving_versus_benchmark_kwh  * blended_co2_per_kwh
 
     @one_year_exemplar_by_pupil_kwh             = BenchmarkMetrics.exemplar_annual_electricity_usage_kwh(school_type, pup)
     @one_year_exemplar_by_pupil_£               = @one_year_exemplar_by_pupil_kwh * @historic_rate_£_per_kwh
     @one_year_exemplar_by_pupil_£current        = @one_year_exemplar_by_pupil_kwh * @current_rate_£_per_kwh
+    @one_year_exemplar_by_pupil_co2 = @one_year_exemplar_by_pupil_kwh * blended_co2_per_kwh
 
     @one_year_saving_versus_exemplar_kwh      = @last_year_kwh - @one_year_exemplar_by_pupil_kwh
     @one_year_saving_versus_exemplar_£        = @one_year_saving_versus_exemplar_kwh * @historic_rate_£_per_kwh
@@ -342,30 +346,35 @@ class AlertElectricityAnnualVersusBenchmark < AlertElectricityOnlyBase
       school: {
         kwh:      @last_year_kwh,
         £:        @last_year_£,
-        £current: @last_year_£current
+        £current: @last_year_£current,
+        co2:      @last_year_co2
       },
       benchmark: {
         kwh:      @one_year_benchmark_by_pupil_kwh,
         £:        @one_year_benchmark_by_pupil_£,
         £current: @one_year_benchmark_by_pupil_£current,
+        co2:      @one_year_benchmark_by_pupil_co2,
 
         saving: {
           kwh:       @one_year_saving_versus_benchmark_kwh,
           £:         @one_year_saving_versus_benchmark_£,
           £current:  @one_year_saving_versus_benchmark_£current,
-          percent:   @percent_difference_from_average_per_pupil
+          percent:   @percent_difference_from_average_per_pupil,
+          co2:       @one_year_saving_versus_benchmark_co2
         }
       },
       exemplar: {
         kwh:      @one_year_exemplar_by_pupil_kwh,
         £:        @one_year_exemplar_by_pupil_£,
         £current: @one_year_exemplar_by_pupil_£current,
+        co2:      @one_year_exemplar_by_pupil_co2,
 
         saving: {
           kwh:       @one_year_saving_versus_exemplar_kwh,
           £:         @one_year_saving_versus_exemplar_£,
           £current:  @one_year_saving_versus_exemplar_£current,
-          percent:   @percent_difference_from_exemplar_per_pupil
+          percent:   @percent_difference_from_exemplar_per_pupil,
+          co2:       @one_year_saving_versus_exemplar_co2
         }
       }
     }

--- a/lib/dashboard/alerts/gas/alert_gas_annual_versus_benchmark.rb
+++ b/lib/dashboard/alerts/gas/alert_gas_annual_versus_benchmark.rb
@@ -352,15 +352,18 @@ class AlertGasAnnualVersusBenchmark < AlertGasModelBase
     # benchmark £ using same tariff as school not benchmark tariff
     @one_year_benchmark_floor_area_£        = @one_year_benchmark_floor_area_kwh * @historic_rate_£_per_kwh
     @one_year_benchmark_floor_area_£current = @one_year_benchmark_floor_area_kwh * @current_rate_£_per_kwh
+    @one_year_benchmark_floor_area_co2 = gas_co2(@one_year_benchmark_floor_area_kwh)
 
     @one_year_saving_versus_benchmark_kwh       = @last_year_kwh      - @one_year_benchmark_floor_area_kwh
     @one_year_saving_versus_benchmark_£         = @last_year_£        - @one_year_benchmark_floor_area_£
     @one_year_saving_versus_benchmark_£current  = @last_year_£current - @one_year_benchmark_floor_area_£current
+    @one_year_savings_versus_benchmark_co2 = @last_year_co2 - @one_year_benchmark_floor_area_co2
 
     @one_year_exemplar_floor_area_kwh       = BenchmarkMetrics::EXEMPLAR_GAS_USAGE_PER_M2 * fa / @degree_day_adjustment
     @one_year_exemplar_floor_area_£         = @one_year_exemplar_floor_area_kwh * @historic_rate_£_per_kwh
     @one_year_exemplar_floor_area_£current  = @one_year_exemplar_floor_area_kwh * @current_rate_£_per_kwh
     @one_year_exemplar_floor_area_co2   = gas_co2(@one_year_exemplar_floor_area_kwh)
+
 
     @one_year_saving_versus_exemplar_kwh      = @last_year_kwh      - @one_year_exemplar_floor_area_kwh
     @one_year_saving_versus_exemplar_£        = @last_year_£        - @one_year_exemplar_floor_area_£
@@ -423,30 +426,35 @@ class AlertGasAnnualVersusBenchmark < AlertGasModelBase
       school: {
         kwh:      @last_year_kwh,
         £:        @last_year_£,
-        £current: @last_year_£current
+        £current: @last_year_£current,
+        co2:      @last_year_co2
       },
       benchmark: {
         kwh:      @one_year_benchmark_floor_area_kwh,
         £:        @one_year_benchmark_floor_area_£,
         £current: @one_year_benchmark_floor_area_£current,
+        co2:      @one_year_benchmark_floor_area_co2,
 
         saving: {
           kwh:       @one_year_saving_versus_benchmark_kwh,
           £:         @one_year_saving_versus_benchmark_£,
           £current:  @one_year_saving_versus_benchmark_£current,
-          percent:   @percent_difference_from_average_per_floor_area
+          percent:   @percent_difference_from_average_per_floor_area,
+          co2:       @one_year_savings_versus_benchmark_co2
         }
       },
       exemplar: {
         kwh:      @one_year_exemplar_floor_area_kwh,
         £:        @one_year_exemplar_floor_area_£,
         £current: @one_year_exemplar_floor_area_£current,
+        co2:      @one_year_exemplar_floor_area_co2,
 
         saving: {
           kwh:       @one_year_saving_versus_exemplar_kwh,
           £:         @one_year_saving_versus_exemplar_£,
           £current:  @one_year_saving_versus_exemplar_£current,
-          percent:   @percent_difference_from_exemplar_per_floor_area
+          percent:   @percent_difference_from_exemplar_per_floor_area,
+          co2:       @one_year_saving_versus_exemplar_co2
         }
       }
     }

--- a/lib/dashboard/charting_and_reports/charts/aggregator_benchmarks.rb
+++ b/lib/dashboard/charting_and_reports/charts/aggregator_benchmarks.rb
@@ -58,7 +58,7 @@ class AggregatorBenchmarks < AggregatorBase
     @alerts[fuel_type] ||= AlertAnalysisBase.benchmark_alert(@school, fuel_type, asof_date)
     @alerts[fuel_type].benchmark_chart_data[benchmark_type][datatype]
   end
-end 
+end
 
 =begin
     if benchmark_required?('electricity')
@@ -91,7 +91,7 @@ end
     @current_year_floor_area = school.floor_area(most_recent_start_date, most_recent_end_date)
     @current_year_number_of_pupils = school.number_of_pupils(most_recent_start_date, most_recent_end_date)
 
-    
+
     # scale_school_data if chart_config.scale_y_axis?
 
   def scale_benchmarks_deprecated(benchmark_usage_kwh, fuel_type)

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -8,7 +8,7 @@ module Logging
 end
 
 
-schools = ['a*'] # ['king-j*', 'combe-d*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
+schools = ['r*'] # ['king-j*', 'combe-d*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
 
 overrides = {
   schools: schools,
@@ -16,7 +16,7 @@ overrides = {
   no_adult_dashboard: { control: { user: { user_role: :analytics, staff_role: nil } } },
   adult_dashboard: {
     control: {
-      pages: %i[boiler_control_seasonal],
+      pages: %i[benchmark],
       no_pages: %i[hotwater], # storage_heater
       compare_results: [ :summary, :report_differences],
       user: { user_role: :analytics, staff_role: nil }

--- a/script/standard/test_charts.rb
+++ b/script/standard/test_charts.rb
@@ -8,6 +8,7 @@ module Logging
 end
 
 charts = {
+  adhoc: %i[ benchmark_co2 ]
   # bm:   %i[community_use_test_electricity management_dashboard_group_by_week_electricity]
   # eco: %i[test_economic_costs_gas_by_week_unlimited_£ test_economic_costs_electric_by_week_unlimited_£ ],
   # solar: %i[solar_pv_group_by_month solar_pv_last_7_days_by_submeter]
@@ -15,10 +16,10 @@ charts = {
   #     test_current_economic_costs_electric_by_week_unlimited_kwh_meter_breakdown
   #     test_economic_costs_electric_by_week_unlimited_£
   #     test_economic_costs_electric_by_week_unlimited_kwh_meter_breakdown
-  economictariffs: %i[
-
-    targeting_and_tracking_weekly_electricity_to_date_line
-  ]
+  #economictariffs: %i[
+  #
+  #  targeting_and_tracking_weekly_electricity_to_date_line
+  #]
 }
 
 no_charts = { adhoc: %i[group_by_week_gas_versus_benchmark intraday_line_school_days_gas_reduced_data_versus_benchmarks] }
@@ -36,7 +37,7 @@ control = {
 }
 
 overrides = {
-  schools:  ['caer*'], # ['hugh*', 'herst*'], # ['tow*', 'st-julian-s-h*'], # ['chase-lane-target*'], # ['king-ja*', 'marksb*', 'long*'],
+  schools:  ['r*'], # ['hugh*', 'herst*'], # ['tow*', 'st-julian-s-h*'], # ['chase-lane-target*'], # ['king-ja*', 'marksb*', 'long*'],
   cache_school: false,
   charts:   { charts: charts, control: control }
 }


### PR DESCRIPTION
The benchmark and exemplar values for the benchmarking charts (e.g. `:benchmark`) have recently been changed to extract values from relevant alerts.

However the alerts were not producing the necessary values for co2, which meant that the charts were not showing the expected comparisons.

This PR updates the alerts to add in the missing values. I've confirmed that the charts now work correctly.

A couple of co2 values were being calculated & these changes use the same method, so hopefully consistent.

@PhilipTB I'd appreciate it if you could take a look.