### PR TITLE
Revise rating logic for AlertPeriodComparisonBase

### DIFF
--- a/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
@@ -174,7 +174,7 @@ class AlertPeriodComparisonBase < AlertAnalysisBase
 
     current_period_data             = meter_values_period(current_period)
     previous_period_data            = normalised_period_data(current_period, previous_period)
-    previous_period_data_unadjusted = meter_values_period(current_period) 
+    previous_period_data_unadjusted = meter_values_period(current_period)
 
     @difference_kwh       = current_period_data[:kwh]       - previous_period_data[:kwh]
     @difference_£         = current_period_data[:£]         - previous_period_data[:£]
@@ -317,9 +317,11 @@ class AlertPeriodComparisonBase < AlertAnalysisBase
   end
 
   def calculate_rating(percentage_difference, financial_difference_£, fuel_type)
-    # PH removed £10 limit 20Nov2019 at CT request
-    # PH reinstated after CT request 21Dec2020
-    return 10.0 if financial_difference_£.between?(-MINIMUM_DIFFERENCE_FOR_NON_10_RATING_£, MINIMUM_DIFFERENCE_FOR_NON_10_RATING_£)
+    # The goal is to not show alerts when the cost saving is negligible.
+    # Defined here as +/- £10. To do that we need to set the rating to nil (rather than 10)
+    # as this will cause the application to ignore the results. A rating of 10 would
+    # mean the application always aims to display the alert results.
+    return nil if financial_difference_£.between?(-MINIMUM_DIFFERENCE_FOR_NON_10_RATING_£, MINIMUM_DIFFERENCE_FOR_NON_10_RATING_£)
     ten_rating_range_percent = fuel_type == :electricity ? 0.10 : 0.15 # more latitude for gas
     calculate_rating_from_range(-ten_rating_range_percent, ten_rating_range_percent, percentage_difference)
   end
@@ -436,7 +438,7 @@ class AlertPeriodComparisonBase < AlertAnalysisBase
     return false if t1_£_per_kwh.nan? || t2_£_per_kwh.nan?
 
     t1_£_per_kwh.round(2) != t2_£_per_kwh.round(2)
-  end 
+  end
 
   def kwh_date_range(meter, start_date, end_date, data_type)
     super(aggregate_meter, start_date, end_date, data_type, community_use: community_use)

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -7,8 +7,8 @@ module Logging
   logger.level = :debug
 end
 
-asof_date = Date.new(2022, 2, 1)
-schools = ['*-academy']
+asof_date = Date.new(2023, 3, 6)
+schools = ['welton*']
 
 overrides = {
   schools:  schools,
@@ -33,9 +33,7 @@ overrides = {
     #AlertGasAnnualVersusBenchmark,
     #AlertGasLongTermTrend
     # AlertChangeInElectricityBaseloadShortTerm
-    AlertOutOfHoursElectricityUsage,
-    AlertOutOfHoursGasUsage,
-    AlertStorageHeaterOutOfHours
+    AlertSchoolWeekComparisonGas
     ],
   control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving html_template_variables], log: [:invalid_alerts] } },
   no_alerts:   { alerts: [], control: { asof_date: asof_date } }


### PR DESCRIPTION
AlertPeriodComparisonBase has a custom `calculate_rating` method which is intended to stop the alerts from displaying if the cost savings is between +/- £10.

But the method was doing the following:

```
return 10.0 if financial_difference_£.between?(-MINIMUM_DIFFERENCE_FOR_NON_10_RATING_£, MINIMUM_DIFFERENCE_FOR_NON_10_RATING_£)
```

This means that the alert was being assigned the maximum rating for minor cost savings. The net result of which was that the alerts are ranked higher than others, which is the opposite of what is intended. So users are seeing alerts for, e.g. a 74p cost saving. 

The PR revises the code to return nil if the cost saving is within +/- £10. If there's no rating then the application will not try and display the results.

This is done here, rather than marking the alert as not relevant, because the calculations need to be carried out before the assessment can be made.