### PR TITLE
Translate chart timescales

### DIFF
--- a/config/locales/charts/chart_timescale_descriptions.yml
+++ b/config/locales/charts/chart_timescale_descriptions.yml
@@ -1,0 +1,24 @@
+---
+en:
+  charts:
+    timescale_name:
+      year: year
+      up_to_a_year: year
+      years: long term
+      academicyear: academic year
+      month: month
+      holiday: holiday
+      includeholiday: holiday
+      week: week
+      workweek: week
+      schoolweek: school week
+      day: day
+      frostday: frosty day
+      frostday_3: frosty day
+      diurnal: day with large diurnal range
+      optimum_start: optimum start example day
+      daterange: date range
+      hotwater: summer period with hot water usage
+      none:
+      period: period
+      n_weeks: "%{count} weeks"

--- a/config/locales/charts/chart_timescale_descriptions.yml
+++ b/config/locales/charts/chart_timescale_descriptions.yml
@@ -2,23 +2,22 @@
 en:
   charts:
     timescale_name:
-      year: year
-      up_to_a_year: year
-      years: long term
       academicyear: academic year
-      month: month
-      holiday: holiday
-      includeholiday: holiday
-      week: week
-      workweek: week
-      schoolweek: school week
+      daterange: date range
       day: day
+      diurnal: day with large diurnal range
       frostday: frosty day
       frostday_3: frosty day
-      diurnal: day with large diurnal range
-      optimum_start: optimum start example day
-      daterange: date range
+      holiday: holiday
       hotwater: summer period with hot water usage
-      none:
-      period: period
+      includeholiday: holiday
+      month: month
       n_weeks: "%{count} weeks"
+      optimum_start: optimum start example day
+      period: period
+      schoolweek: school week
+      up_to_a_year: year
+      week: week
+      workweek: week
+      year: year
+      years: long term

--- a/lib/dashboard/charting_and_reports/charts/chart_timescale_descriptions.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_timescale_descriptions.rb
@@ -9,7 +9,7 @@ class ChartTimeScaleDescriptions
 
   def self.timescale_name(timescale_symbol) # also used by drilldown
     #using default rather than falling back to :none
-    I18n.t("#{TIMESCALE_TYPES}.#{timescale_symbol}", default: '')
+    I18n.t("charts.timescale_name.#{timescale_symbol}", default: '')
   end
 
   def self.convert_timescale_to_array(timescale)

--- a/lib/dashboard/charting_and_reports/charts/chart_timescale_descriptions.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_timescale_descriptions.rb
@@ -1,31 +1,15 @@
+# Helper class that interprets the `:timescale` key in a chart configuration
+# to produce a label or description of the time period
 class ChartTimeScaleDescriptions
+  TIMESCALE_TYPES = 'charts.timescale_name'.freeze
+
   def initialize(chart_config)
     @chart_config = chart_config
   end
 
-  TIME_SCALE_TYPES = { 
-    year:           'year',
-    up_to_a_year:   'year',
-    years:          'long term',
-    academicyear:   'academic year',
-    month:          'month',
-    holiday:        'holiday',
-    includeholiday: 'holiday',
-    week:           'week',
-    workweek:       'week',
-    schoolweek:     'school week',
-    day:            'day',
-    frostday:       'frosty day',
-    frostday_3:     'frosty day',
-    diurnal:        'day with large diurnal range',
-    optimum_start:  'optimum start example day',
-    daterange:      'date range',
-    hotwater:       'summer period with hot water usage',
-    none:           ''
-  }.freeze
-
   def self.timescale_name(timescale_symbol) # also used by drilldown
-    TIME_SCALE_TYPES.key?(timescale_symbol) ? TIME_SCALE_TYPES[timescale_symbol] : TIME_SCALE_TYPES[:none] 
+    #using default rather than falling back to :none
+    I18n.t("#{TIMESCALE_TYPES}.#{timescale_symbol}", default: '')
   end
 
   def self.convert_timescale_to_array(timescale)
@@ -51,12 +35,12 @@ class ChartTimeScaleDescriptions
     timescale = timescales[0]
     if timescale.is_a?(Hash) && !timescale.empty? && timescale.keys[0] == :daterange
       impute_description_from_date_range(timescale.values[0])
-    elsif TIME_SCALE_TYPES.key?(timescale)
+    elsif known_type?(timescale)
       timescale_name(timescale)
-    elsif timescale.is_a?(Hash) && !timescale.empty? && TIME_SCALE_TYPES.key?(timescale.keys[0])
+    elsif timescale.is_a?(Hash) && !timescale.empty? && known_type?(timescale.keys[0])
       timescale_name(timescale.keys[0])
     else
-      'period'
+      timescale_name(:period)
     end
   end
 
@@ -79,10 +63,17 @@ class ChartTimeScaleDescriptions
       if days > 380
         timescale_name(:years)
       elsif days % 7 == 0
-        "#{days / 7} weeks" # ends up with duplicate number e.g. 'Move forward 1 2 weeks' TODO(PH, 13Sep2019) fix further up hierarchy
+        # ends up with duplicate number e.g. 'Move forward 1 2 weeks' TODO(PH, 13Sep2019) fix further up hierarchy
+        I18n.t("#{TIMESCALE_TYPES}.n_weeks", count: days / 7)
       else
         timescale_name(:daterange)
       end
     end
+  end
+
+  def self.known_type?(timescale)
+    #test for :none as fallback behaviour for any code relying on
+    #previous behaviour
+    I18n.t(TIMESCALE_TYPES).key?(timescale) || timescale == :none
   end
 end

--- a/script/standard/test_charts.rb
+++ b/script/standard/test_charts.rb
@@ -8,7 +8,7 @@ module Logging
 end
 
 charts = {
-  adhoc: %i[ solar_pv_group_by_week_by_submeter solar_pv_group_by_month management_dashboard_group_by_week_electricity]
+  adhoc: %i[ management_dashboard_group_by_week_electricity ]
 }
 
 no_charts = RunCharts.standard_charts_for_school
@@ -24,7 +24,7 @@ control = {
 }
 
 overrides = {
-  schools:  ['coed*', 'fresh*', 'hugh*'],
+  schools:  ['a*'],
   cache_school: false,
   charts:   { charts: charts, control: control }
 }

--- a/spec/lib/dashboard/charting_and_reports/charts/chart_timescale_descriptions_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/chart_timescale_descriptions_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe ChartTimeScaleDescriptions do
+  context '.timescale_name' do
+    it 'returns expected values' do
+      expect(ChartTimeScaleDescriptions.timescale_name(:year)).to eq 'year'
+      expect(ChartTimeScaleDescriptions.timescale_name(:up_to_a_year)).to eq 'year'
+      expect(ChartTimeScaleDescriptions.timescale_name(:years)).to eq 'long term'
+      expect(ChartTimeScaleDescriptions.timescale_name(:academicyear)).to eq 'academic year'
+      expect(ChartTimeScaleDescriptions.timescale_name(:month)).to eq 'month'
+      expect(ChartTimeScaleDescriptions.timescale_name(:holiday)).to eq 'holiday'
+      expect(ChartTimeScaleDescriptions.timescale_name(:includeholiday)).to eq 'holiday'
+      expect(ChartTimeScaleDescriptions.timescale_name(:week)).to eq 'week'
+      expect(ChartTimeScaleDescriptions.timescale_name(:schoolweek)).to eq 'school week'
+      expect(ChartTimeScaleDescriptions.timescale_name(:day)).to eq 'day'
+      expect(ChartTimeScaleDescriptions.timescale_name(:frostday)).to eq 'frosty day'
+      expect(ChartTimeScaleDescriptions.timescale_name(:frostday_3)).to eq 'frosty day'
+      expect(ChartTimeScaleDescriptions.timescale_name(:diurnal)).to eq 'day with large diurnal range'
+      expect(ChartTimeScaleDescriptions.timescale_name(:optimum_start)).to eq 'optimum start example day'
+      expect(ChartTimeScaleDescriptions.timescale_name(:daterange)).to eq 'date range'
+      expect(ChartTimeScaleDescriptions.timescale_name(:hotwater)).to eq 'summer period with hot water usage'
+      expect(ChartTimeScaleDescriptions.timescale_name(:none)).to eq ''
+      expect(ChartTimeScaleDescriptions.timescale_name(:period)).to eq 'period'
+    end
+  end
+
+  context '.interpret_timescale_description' do
+    it 'returns expected description' do
+      expect(ChartTimeScaleDescriptions.interpret_timescale_description(:up_to_a_year)).to eq 'year'
+      expect(ChartTimeScaleDescriptions.interpret_timescale_description(:none)).to eq ''
+      expect(ChartTimeScaleDescriptions.interpret_timescale_description(:unknown)).to eq 'period'
+      timescale = {schoolweek: -1}
+      expect(ChartTimeScaleDescriptions.interpret_timescale_description(timescale)).to eq 'school week'
+      timescale = {week: -1..0}
+      expect(ChartTimeScaleDescriptions.interpret_timescale_description(timescale)).to eq 'week'
+      timescale = [{year: 0}, {year: -1}]
+      expect(ChartTimeScaleDescriptions.interpret_timescale_description(timescale)).to eq 'year'
+      timescale = {daterange: Date.today..Date.today}
+      expect(ChartTimeScaleDescriptions.interpret_timescale_description(timescale)).to eq 'day'
+      timescale = {daterange: Date.today-6..Date.today}
+      expect(ChartTimeScaleDescriptions.interpret_timescale_description(timescale)).to eq 'week'
+      timescale = {daterange: Date.today-30..Date.today}
+      expect(ChartTimeScaleDescriptions.interpret_timescale_description(timescale)).to eq 'month'
+      timescale = {daterange: Date.today-365..Date.today}
+      expect(ChartTimeScaleDescriptions.interpret_timescale_description(timescale)).to eq 'year'
+      timescale = {daterange: Date.today-500..Date.today}
+      expect(ChartTimeScaleDescriptions.interpret_timescale_description(timescale)).to eq 'long term'
+      timescale = {daterange: Date.today-69..Date.today}
+      expect(ChartTimeScaleDescriptions.interpret_timescale_description(timescale)).to eq '10 weeks'
+    end
+  end
+
+end

--- a/spec/lib/dashboard/charting_and_reports/charts/chart_timescale_manipulation_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/chart_timescale_manipulation_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+describe ChartManagerTimescaleManipulation do
+
+  let(:operation_type)    { :move }
+
+  let(:timescale)   { :up_to_a_year }
+
+  let(:chart_config) {
+    {
+      :name=>"By Week: Electricity",
+      :chart1_type=>:column,
+      :chart1_subtype=>:stacked,
+      :meter_definition=>:allelectricity,
+      :x_axis=>:week,
+      :series_breakdown=>:daytype,
+      :yaxis_units=>:£,
+      :yaxis_scaling=>:none,
+      :timescale=>timescale,
+      :community_use=>{:filter=>:all, :aggregate=>:community_use, :split_electricity_baseload=>true}
+    }
+  }
+
+  let(:end_date)    { Date.today - 1 }
+  let(:start_date)  { end_date - 365 }
+  let(:amr_data)    { double('amr-data') }
+
+  let(:electricity_aggregate_meter) { double('electricity-aggregated-meter')}
+  let(:meter_collection)            { double('meter-collection') }
+
+  before(:each) do
+    allow(amr_data).to receive(:start_date).and_return(start_date)
+    allow(amr_data).to receive(:end_date).and_return(end_date)
+    allow(electricity_aggregate_meter).to receive(:amr_data).and_return(amr_data)
+    allow(meter_collection).to receive(:aggregated_electricity_meters).and_return(electricity_aggregate_meter)
+  end
+
+  context '.factory' do
+    %i[move extend contract compare].each do |operation|
+      it "produces manipulator for #{operation}" do
+        expect( ChartManagerTimescaleManipulation.factory(operation, chart_config, meter_collection) ).to_not be_nil
+      end
+    end
+  end
+
+  context 'ChartManagerTimescaleManipulationMove' do
+    let(:manipulator) { ChartManagerTimescaleManipulationMove.new(operation_type, chart_config, meter_collection)}
+
+    context '#adjust_timescale' do
+      context 'with enough data' do
+        let(:period)  { -1 }
+        let(:expected_timescale)  { [{timescale => period}]}
+
+        let(:start_date) { end_date - (365*3) }
+        it 'updates timescale' do
+          chart_config = manipulator.adjust_timescale(period)
+          expect(chart_config[:timescale]).to eq expected_timescale
+        end
+      end
+
+      context 'with not enough data' do
+        it 'raises exception' do
+          expect { manipulator.adjust_timescale(-1) }.to raise_error(EnergySparksNotEnoughDataException)
+        end
+      end
+    end
+
+    context '#can_go_back_in_time_one_period?' do
+      context 'with enough data' do
+        let(:start_date) { end_date - (365*3) }
+        it 'returns true' do
+          expect(manipulator.can_go_back_in_time_one_period?).to be true
+        end
+      end
+
+      context 'with not enough data' do
+        it 'returns false' do
+          #default dates are a single year
+          expect(manipulator.can_go_back_in_time_one_period?).to be false
+        end
+      end
+    end
+
+    context '#can_go_forward_in_time_one_period' do
+      context 'with enough data' do
+        let(:start_date) { Date.today - 365 }
+        let(:end_date)   { Date.today + (365*2) }
+        #cannot just move forward, need an existing period
+        let(:timescale)   { [{up_to_a_year: -1}] }
+        it 'returns true' do
+          expect(manipulator.can_go_forward_in_time_one_period?).to be true
+        end
+      end
+
+      context 'with not enough data' do
+        it 'returns false' do
+          #default dates are a single year
+          expect(manipulator.can_go_forward_in_time_one_period?).to be false
+        end
+      end
+    end
+
+    context '#chart_suitable_for_timescale_manipulation?' do
+      it 'returns true' do
+        expect(manipulator.chart_suitable_for_timescale_manipulation?).to be true
+      end
+      context 'with no timescale value' do
+        let(:timescale) { nil }
+        it 'returns false' do
+          expect(manipulator.chart_suitable_for_timescale_manipulation?).to be false
+          chart_config.delete(:timescale)
+          expect(manipulator.chart_suitable_for_timescale_manipulation?).to be false
+        end
+      end
+    end
+
+    context '#timescale_description' do
+      it 'returns expected valid' do
+        expect(manipulator.timescale_description).to eq 'year'
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Ensures that all the time periods used for chart timescales are translatable.

There PR also adds some code comments and additional rspecs for the related classes.