### PR TITLE
Tidy up chart tools

### DIFF
--- a/config/locales/charts/chart_configuration.yml
+++ b/config/locales/charts/chart_configuration.yml
@@ -460,9 +460,6 @@ en:
     group_by_week_electricity_meter_breakdown_one_year:
       title:
       - 'By Week: Electricity (Meter Breakdown)'
-    group_by_week_electricity_school_comparison_line:
-      title:
-      - ''
     group_by_week_electricity_simulator:
       title:
       - 'By Week: Electricity (Simulator)'
@@ -910,18 +907,12 @@ en:
     targeting_and_tracking_unscaled_target_group_by_week_storage_heater:
       title:
       - Unscaled target <%= meter.fuel_type %> group by week chart (<%= total_kwh %> kWh)
-    targeting_and_tracking_weekly_electricity_one_year_column_deprecated:
-      title:
-      - targeting_and_tracking_weekly_electricity_one_year_column
     targeting_and_tracking_weekly_electricity_one_year_cumulative_line:
       title:
       - Weekly progress versus target to date
     targeting_and_tracking_weekly_electricity_one_year_line:
       title:
       - Weekly progress versus target to date
-    targeting_and_tracking_weekly_electricity_to_date_column_deprecated:
-      title:
-      - Weekly progress versus target
     targeting_and_tracking_weekly_electricity_to_date_cumulative_line:
       title:
       - Cumulative progress versus target

--- a/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
@@ -393,19 +393,6 @@ class ChartManager
       inherits_from:    :test_economic_costs_electric_by_datetime_year_£,
       meter_definition: :allheat
     },
-
-    targeting_and_tracking_weekly_electricity_to_date_column_deprecated: {
-      name:           :targeting_and_tracking_weekly_electricity_to_date_column.to_s,
-      chart1_type:    :column,
-      chart1_subtype: nil,
-      inherits_from: :targeting_and_tracking_weekly_electricity_to_date_line
-    },
-    targeting_and_tracking_weekly_electricity_one_year_column_deprecated: {
-      name:           :targeting_and_tracking_weekly_electricity_one_year_column.to_s,
-      target:             {calculation_type: :day, extend_chart_into_future: true, truncate_before_start_date: true},
-      inherits_from: :targeting_and_tracking_weekly_electricity_to_date_column
-    },
-
     # ============================================================================================
     group_by_week_electricity_versus_benchmark: {
       name:                 'By Week: Electricity - compared with benchmark',
@@ -838,10 +825,6 @@ class ChartManager
       chart1_type:      :line,
       series_breakdown: :none,
       yaxis_units:      :kw
-    },
-    group_by_week_electricity_school_comparison_line: {
-      inherits_from:    :group_by_week_electricity_school_comparison,
-      chart1_type:      :line
     },
     group_by_week_electricity_unlimited: {
       name:             'By Week: Electricity (multi-year)',

--- a/script/tools/chart_config.rb
+++ b/script/tools/chart_config.rb
@@ -1,0 +1,43 @@
+require 'optparse'
+require 'require_all'
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
+
+options = {
+  chart: :group_by_week_electricity,
+  sort: true
+}
+
+optparse = OptionParser.new do |opts|
+  opts.banner = "Usage: chart_config.rb [options]"
+  opts.on("-n", "--name NAME", "Chart name") do |v|
+    options[:chart] = v.to_sym
+  end
+  opts.on("-s", "--[no-]sort", "Sort chart configuration keys. Default is #{options[:sort]}") do |v|
+    options[:sort] = v
+  end
+end
+
+begin
+  optparse.parse!
+  mandatory = [:chart]
+  missing = mandatory.select{ |param| options[param].nil? }
+  unless missing.empty?
+    raise OptionParser::MissingArgument.new(missing.join(', '))
+  end
+rescue OptionParser::InvalidOption, OptionParser::MissingArgument
+  puts $!.to_s
+  puts optparse
+  exit
+end
+
+definition = ChartManager::STANDARD_CHART_CONFIGURATION[options[:chart]]
+if definition.nil?
+  $stderr.puts "Chart #{options[:chart]} not found"
+  exit
+end
+
+manager = ChartManager.new(nil)
+chart_config = manager.resolve_chart_inheritance(definition)
+
+ap chart_config, indent: -2, sort_keys: options[:sort]

--- a/script/tools/chart_configuration_analyser.rb
+++ b/script/tools/chart_configuration_analyser.rb
@@ -1,66 +1,37 @@
+require 'optparse'
 require 'require_all'
-require_relative '../lib/dashboard.rb'
-require_rel '../test_support'
-# goes through all the charts in chart_configation.rb
-# and analyses them for inheritance and configuraiton types
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
 
-chart_name = :group_by_week_electricity
-
-puts "Analysing parents and children of #{chart_name}"
-
-def inherits_from(chart_name, list)
-  chart_config = ChartManager::STANDARD_CHART_CONFIGURATION[chart_name]
-  if chart_config.key?(:inherits_from)
-    list.push(chart_config[:inherits_from])
-    inherits_from(chart_config[:inherits_from], list)
-  end
-end
-
-def children_of(chart_name, list)
-  immediate_children = ChartManager::STANDARD_CHART_CONFIGURATION.select do |_name, config|
-    config.key?(:inherits_from) && config[:inherits_from] == chart_name
-  end
-  list.push(immediate_children.keys) unless immediate_children.empty?
-  immediate_children.each_key do |child_chart_name|
-    children_of(child_chart_name, list)
-  end
-end
-
-def resolve_chart(chart_name)
-  chart_config = ChartManager::STANDARD_CHART_CONFIGURATION[chart_name]
-  parents = []
-  inherits_from(chart_name, parents)
-  children = []
-  children_of(chart_name, children)
-  children
-end
-
-mapping = ChartManager::STANDARD_CHART_CONFIGURATION.keys.map do |chart_name|
-  [chart_name, resolve_chart(chart_name).flatten]
-end.to_h
-
-# ap mapping
-# ap mapping.length
+# Runs through chart configuration.rb, resolving all chart inheritance
+# then produces a summary of the chart configuration keys used
 
 manager = ChartManager.new(nil)
+
+#resolve inheritance for all charts
 configs = ChartManager::STANDARD_CHART_CONFIGURATION.map do |chart_name, definition|
   [chart_name, manager.resolve_chart_inheritance(definition)]
 end.to_h
 
+#accumulate occurences of each chart config key
 stats = Hash.new{ |hash, key| hash[key] = Array.new }
+
 configs.each do |_name, definition|
   definition.each do |key, value|
     stats[key].push(value)
   end
 end
 
+#count up occurences of each key
 counted_stats = stats.map do |key, value|
   [key, value.each_with_object(Hash.new(0)) { |l, o| o[l] += 1 }]
+end.to_h
+
+#Dump keys, in alphabetical order with values sorted by occurences
+counted_stats.keys.sort.each do |k|
+  ap k
+  counted_stats[k].sort_by {|k,v| -v }.each do |k,v|
+    ap [v, k], multiline: false
+  end
+  puts
 end
-
-# ap configs
-
-# ap stats
-
-ap counted_stats
-

--- a/script/tools/chart_inheritance.rb
+++ b/script/tools/chart_inheritance.rb
@@ -1,14 +1,11 @@
+require 'optparse'
+require 'dotenv/load'
+
 require 'require_all'
-require_relative '../lib/dashboard.rb'
-require_rel '../test_support'
-# prints parents and childdren of given chart
+require_relative '../../lib/dashboard.rb'
+require_rel '../../test_support'
 
-chart_name = :group_by_week_electricity
-
-
-
-puts "Analysing parents and children of #{chart_name}"
-
+#recursively find parents of a named chart
 def inherits_from(chart_name, list)
   chart_config = ChartManager::STANDARD_CHART_CONFIGURATION[chart_name]
   if chart_config.key?(:inherits_from)
@@ -17,6 +14,7 @@ def inherits_from(chart_name, list)
   end
 end
 
+#recursively find children of a named chart
 def children_of(chart_name, list)
   immediate_children = ChartManager::STANDARD_CHART_CONFIGURATION.select do |_name, config|
     config.key?(:inherits_from) && config[:inherits_from] == chart_name
@@ -27,13 +25,55 @@ def children_of(chart_name, list)
   end
 end
 
-chart_config = ChartManager::STANDARD_CHART_CONFIGURATION[chart_name]
-parents = []
-inherits_from(chart_name, parents)
-puts "Parents:"
-ap parents
-children = []
-children_of(chart_name, children)
-puts "Children:"
-ap children
+options = {
+  chart: :group_by_week_electricity,
+  parents: false,
+  children: true
+}
 
+optparse = OptionParser.new do |opts|
+  opts.banner = "Usage: chart_inheritance.rb [options]"
+  opts.on("-p", "--parents", "Show parents. Default: #{options[:parents]}") do |v|
+    options[:parents] = v
+  end
+  opts.on("-c", "--children", "Show children. Default: #{options[:children]}") do |v|
+    options[:children] = v
+  end
+  opts.on("-n", "--name NAME", "Chart name") do |v|
+    options[:chart] = v.to_sym
+  end
+end
+
+begin
+  optparse.parse!
+  mandatory = [:chart]
+  missing = mandatory.select{ |param| options[param].nil? }
+  unless missing.empty?
+    raise OptionParser::MissingArgument.new(missing.join(', '))
+  end
+rescue OptionParser::InvalidOption, OptionParser::MissingArgument
+  puts $!.to_s
+  puts optparse
+  exit
+end
+
+if ChartManager::STANDARD_CHART_CONFIGURATION[options[:chart]].nil?
+  puts "Chart not found"
+  exit
+end
+
+puts "Analysing chart: #{options[:chart]}"
+
+if options[:parents]
+  parents = []
+  inherits_from(options[:chart], parents)
+  puts "PARENTS. Ordered with direct parent first"
+  ap parents
+end
+
+if options[:children]
+  children = []
+  children_of(options[:chart], children)
+  puts "CHILDREN"
+  ap children, {indent: 4}
+end

--- a/script/tools/chart_inheritance.rb
+++ b/script/tools/chart_inheritance.rb
@@ -1,6 +1,4 @@
 require 'optparse'
-require 'dotenv/load'
-
 require 'require_all'
 require_relative '../../lib/dashboard.rb'
 require_rel '../../test_support'


### PR DESCRIPTION
Fixes up two tools for inspecting the chart configuration which weren't working because of code and configuration changes and adds a new third tool (chart config)

## Chart inheritance:

```
bundle exec ruby script/tools/chart_inheritance.rb --name management_dashboard_group_by_week_electricity
```

Now accepts options to specify chart to analyse and whether to check for parents and children.

## Chart configuration analyser

```
bundle exec ruby script/tools/chart_configuration_analyser.rb
```

Resolves inheritance of all charts and dumps a report of each chart configuration option, plus counts of their occurence. 

## Chart config

```
bundle exec ruby script/tools/chart_config.rb --name electricity_cost_1_year_accounting_breakdown
```

Resolves chart inheritance and dumps configuration for a single chart.

While fixing these up I discovered a couple of charts which no longer have parents. I've removed those unused/deprecated charts from the configuration and added a new exception which will be thrown if a chart declares it inherits from a chart that doesn't exist. 

