### PR TITLE
Add holiday usage calculator

### DIFF
--- a/app/services/usage/holiday_usage_calculation_service.rb
+++ b/app/services/usage/holiday_usage_calculation_service.rb
@@ -1,0 +1,130 @@
+module Usage
+  class HolidayUsageCalculationService
+
+    def initialize(analytics_meter, holidays, asof_date=Date.today)
+      @meter = analytics_meter
+      @holidays = holidays
+      @asof_date = asof_date
+    end
+
+    #Returns the usage for a specific holiday, expressed as a
+    #Holiday or School Period.
+    #
+    #Will return +nil+ if the meter doesn't have data for the
+    #entire period
+    #
+    #@param [Holiday] school period, the period to be analysed
+    #@return [CombinedUsageMetric] the calculated usage
+    def holiday_usage(school_period:)
+      return nil unless has_data_for_period?(school_period)
+      return CombinedUsageMetric.new(
+        kwh: usage_for_period(school_period, :kwh),
+        £: usage_for_period(school_period, :£),
+        co2: usage_for_period(school_period, :co2)
+      )
+    end
+
+    # Calculates the usage for the provided holiday period and
+    # the same holiday period in the previous year. E.g. usage
+    # Xmas 2022 holiday and the Xmas 2021 holiday.
+    #
+    # Does not do any temperature compensation or normalisation
+    # of the usage across periods, so this is not consistent with
+    # the alerts. So should only be used for reporting the "metered"
+    # usage for the periods.
+    #
+    #@param [Holiday] school period, the period to be analysed
+    #@return [OpenStruct]
+    def holiday_usage_comparison(school_period:)
+      usage_for_period = holiday_usage(school_period: school_period)
+      previous_period = holiday_period_for_previous_year(school_period)
+      usage_for_previous_period = previous_period.nil? ? nil : holiday_usage(school_period: previous_period)
+      return OpenStruct.new(
+        usage: usage_for_period,
+        previous_holiday_usage: usage_for_previous_period,
+        previous_holiday: previous_period
+      )
+    end
+
+    # For a given set of Holiday periods, returns the usage for that period
+    # and the same period for the previous year where data is available
+    #
+    # Equivalent to calling +holiday_usage_comparison+ for each item in the
+    # Array. Useful when tabulating usage across a range of periods
+    #
+    #@param [Array] school_periods, an array of periods
+    #@return [Hash] of school_period => OpenStruct
+    def holidays_usage_comparison(school_periods: [])
+      school_periods.map do |school_period|
+        [school_period, holiday_usage_comparison(school_period: school_period)]
+      end.to_h
+    end
+
+    # Returns the usage for a full "calendar" of holidays periods
+    #
+    # A school has 6 holidays in a given year:
+    # - Autumn half term
+    # - Christmas holiday
+    # - Spring half term
+    # - Easter holiday
+    # - Summer half-term
+    # - Summer holiday
+    #
+    # The results will include all holidays from the current academic year
+    # so far, plus those from the previous academic year that have not yet
+    # happened.
+    #
+    # E.g. In March 2023 it would return the Autum half term, xmas holiday and
+    # spring half term for the 2022/2023 calendar year. Plus the easter, summer
+    # half term and summer holiday for the 2021/2022 calendar year.
+    #
+    # This is to allow us to provide a "rolling" calendar of holiday usage
+    # calculations
+    #
+    #@return [Hash] of school_period => OpenStruct
+    def school_holiday_calendar_comparison
+      academic_year = academic_year_for_comparison
+      holidays_for_academic_year = @holidays.holidays.select{|h| h.academic_year == academic_year }
+      comparison_periods = holidays_for_academic_year.map do |holiday|
+        #use last year holiday if the holiday hasn't started yet
+        if holiday.start_date > @asof_date
+          holiday_period_for_previous_year(holiday)
+        else
+          holiday
+        end
+      end
+      holidays_usage_comparison(school_periods: comparison_periods)
+    end
+
+    private
+
+    def has_data_for_period?(school_period)
+      @meter.amr_data.start_date < school_period.start_date && @meter.amr_data.end_date > end_date(school_period)
+    end
+
+    def end_date(school_period)
+      if @asof_date > school_period.start_date && @asof_date < school_period.end_date
+        @asof_date
+      else
+        school_period.end_date
+      end
+    end
+
+    def holiday_period_for_previous_year(school_period)
+      @holidays.same_holiday_previous_year(school_period)
+    end
+
+    def academic_year_for_comparison
+      if @asof_date.month > 8
+        @asof_date.year..(@asof_date.year + 1)
+      else
+        (@asof_date.year - 1)..@asof_date.year
+      end
+    end
+
+    def usage_for_period(school_period, data_type = :kwh)
+      @meter.amr_data.kwh_date_range(school_period.start_date, end_date(school_period), data_type)
+    end
+
+  end
+end

--- a/app/services/usage/holiday_usage_calculation_service.rb
+++ b/app/services/usage/holiday_usage_calculation_service.rb
@@ -17,7 +17,7 @@ module Usage
     #@return [CombinedUsageMetric] the calculated usage
     def holiday_usage(school_period:)
       return nil unless has_data_for_period?(school_period)
-      return CombinedUsageMetric.new(
+      CombinedUsageMetric.new(
         kwh: usage_for_period(school_period, :kwh),
         £: usage_for_period(school_period, :£),
         co2: usage_for_period(school_period, :co2)
@@ -39,7 +39,7 @@ module Usage
       usage_for_period = holiday_usage(school_period: school_period)
       previous_period = holiday_period_for_previous_year(school_period)
       usage_for_previous_period = previous_period.nil? ? nil : holiday_usage(school_period: previous_period)
-      return OpenStruct.new(
+      OpenStruct.new(
         usage: usage_for_period,
         previous_holiday_usage: usage_for_previous_period,
         previous_holiday: previous_period
@@ -84,7 +84,7 @@ module Usage
     #@return [Hash] of school_period => OpenStruct
     def school_holiday_calendar_comparison
       academic_year = academic_year_for_comparison
-      holidays_for_academic_year = @holidays.holidays.select{|h| h.academic_year == academic_year }
+      holidays_for_academic_year = @holidays.holidays.select{ |h| h.academic_year == academic_year }
       comparison_periods = holidays_for_academic_year.map do |holiday|
         #use last year holiday if the holiday hasn't started yet
         if holiday.start_date > @asof_date

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -7,8 +7,8 @@ module Logging
   logger.level = :debug
 end
 
-asof_date = Date.new(2023, 3, 6)
-schools = ['welton*']
+asof_date = Date.new(2021, 1, 3)
+schools = ['acme*']
 
 overrides = {
   schools:  schools,
@@ -33,7 +33,8 @@ overrides = {
     #AlertGasAnnualVersusBenchmark,
     #AlertGasLongTermTrend
     # AlertChangeInElectricityBaseloadShortTerm
-    AlertSchoolWeekComparisonGas
+    AlertPreviousYearHolidayComparisonElectricity,
+    AlertPreviousHolidayComparisonElectricity
     ],
   control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving html_template_variables], log: [:invalid_alerts] } },
   no_alerts:   { alerts: [], control: { asof_date: asof_date } }

--- a/spec/app/services/usage/holiday_usage_calculation_service_spec.rb
+++ b/spec/app/services/usage/holiday_usage_calculation_service_spec.rb
@@ -1,0 +1,190 @@
+require 'spec_helper'
+
+describe Usage::HolidayUsageCalculationService, type: :service do
+
+  let(:fuel_type)        { :electricity }
+  let(:meter_collection) { @acme_academy }
+  let(:meter)            { meter_collection.aggregated_electricity_meters }
+  let(:asof_date)        { Date.today }
+  let(:service)          { Usage::HolidayUsageCalculationService.new(meter, meter_collection.holidays, asof_date)}
+
+  #using before(:all) here to avoid slow loading of YAML and then
+  #running the aggregation code for each test.
+  before(:all) do
+    @acme_academy = load_unvalidated_meter_collection(school: 'acme-academy')
+  end
+
+  context 'with electricity meters' do
+    context '#holiday_usage' do
+      let(:academic_year) { nil }
+      let(:school_period) { Holiday.new(holiday_type, name, start_date, end_date, academic_year) }
+      let(:usage) { service.holiday_usage(school_period: school_period) }
+
+      context 'for xmas 2021/2022' do
+        let(:holiday_type)  { :xmas }
+        let(:name)          { "Xmas 2021/2022" }
+        let(:start_date)    { Date.new(2021,12,18)}
+        #last day of xmas holiday
+        let(:end_date)      { Date.new(2022,01,3) }
+
+        it 'calculates the expected usage' do
+          expect(usage.kwh).to be_within(0.1).of(10425.6)
+          expect(usage.co2).to be_within(0.1).of(1794.7996)
+          expect(usage.£).to be_within(0.1).of(1558.438)
+        end
+      end
+
+      context 'for xmas 2020/2021' do
+        let(:holiday_type)  { :xmas }
+        let(:name)          { "Xmas 2020/2021" }
+        let(:start_date)    { Date.new(2020,12,19)}
+        #last day of xmas holiday
+        let(:end_date)      { Date.new(2021,1,3) }
+
+        it 'calculates the expected usage' do
+          expect(usage.kwh).to be_within(0.1).of(11728.89)
+          expect(usage.co2).to be_within(0.1).of(2068.9643)
+          expect(usage.£).to be_within(0.1).of(1754.026)
+        end
+      end
+
+      context 'for autumn half term 2021' do
+        let(:holiday_type)  { :autumn_half_term }
+        let(:name)          { "Autumn half term" }
+        let(:start_date)    { Date.new(2021,10,23) }
+        let(:end_date)      { Date.new(2021,10,31) }
+
+        it 'calculates the expected usage' do
+          expect(usage.kwh).to be_within(0.1).of(7801.6)
+          expect(usage.co2).to be_within(0.1).of(979.229)
+          expect(usage.£).to be_within(0.1).of(1181.78)
+        end
+      end
+
+      context 'for period outside meter range' do
+        let(:holiday_type)  { :summer }
+        let(:name)          { "Summer 2022" }
+        let(:start_date)    { Date.new(2022,7,14) }
+        let(:end_date)      { Date.new(2022,8,31) }
+        it 'returns nil' do
+          expect(usage).to eq nil
+        end
+      end
+
+      context 'in the middle of a holiday' do
+        let(:holiday_type)  { :xmas }
+        let(:name)          { "Xmas 2021/2022" }
+        let(:start_date)    { Date.new(2021,12,18)}
+        #last day of xmas holiday
+        let(:end_date)      { Date.new(2022,01,3) }
+        let(:asof_date)     { Date.new(2021,12,25) }
+
+        it 'returns partial usage' do
+          #less than usage for full holiday
+          expect(usage.kwh).to be <= 10425.6
+        end
+
+      end
+    end
+
+    context '#holiday_usage_comparison' do
+      let(:academic_year) { nil }
+      let(:school_period) { Holiday.new(holiday_type, name, start_date, end_date, academic_year) }
+      let(:comparison) { service.holiday_usage_comparison(school_period: school_period) }
+
+      context 'for xmas 2021/2022' do
+        let(:holiday_type)  { :xmas }
+        let(:name)          { "Xmas" }
+        let(:start_date)    { Date.new(2021,12,18)}
+        let(:end_date)      { Date.new(2022,01,3) }
+
+        it 'produces the right comparison' do
+          xmas_2021_usage = comparison.usage
+          expect(xmas_2021_usage.kwh).to be_within(0.1).of(10425.6)
+          expect(xmas_2021_usage.co2).to be_within(0.1).of(1794.7996)
+          expect(xmas_2021_usage.£).to be_within(0.1).of(1558.438)
+
+          expect(comparison.previous_holiday).to_not be_nil
+
+          xmas_2020_usage = comparison.previous_holiday_usage
+          expect(xmas_2020_usage.kwh).to be_within(0.1).of(11728.89)
+          expect(xmas_2020_usage.co2).to be_within(0.1).of(2068.9643)
+          expect(xmas_2020_usage.£).to be_within(0.1).of(1754.026)
+        end
+      end
+
+      context 'for period outside meter range' do
+        let(:holiday_type)  { :easter }
+        let(:name)          { "Easter 2019" }
+        let(:start_date)    { Date.new(2019,4,13)}
+        let(:end_date)      { Date.new(2019,4,28) }
+
+        it 'returns nil for previous year' do
+          expect(comparison.usage).to_not be_nil
+          expect(comparison.previous_holiday_usage).to be_nil
+        end
+      end
+    end
+
+    context '#holidays_usage_comparison' do
+      let(:academic_year) { nil }
+      let(:school_period_1) { Holiday.new(:xmas, "Xmas 2021/2022", Date.new(2021,12,18), Date.new(2022,01,3), academic_year) }
+      let(:school_period_2) { Holiday.new(:autumn_half_term, "Autum half term", Date.new(2021,10,23), Date.new(2021,10,31), academic_year) }
+      let(:comparison) { service.holidays_usage_comparison(school_periods: [school_period_1, school_period_2]) }
+
+      it 'calculates all comparisons' do
+        expect(comparison[school_period_1]).to_not be_nil
+        expect(comparison[school_period_2]).to_not be_nil
+      end
+    end
+
+    context '#school_holiday_calendar_comparison' do
+
+      context 'for Easter 2022' do
+        let(:asof_date)        { Date.new(2022, 4, 1) }
+        let(:holiday_comparison) { service.school_holiday_calendar_comparison }
+
+        it 'finds all the holidays' do
+          holiday_types = holiday_comparison.keys.map {|h| h.type }
+          expect(holiday_types).to match_array([:autumn_half_term, :xmas, :spring_half_term, :easter, :summer_half_term, :summer])
+        end
+
+        it 'calculates usage for all holidays' do
+          holiday_comparison.each do |holiday, usage|
+            expect(usage.usage).to_not be_nil
+          end
+        end
+
+        it 'has Easter as latest' do
+          latest_holiday = holiday_comparison.keys.sort{|a,b| b.start_date <=> a.start_date }.last
+          expect(latest_holiday.type).to eq :easter
+        end
+      end
+
+      context 'for Summer 2022' do
+        #last meter date
+        let(:asof_date)        { Date.new(2022,7,13) }
+        let(:service)          { Usage::HolidayUsageCalculationService.new(meter, meter_collection.holidays, asof_date)}
+        let(:holiday_comparison) { service.school_holiday_calendar_comparison }
+
+        it 'finds all the holidays' do
+          holiday_types = holiday_comparison.keys.map {|h| h.type }
+          expect(holiday_types).to match_array([:autumn_half_term, :xmas, :spring_half_term, :easter, :summer_half_term, :summer])
+        end
+
+        it 'calculates usage for all holidays' do
+          holiday_comparison.each do |holiday, usage|
+            expect(usage.usage).to_not be_nil
+          end
+        end
+
+        it 'has Summer as latest' do
+          latest_holiday = holiday_comparison.keys.sort{|a,b| b.start_date <=> a.start_date }.last
+          expect(latest_holiday.type).to eq :summer
+        end
+
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Adds a service that can be used for calculating usage for single, multiple or a full school "calendar" of holidays based on the available data. This will be used to populate a table of holiday usage in the application.

It doesn't do the period normalisation used in the alerts, but for the moment we just want the "metered" usage values.