### PR TITLE
Raise error when target meter is nil

### DIFF
--- a/app/services/targets_service.rb
+++ b/app/services/targets_service.rb
@@ -9,6 +9,14 @@ class TargetsService
   end
 
   def progress
+    #Currently TargetSchool.calculate_target_meter can set the target meter
+    #to nil in certain conditions, which means generating the progress report fails.
+    #Adding this check as a temporary measure to catch this happening then raise
+    #a more appropriate error.
+    if target_meter.nil? && target_school.reason_for_nil_meter(@fuel_type) != nil
+      raise StandardError.new(target_school.reason_for_nil_meter(@fuel_type)[:text])
+      return
+    end
     TargetsProgress.new(
       fuel_type: @fuel_type,
       months: data_headers, # populate table in report

--- a/lib/dashboard/modelling/targeting and tracking/target_school.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_school.rb
@@ -91,6 +91,9 @@ class TargetSchool < MeterCollection
 
     debug "Calculating target meter of type #{fuel_type}".ljust(100, '-')
 
+    #Rather than just setting nil here, the code should just raise exceptions.
+    #Some of these are preconditions that calling code should deal with.
+    #Calculation errors ought to be thrown so they can be tracked and resolved.
     target_meter = if original_meter.nil?
       set_nil_meter_with_reason(fuel_type, NO_PARENT_METER, nil)
     elsif !target_set?(original_meter)
@@ -154,4 +157,3 @@ class TargetSchool < MeterCollection
     puts var if @debug && !Object.const_defined?('Rails')
   end
 end
-

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -8,7 +8,7 @@ module Logging
 end
 
 asof_date = Date.new(2021, 1, 3)
-schools = ['acme*']
+schools = ['g*']
 
 overrides = {
   schools:  schools,
@@ -33,8 +33,9 @@ overrides = {
     #AlertGasAnnualVersusBenchmark,
     #AlertGasLongTermTrend
     # AlertChangeInElectricityBaseloadShortTerm
-    AlertPreviousYearHolidayComparisonElectricity,
-    AlertPreviousHolidayComparisonElectricity
+    #AlertPreviousYearHolidayComparisonElectricity,
+    #AlertPreviousHolidayComparisonElectricity
+    AlertElectricityTarget1Week
     ],
   control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving html_template_variables], log: [:invalid_alerts] } },
   no_alerts:   { alerts: [], control: { asof_date: asof_date } }


### PR DESCRIPTION
TargetSchool is trapping some errors which aren't reported to the application as exceptions. This leads to errors in unrelated code that makes tracking down the source of the problem harder.

This is an interim fix to raise a clearer error message, pending further refactoring.