### PR TITLE
Fix for community use issue

### DIFF
--- a/lib/dashboard/aggregation/amr_data_community_open_close_breakdown.rb
+++ b/lib/dashboard/aggregation/amr_data_community_open_close_breakdown.rb
@@ -204,6 +204,9 @@ class AMRDataCommunityOpenCloseBreakdown
     open_kwh                = kwh * open_t
     community_kwh           = [(kwh - baseload_kwh) * community_t, 0.0].max
     community_baseload_kwh  = [baseload_kwh * community_t, kwh].min
+    #LD 2023-3-21 dont allocate community baseload if community use has been clipped to zero
+    community_baseload_kwh  = 0.0 if community_kwh == 0.0
+
     closed_kwh              = kwh - open_kwh - community_kwh - community_baseload_kwh
     closed_kwh              = 0.0 if closed_kwh.magnitude < 0.00000001 # remove floating point noise
 

--- a/script/standard/test_adult_dashboard.rb
+++ b/script/standard/test_adult_dashboard.rb
@@ -8,7 +8,7 @@ module Logging
 end
 
 
-schools = ['r*'] # ['king-j*', 'combe-d*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
+schools = ['balf*'] # ['king-j*', 'combe-d*'] # ['ullapool-pv-storage_heaters_not_relevant*'] + SchoolFactory.storage_heater_schools
 
 overrides = {
   schools: schools,
@@ -16,7 +16,7 @@ overrides = {
   no_adult_dashboard: { control: { user: { user_role: :analytics, staff_role: nil } } },
   adult_dashboard: {
     control: {
-      pages: %i[electricity_profit_loss],
+      pages: %i[electric_out_of_hours],
       no_pages: %i[hotwater], # storage_heater
       compare_results: [ :summary, :report_differences],
       user: { user_role: :analytics, staff_role: nil }

--- a/script/standard/test_charts.rb
+++ b/script/standard/test_charts.rb
@@ -8,7 +8,7 @@ module Logging
 end
 
 charts = {
-  adhoc: %i[ benchmark_co2 ]
+  adhoc: %i[ management_dashboard_group_by_week_electricity ]
   # bm:   %i[community_use_test_electricity management_dashboard_group_by_week_electricity]
   # eco: %i[test_economic_costs_gas_by_week_unlimited_£ test_economic_costs_electric_by_week_unlimited_£ ],
   # solar: %i[solar_pv_group_by_month solar_pv_last_7_days_by_submeter]
@@ -37,7 +37,7 @@ control = {
 }
 
 overrides = {
-  schools:  ['r*'], # ['hugh*', 'herst*'], # ['tow*', 'st-julian-s-h*'], # ['chase-lane-target*'], # ['king-ja*', 'marksb*', 'long*'],
+  schools:  ['balf*'], # ['hugh*', 'herst*'], # ['tow*', 'st-julian-s-h*'], # ['chase-lane-target*'], # ['king-ja*', 'marksb*', 'long*'],
   cache_school: false,
   charts:   { charts: charts, control: control }
 }


### PR DESCRIPTION
This PR has a proposed fix for an issue calculating community usage for schools.

A school on EnergySparks has community use period in the morning, but for at least one day the calculation that assigns usage and baseload to community use was producing negative figures.

This is because while the community use in kwh may be set to a minimum of zero, the community baseload usage is still calculated as a portion of the actual baseload.

If the community and community baseload are both set to zero when there is minimal community use the calculations work.

