### PR TITLE
Update and extract text for chart table grouping

### DIFF
--- a/config/locales/benchmarking/content_base.yml
+++ b/config/locales/benchmarking/content_base.yml
@@ -2,6 +2,12 @@
 en:
   analytics:
     benchmarking:
+      chart_table_grouping:
+        total_energy_use_benchmarks: Total Energy Use Benchmarks
+        electricity_benchmarks: Electricity Benchmarks
+        gas_and_storage_heater_benchmarks: Gas and Storage Heater Benchmarks
+        solar_benchmarks: Solar Benchmarks
+        date_limited_comparisons: Date limited comparisons
       caveat_text:
         es_data_not_in_sync_html: |-
           <p>

--- a/config/locales/benchmarking/content_base.yml
+++ b/config/locales/benchmarking/content_base.yml
@@ -2,12 +2,6 @@
 en:
   analytics:
     benchmarking:
-      chart_table_grouping:
-        total_energy_use_benchmarks: Total Energy Use Benchmarks
-        electricity_benchmarks: Electricity Benchmarks
-        gas_and_storage_heater_benchmarks: Gas and Storage Heater Benchmarks
-        solar_benchmarks: Solar Benchmarks
-        date_limited_comparisons: Date limited comparisons
       caveat_text:
         es_data_not_in_sync_html: |-
           <p>
@@ -77,6 +71,12 @@ en:
         thermostat_sensitivity: Annual saving through 1C reduction in thermostat temperature
         thermostatic_control: Quality of thermostatic control
         weekday_baseload_variation: Weekday baseload variation
+      chart_table_grouping:
+        date_limited_comparisons: Date limited comparisons
+        electricity_benchmarks: Electricity Benchmarks
+        gas_and_storage_heater_benchmarks: Gas and Storage Heater Benchmarks
+        solar_benchmarks: Solar Benchmarks
+        total_energy_use_benchmarks: Total Energy Use Benchmarks
       content:
         annual_energy_costs:
           introduction_text_html: |-

--- a/lib/dashboard/benchmarking/benchmark_configuration.rb
+++ b/lib/dashboard/benchmarking/benchmark_configuration.rb
@@ -226,13 +226,13 @@ module Benchmarking
       column_definition.key?(key) && column_definition[key]
     end
 
-    def self.structured_pages(user_type_hash, filter_out = nil)
-        # TODO filter by user_type_hash 
+    def self.structured_pages(user_type_hash, _filter_out = nil)
+      # TODO: filter by user_type_hash
       CHART_TABLE_GROUPING.each_with_object([]) do |(group_key, benchmark_keys), structured_pages|
         structured_pages << {
           name: I18n.t("analytics.benchmarking.chart_table_grouping.#{group_key}"),
-          benchmarks: benchmark_keys.map do |benchmark_key| 
-            [ benchmark_key, I18n.t("analytics.benchmarking.chart_table_config.#{benchmark_key}")]
+          benchmarks: benchmark_keys .map do |benchmark_key|
+            [benchmark_key, I18n.t("analytics.benchmarking.chart_table_config.#{benchmark_key}")]
           end.to_h
         }
       end

--- a/lib/dashboard/benchmarking/benchmark_configuration.rb
+++ b/lib/dashboard/benchmarking/benchmark_configuration.rb
@@ -227,15 +227,13 @@ module Benchmarking
     end
 
     def self.structured_pages(user_type_hash, filter_out = nil)
-      CHART_TABLE_GROUPING.map do |group|
-        visible_benchmarks = if ContentBase.analytics_user?(user_type_hash)
-          group[:benchmarks]
-        else
-          group[:benchmarks].select { |key| !CHART_TABLE_CONFIG[key].fetch(:analytics_user_type, false) }
-        end
-        {
-          name:  group[:name],
-          benchmarks: visible_benchmarks.map{ |key| [key, CHART_TABLE_CONFIG[key][:name]] }.to_h
+        # TODO filter by user_type_hash 
+      CHART_TABLE_GROUPING.each_with_object([]) do |(group_key, benchmark_keys), structured_pages|
+        structured_pages << {
+          name: I18n.t("analytics.benchmarking.chart_table_grouping.#{group_key}"),
+          benchmarks: benchmark_keys.map do |benchmark_key| 
+            [ benchmark_key, I18n.t("analytics.benchmarking.chart_table_config.#{benchmark_key}")]
+          end.to_h
         }
       end
     end
@@ -280,75 +278,58 @@ module Benchmarking
       val.nil? ? Float::INFINITY : val
     end
 
-    CHART_TABLE_GROUPING = [
-      {
-        name:       'Energy Cost Benchmarks',
-        benchmarks: %i[
-          annual_energy_costs_per_pupil
-          annual_energy_costs
-          annual_energy_costs_per_floor_area
-        ]
-      },
-      {
-        name:       'Change in Energy Use',
-        benchmarks: %i[
-          change_in_energy_since_last_year
-          change_in_electricity_since_last_year
-          change_in_gas_since_last_year
-          change_in_storage_heaters_since_last_year
-          change_in_solar_pv_since_last_year
-          holiday_usage_last_year
-        ]
-      },
-      {
-        name:       'Electricity Benchmarks',
-        benchmarks: %i[
-          annual_electricity_costs_per_pupil
-          annual_electricity_out_of_hours_use
-          recent_change_in_baseload
-          baseload_per_pupil
-          seasonal_baseload_variation
-          weekday_baseload_variation
-          summer_holiday_electricity_analysis
-          electricity_peak_kw_per_pupil
-          solar_pv_benefit_estimate
-          refrigeration
-          electricity_targets
-          change_in_electricity_consumption_recent_school_weeks
-          change_in_electricity_holiday_consumption_previous_holiday
-          change_in_electricity_holiday_consumption_previous_years_holiday
-          electricity_consumption_during_holiday
-        ]
-      },
-      {
-        name:       'Gas and Storage Heater Benchmarks',
-        benchmarks: %i[
-          annual_heating_costs_per_floor_area
-          annual_gas_out_of_hours_use
-          annual_storage_heater_out_of_hours_use
-          heating_coming_on_too_early
-          thermostat_sensitivity
-          heating_in_warm_weather
-          thermostatic_control
-          hot_water_efficiency
-          gas_targets
-          change_in_gas_consumption_recent_school_weeks
-          change_in_gas_holiday_consumption_previous_holiday
-          change_in_gas_holiday_consumption_previous_years_holiday
-          gas_consumption_during_holiday
-          storage_heater_consumption_during_holiday
-        ]
-      },
-      {
-        name:       'Event Specific Comparisons',
-        benchmarks: %i[
-          layer_up_powerdown_day_november_2022
-          change_in_energy_use_since_joined_energy_sparks
-          autumn_term_2021_2022_energy_comparison
-          sept_nov_2021_2022_energy_comparison
-        ]
-      }
-    ]
+    CHART_TABLE_GROUPING = {
+      total_energy_use_benchmarks: [
+        :annual_energy_costs_per_pupil,
+        :annual_energy_costs,
+        :annual_energy_costs_per_floor_area,
+        :change_in_energy_since_last_year,
+        :holiday_usage_last_year
+      ],
+      electricity_benchmarks: [
+        :change_in_electricity_since_last_year,
+        :annual_electricity_costs_per_pupil,
+        :annual_electricity_out_of_hours_use,
+        :recent_change_in_baseload,
+        :baseload_per_pupil,
+        :seasonal_baseload_variation,
+        :weekday_baseload_variation,
+        :electricity_peak_kw_per_pupil,
+        :electricity_targets,
+        :change_in_electricity_consumption_recent_school_weeks,
+        :change_in_electricity_holiday_consumption_previous_holiday,
+        :change_in_electricity_holiday_consumption_previous_years_holiday,
+        :electricity_consumption_during_holiday
+      ],
+      gas_and_storage_heater_benchmarks: [
+        :change_in_gas_since_last_year,
+        :change_in_storage_heaters_since_last_year,
+        :annual_heating_costs_per_floor_area,
+        :annual_gas_out_of_hours_use,
+        :annual_storage_heater_out_of_hours_use,
+        :heating_coming_on_too_early,
+        :thermostat_sensitivity,
+        :heating_in_warm_weather,
+        :thermostatic_control,
+        :hot_water_efficiency,
+        :gas_targets,
+        :change_in_gas_consumption_recent_school_weeks,
+        :change_in_gas_holiday_consumption_previous_holiday,
+        :change_in_gas_holiday_consumption_previous_years_holiday,
+        :gas_consumption_during_holiday,
+        :storage_heater_consumption_during_holiday
+      ],
+      solar_benchmarks: [
+        :change_in_solar_pv_since_last_year,
+        :solar_pv_benefit_estimate
+      ],
+      date_limited_comparisons: [
+        :layer_up_powerdown_day_november_2022,
+        :change_in_energy_use_since_joined_energy_sparks,
+        :autumn_term_2021_2022_energy_comparison,
+        :sept_nov_2021_2022_energy_comparison
+      ]
+    }
 
     def self.tariff_changed_school_name(content_class = nil)
       if content_class.nil?

--- a/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
+++ b/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'active_support/core_ext'
+
+describe Benchmarking::BenchmarkManager, type: :service do
+  describe '#structured_pages' do
+    it 'returns benchmarks by group' do
+      expect(Benchmarking::BenchmarkManager.structured_pages({})).to eq(
+        [
+          {
+            name: 'Total Energy Use Benchmarks',
+            benchmarks: {
+              annual_energy_costs: 'Annual cost of electricity, gas, storage heaters and combined energy',
+              annual_energy_costs_per_floor_area: 'Annual energy cost per floor area',
+              annual_energy_costs_per_pupil: 'Annual energy use per pupil',
+              change_in_energy_since_last_year: 'Annual change in total energy use',
+              holiday_usage_last_year: 'Cost of energy used in upcoming holiday last year'
+            }
+          },
+          {
+            name: 'Electricity Benchmarks',
+            benchmarks: {
+              annual_electricity_costs_per_pupil: 'Annual electricity use per pupil with savings potential',
+              annual_electricity_out_of_hours_use: 'Electricity used out of school hours',
+              baseload_per_pupil: 'Baseload per pupil',
+              change_in_electricity_consumption_recent_school_weeks: 'Recent change in electricity use',
+              change_in_electricity_holiday_consumption_previous_holiday: 'Change in electricity use between the last 2 holidays',
+              change_in_electricity_holiday_consumption_previous_years_holiday: 'Change in electricity use between this holiday and the same holiday last year',
+              change_in_electricity_since_last_year: 'Annual change in electricity use',
+              electricity_consumption_during_holiday: 'Electricity use during current holiday',
+              electricity_peak_kw_per_pupil: 'Peak school day electricity use',
+              electricity_targets: 'Progress against electricity target',
+              recent_change_in_baseload: 'Recent change in baseload',
+              seasonal_baseload_variation: 'Seasonal baseload variation',
+              weekday_baseload_variation: 'Weekday baseload variation'
+            }
+          },
+          {
+            name: 'Gas and Storage Heater Benchmarks',
+            benchmarks: {
+              annual_gas_out_of_hours_use: 'Gas used out of school hours',
+              annual_heating_costs_per_floor_area: 'Annual heating cost per floor area with savings potential',
+              annual_storage_heater_out_of_hours_use: 'Storage heaters used out of school hours',
+              change_in_gas_consumption_recent_school_weeks: 'Recent change in gas use',
+              change_in_gas_holiday_consumption_previous_holiday: 'Change in gas use between the last 2 holidays',
+              change_in_gas_holiday_consumption_previous_years_holiday: 'Change in gas use between this holiday and the same holiday last year',
+              change_in_gas_since_last_year: 'Annual change in gas use',
+              change_in_storage_heaters_since_last_year: 'Annual change in storage heater',
+              gas_consumption_during_holiday: 'Gas use during current holiday',
+              gas_targets: 'Progress against gas target',
+              heating_coming_on_too_early: 'Heating start time',
+              heating_in_warm_weather: 'Heating used in warm weather',
+              hot_water_efficiency: 'Hot Water Efficiency',
+              storage_heater_consumption_during_holiday: 'Storage heater use during current holiday',
+              thermostat_sensitivity: 'Annual saving through 1C reduction in thermostat temperature',
+              thermostatic_control: 'Quality of thermostatic control'
+            }
+          },
+          {
+            name: 'Solar Benchmarks',
+            benchmarks: {
+              change_in_solar_pv_since_last_year: 'Annual change in solar PV production and resulting CO2 savings',
+              solar_pv_benefit_estimate: 'Benefit of solar PV installation'
+            }
+          },
+          {
+            name: 'Date limited comparisons',
+            benchmarks: {
+              autumn_term_2021_2022_energy_comparison: 'Autumn Term 2021 versus 2022 energy use',
+              change_in_energy_use_since_joined_energy_sparks: 'Change in energy use since the school joined Energy Sparks',
+              layer_up_powerdown_day_november_2022: 'Change in energy for layer up power down day 11 November 2022 (compared with 12 Nov 2021)',
+              sept_nov_2021_2022_energy_comparison: 'September to November 2021 versus 2022 energy use'
+            }
+          }
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
This pr
- [x] creates new benchmark grouping structure 
- [x] adds new group titles
~- [ ] revises group filtering by user type~ <- will be addressed in a follow up pr

`structured_pages` method returns an array of hashes in the same structure as before e.g.
```
[{:name=>"Energy Cost Benchmarks",
  :benchmarks=>
   {:annual_energy_costs_per_pupil=>"Annual energy use per pupil",
    :annual_energy_costs=>"Annual energy costs",
    :annual_energy_costs_per_floor_area=>"Annual energy use per floor area"}},
 {:name=>"Change in Energy Use",
  :benchmarks=>
   {:change_in_energy_since_last_year=>"Change in energy use since last year",
    :change_in_electricity_since_last_year=>
     "Change in electricity consumption since last year",
    :change_in_gas_since_last_year=>
     "Change in gas consumption since last year",
    :change_in_storage_heaters_since_last_year=>
     "Change in storage heater consumption since last year",
    :change_in_solar_pv_since_last_year=>
     "Change in solar PV production since last year",
    :holiday_usage_last_year=>
     "Energy Consumption in upcoming holiday last year"}},
 {:name=>"Electricity Benchmarks",
  :benchmarks=>
   {:annual_electricity_costs_per_pupil=>"Annual electricity use per pupil",
    :annual_electricity_out_of_hours_use=>"Electricity out of hours use",
    :recent_change_in_baseload=>
     "Last week's baseload versus average of last year (% difference)",
    :baseload_per_pupil=>"Baseload per pupil",
    :seasonal_baseload_variation=>"Seasonal baseload variation",
    :weekday_baseload_variation=>"Weekday baseload variation",
    :electricity_peak_kw_per_pupil=>
     "Peak school day electricity comparison kW/floor area",
    :solar_pv_benefit_estimate=>
     "Benefit of estimated optimum size solar PV installation",
    :electricity_targets=>"Progress versus electricity target",
    :change_in_electricity_consumption_recent_school_weeks=>
     "Change in electricity consumption since last school week",
    :change_in_electricity_holiday_consumption_previous_holiday=>
     "Change in electricity consumption between the 2 most recent holidays",
    :change_in_electricity_holiday_consumption_previous_years_holiday=>
     "Change in electricity consumption between this holiday and the same holiday the previous year",
    :electricity_consumption_during_holiday=>
     "Electricity consumption during current holiday"}},
 {:name=>"Gas and Storage Heater Benchmarks",
  :benchmarks=>
   {:annual_heating_costs_per_floor_area=>"Annual heating cost per floor area",
    :annual_gas_out_of_hours_use=>"Gas: out of hours use",
    :annual_storage_heater_out_of_hours_use=>"Storage heater out of hours use",
    :heating_coming_on_too_early=>
     "Heating start time (potentially coming on too early in morning)",
    :thermostat_sensitivity=>
     "Annual saving through 1C reduction in thermostat temperature",
    :heating_in_warm_weather=>
     "Gas or storage heater consumption for heating in warm weather",
    :thermostatic_control=>"Quality of thermostatic control",
    :hot_water_efficiency=>"Hot Water Efficiency",
    :gas_targets=>"Progress versus gas target",
    :change_in_gas_consumption_recent_school_weeks=>
     "Change in gas consumption since last school week",
    :change_in_gas_holiday_consumption_previous_holiday=>
     "Change in gas consumption between the 2 most recent holidays",
    :change_in_gas_holiday_consumption_previous_years_holiday=>
     "Change in gas consumption between this holiday and the same the previous year",
    :gas_consumption_during_holiday=>"Gas consumption during current holiday",
    :storage_heater_consumption_during_holiday=>
     "Storage heater consumption during current holiday"}},
 {:name=>"Event Specific Comparisons",
  :benchmarks=>
   {:layer_up_powerdown_day_november_2022=>
     "Change in energy for layer up power down day 11 November 2022 (compared with 12 Nov 2021)",
    :change_in_energy_use_since_joined_energy_sparks=>
     "Change in energy use since the school joined Energy Sparks",
    :autumn_term_2021_2022_energy_comparison=>
     "Autumn Term 2021 versus 2022 energy use comparison",
    :sept_nov_2021_2022_energy_comparison=>
     "September to November 2021 versus 2022 energy use comparison"}}]
```
