### PR TITLE
Easter switch off alerts & benchmark

### DIFF
--- a/config/locales/benchmarking/content_base.yml
+++ b/config/locales/benchmarking/content_base.yml
@@ -164,6 +164,9 @@ en:
           holiday: Holiday
           holiday_usage_to_date: Holiday usage to date
           kwh_consumption_since_target_set: kWh consumption since target set
+          last_school_week: Final school week
+          last_school_week_temperature_adjusted: Final school week (temperature adjusted)
+          last_school_week_temperature_unadjusted: Final school week (temperature unadjusted)
           last_year: Last year
           last_year_carbon_emissions_tonnes_co2: Last year carbon emissions (tonnes CO2)
           last_year_consumption_kwh: Last year consumption kWh

--- a/config/locales/benchmarking/content_base.yml
+++ b/config/locales/benchmarking/content_base.yml
@@ -52,6 +52,7 @@ en:
             electricity: Electricity
             gas: Gas
             storage_heaters: Storage heaters
+        easter_shutdown_2023_energy_comparison: Easter shutdown 2023 comparison
         electricity_consumption_during_holiday: Electricity use during current holiday
         electricity_peak_kw_per_pupil: Peak school day electricity use
         electricity_targets: Progress against electricity target

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -594,7 +594,10 @@ class AlertAnalysisBase < ContentBase
       AlertAutumnTerm20212022StorageHeaterComparison              => 'a22s',
       AlertSeptNov20212022ElectricityComparison                   => 's22e',
       AlertSeptNov20212022GasComparison                           => 's22g',
-      AlertSeptNov20212022StorageHeaterComparison                 => 's22s'
+      AlertSeptNov20212022StorageHeaterComparison                 => 's22s',
+      AlertEaster2023ShutdownElectricityComparison                => 'e23e',
+      AlertEaster2023ShutdownGasComparison                        => 'e23g',
+      AlertEaster2023ShutdownStorageHeaterComparison              => 'e23s'
     }
   end
 

--- a/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
@@ -122,3 +122,48 @@ end
 
 class AlertSeptNov20212022StorageHeaterComparison < AlertAutumnTerm20212022StorageHeaterComparison
 end
+
+module AlertEaster2023ShutdownConfigurationMixin
+  def basic_configuration
+    {
+      name:                   'Easter shutdown 2023',
+      max_days_out_of_date:   30,
+      enough_days_data:       1,
+      holiday_date:           Date.new(2023,4,7), #good friday
+      school_weeks:           0
+    }
+  end
+end
+
+class AlertEaster2023ShutdownElectricityComparison < AlertArbitraryPeriodComparisonElectricityBase
+  include ArbitraryPeriodComparisonMixIn #adds in helpers
+  include HolidayShutdownComparisonMixin #adds in some additional helpers
+  include AlertEaster2023ShutdownConfigurationMixin #mixin the configuration
+
+  #Method to access the configuration
+  def comparison_configuration
+    basic_configuration
+  end
+end
+
+class AlertEaster2023ShutdownGasComparison < AlertArbitraryPeriodComparisonGasBase
+  include ArbitraryPeriodComparisonMixIn #adds in helpers
+  include HolidayShutdownComparisonMixin #adds in some additional helpers
+  include AlertEaster2023ShutdownConfigurationMixin #mixin the configuration
+
+  #Method to access the configuration
+  def comparison_configuration
+    basic_configuration
+  end
+end
+
+class AlertEaster2023ShutdownStorageHeaterComparison < AlertArbitraryPeriodComparisonStorageHeaterBase
+  include ArbitraryPeriodComparisonMixIn #adds in helpers
+  include HolidayShutdownComparisonMixin #adds in some additional helpers
+  include AlertEaster2023ShutdownConfigurationMixin #mixin the configuration
+
+  #Method to access the configuration
+  def comparison_configuration
+    basic_configuration
+  end
+end

--- a/lib/dashboard/benchmarking/benchmark_configuration.rb
+++ b/lib/dashboard/benchmarking/benchmark_configuration.rb
@@ -148,7 +148,7 @@ module Benchmarking
         :change_in_energy_use_since_joined_energy_sparks,
         :autumn_term_2021_2022_energy_comparison,
         :sept_nov_2021_2022_energy_comparison,
-        :easter_shutdown_2023
+        :easter_shutdown_2023_energy_comparison
       ]
     }
 

--- a/lib/dashboard/benchmarking/benchmark_configuration.rb
+++ b/lib/dashboard/benchmarking/benchmark_configuration.rb
@@ -1708,7 +1708,7 @@ module Benchmarking
           # CO2
           { data: ->{ e23s_pppc }, name: :last_school_week, units: :co2 },
           { data: ->{ e23s_cppc }, name: :holiday,  units: :co2 },
-          { data: ->{ percent_change(e23s_pppc, s22s_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
+          { data: ->{ percent_change(e23s_pppc, e23s_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # £
           { data: ->{ e23s_ppp£ }, name: :last_school_week, units: :£ },

--- a/lib/dashboard/benchmarking/benchmark_configuration.rb
+++ b/lib/dashboard/benchmarking/benchmark_configuration.rb
@@ -147,7 +147,8 @@ module Benchmarking
         :layer_up_powerdown_day_november_2022,
         :change_in_energy_use_since_joined_energy_sparks,
         :autumn_term_2021_2022_energy_comparison,
-        :sept_nov_2021_2022_energy_comparison
+        :sept_nov_2021_2022_energy_comparison,
+        :easter_shutdown_2023
       ]
     }
 
@@ -211,7 +212,7 @@ module Benchmarking
         sort_by:  [4],
         type: %i[chart table],
         admin_only: false,
-        column_heading_explanation: :last_year_definition_html        
+        column_heading_explanation: :last_year_definition_html
       },
       annual_energy_costs_per_floor_area: {
         benchmark_class:  BenchmarkContentEnergyPerFloorArea,
@@ -257,7 +258,7 @@ module Benchmarking
           # kWh
 
           { data: ->{ sum_if_complete([lue1_pppk, lug1_pppk, lus1_pppk], [lue1_cppk, lug1_cppk, lus1_cppk]) }, name: :previous_year, units: :kwh },
-          { data: ->{ sum_data([lue1_cppk, lug1_cppk, lus1_cppk]) },                                name: :last_year,  units: :kwh }, 
+          { data: ->{ sum_data([lue1_cppk, lug1_cppk, lus1_cppk]) },                                name: :last_year,  units: :kwh },
           {
             data: ->{ percent_change(
                                       sum_if_complete([lue1_pppk, lug1_pppk, lus1_pppk], [lue1_cppk, lug1_cppk, lus1_cppk]),
@@ -269,7 +270,7 @@ module Benchmarking
 
           # CO2
           { data: ->{ sum_if_complete([lue1_pppc, lug1_pppc, lus1_pppc], [lue1_cppc, lug1_cppc, lus1_cppc]) }, name: :previous_year, units: :co2 },
-          { data: ->{ sum_data([lue1_cppc, lug1_cppc, lus1_cppc]) },                                name: :last_year,  units: :co2 }, 
+          { data: ->{ sum_data([lue1_cppc, lug1_cppc, lus1_cppc]) },                                name: :last_year,  units: :co2 },
           {
             data: ->{ percent_change(
                                       sum_if_complete([lue1_pppc, lug1_pppc, lus1_pppc], [lue1_cppc, lug1_cppc, lus1_cppc]),
@@ -282,7 +283,7 @@ module Benchmarking
           # £
 
           { data: ->{ sum_if_complete([lue1_ppp£, lug1_ppp£, lus1_ppp£], [lue1_cpp£, lug1_cpp£, lus1_cpp£]) }, name: :previous_year, units: :£ },
-          { data: ->{ sum_data([lue1_cpp£, lug1_cpp£, lus1_cpp£]) },                                name: :last_year,  units: :£ }, 
+          { data: ->{ sum_data([lue1_cpp£, lug1_cpp£, lus1_cpp£]) },                                name: :last_year,  units: :£ },
           {
             data: ->{ percent_change(
                                       sum_if_complete([lue1_ppp£, lug1_ppp£, lus1_ppp£], [lue1_cpp£, lug1_cpp£, lus1_cpp£]),
@@ -327,7 +328,7 @@ module Benchmarking
           # kWh
 
           { data: ->{ sum_if_complete([a22e_pppk, a22g_pppk, a22s_pppk], [a22e_cppk, a22g_cppk, a22s_cppk]) }, name: :previous_year, units: :kwh },
-          { data: ->{ sum_data([a22e_cppk, a22g_cppk, a22s_cppk]) },                                name: :last_year,  units: :kwh }, 
+          { data: ->{ sum_data([a22e_cppk, a22g_cppk, a22s_cppk]) },                                name: :last_year,  units: :kwh },
           {
             data: ->{ percent_change(
                                       sum_if_complete([a22e_pppk, a22g_pppk, a22s_pppk], [a22e_cppk, a22g_cppk, a22s_cppk]),
@@ -339,7 +340,7 @@ module Benchmarking
 
           # CO2
           { data: ->{ sum_if_complete([a22e_pppc, a22g_pppc, a22s_pppc], [a22e_cppc, a22g_cppc, a22s_cppc]) }, name: :previous_year, units: :co2 },
-          { data: ->{ sum_data([a22e_cppc, a22g_cppc, a22s_cppc]) },                                name: :last_year,  units: :co2 }, 
+          { data: ->{ sum_data([a22e_cppc, a22g_cppc, a22s_cppc]) },                                name: :last_year,  units: :co2 },
           {
             data: ->{ percent_change(
                                       sum_if_complete([a22e_pppc, a22g_pppc, a22s_pppc], [a22e_cppc, a22g_cppc, a22s_cppc]),
@@ -352,7 +353,7 @@ module Benchmarking
           # £
 
           { data: ->{ sum_if_complete([a22e_ppp£, a22g_ppp£, a22s_ppp£], [a22e_cpp£, a22g_cpp£, a22s_cpp£]) }, name: :previous_year, units: :£ },
-          { data: ->{ sum_data([a22e_cpp£, a22g_cpp£, a22s_cpp£]) },                                name: :last_year,  units: :£ }, 
+          { data: ->{ sum_data([a22e_cpp£, a22g_cpp£, a22s_cpp£]) },                                name: :last_year,  units: :£ },
           {
             data: ->{ percent_change(
                                       sum_if_complete([a22e_ppp£, a22g_ppp£, a22s_ppp£], [a22e_cpp£, a22g_cpp£, a22s_cpp£]),
@@ -398,7 +399,7 @@ module Benchmarking
           # kWh
 
           { data: ->{ sum_if_complete([s22e_pppk, s22g_pppk, s22s_pppk], [s22e_cppk, s22g_cppk, s22s_cppk]) }, name: :previous_year, units: :kwh },
-          { data: ->{ sum_data([s22e_cppk, s22g_cppk, s22s_cppk]) },                                name: :last_year,  units: :kwh }, 
+          { data: ->{ sum_data([s22e_cppk, s22g_cppk, s22s_cppk]) },                                name: :last_year,  units: :kwh },
           {
             data: ->{ percent_change(
                                       sum_if_complete([s22e_pppk, s22g_pppk, s22s_pppk], [s22e_cppk, s22g_cppk, s22s_cppk]),
@@ -410,7 +411,7 @@ module Benchmarking
 
           # CO2
           { data: ->{ sum_if_complete([s22e_pppc, s22g_pppc, s22s_pppc], [s22e_cppc, s22g_cppc, s22s_cppc]) }, name: :previous_year, units: :co2 },
-          { data: ->{ sum_data([s22e_cppc, s22g_cppc, s22s_cppc]) },                                name: :last_year,  units: :co2 }, 
+          { data: ->{ sum_data([s22e_cppc, s22g_cppc, s22s_cppc]) },                                name: :last_year,  units: :co2 },
           {
             data: ->{ percent_change(
                                       sum_if_complete([s22e_pppc, s22g_pppc, s22s_pppc], [s22e_cppc, s22g_cppc, s22s_cppc]),
@@ -423,7 +424,7 @@ module Benchmarking
           # £
 
           { data: ->{ sum_if_complete([s22e_ppp£, s22g_ppp£, s22s_ppp£], [s22e_cpp£, s22g_cpp£, s22s_cpp£]) }, name: :previous_year, units: :£ },
-          { data: ->{ sum_data([s22e_cpp£, s22g_cpp£, s22s_cpp£]) },                                name: :last_year,  units: :£ }, 
+          { data: ->{ sum_data([s22e_cpp£, s22g_cpp£, s22s_cpp£]) },                                name: :last_year,  units: :£ },
           {
             data: ->{ percent_change(
                                       sum_if_complete([s22e_ppp£, s22g_ppp£, s22s_ppp£], [s22e_cpp£, s22g_cpp£, s22s_cpp£]),
@@ -465,7 +466,7 @@ module Benchmarking
         name:     'Change in energy use since last year',
         columns:  [
           { data: 'addp_name',              name: :name, units: :short_school_name, chart_data: true, content_class: AdviceBenchmark },
-          { data: ->{ sum_if_complete([enba_ken, enba_kgn, enba_khn, enba_ksn], 
+          { data: ->{ sum_if_complete([enba_ken, enba_kgn, enba_khn, enba_ksn],
                                       [enba_ke0, enba_kg0, enba_kh0, enba_ks0]) }, name: :previous_year, units: :kwh },
           { data: ->{ sum_data([enba_ke0, enba_kg0, enba_kh0, enba_ks0]) }, name: :last_year, units: :kwh },
           { data: ->{ percent_change(
@@ -480,7 +481,7 @@ module Benchmarking
                     name: :change_pct, units: :relative_percent_0dp
           },
 
-          { data: ->{ sum_if_complete([enba_cen, enba_cgn, enba_chn, enba_csn], 
+          { data: ->{ sum_if_complete([enba_cen, enba_cgn, enba_chn, enba_csn],
                                       [enba_ce0, enba_cg0, enba_ch0, enba_cs0]) }, name: :previous_year, units: :co2 },
           { data: ->{ sum_data([enba_ce0, enba_cg0, enba_ch0, enba_cs0]) }, name: :last_year, units: :co2 },
           { data: ->{ percent_change(
@@ -495,7 +496,7 @@ module Benchmarking
                     name: :change_pct, units: :relative_percent_0dp
           },
 
-          { data: ->{ sum_if_complete([enba_pen, enba_pgn, enba_phn, enba_psn], 
+          { data: ->{ sum_if_complete([enba_pen, enba_pgn, enba_phn, enba_psn],
                                       [enba_pe0, enba_pg0, enba_ph0, enba_ps0]) }, name: :previous_year, units: :£ },
           { data: ->{ sum_data([enba_pe0, enba_pg0, enba_ph0, enba_ps0]) }, name: :last_year, units: :£ },
           { data: ->{ percent_change(
@@ -510,7 +511,7 @@ module Benchmarking
                     name: :change_pct, units: :relative_percent_0dp
           },
           {
-            data: ->{ 
+            data: ->{
               [
                 enba_pe0.nil?     ? nil : 'E',
                 enba_pg0.nil?     ? nil : 'G',
@@ -520,8 +521,8 @@ module Benchmarking
             },
             name: :fuel, units: String
           },
-          { 
-            data: ->{ 
+          {
+            data: ->{
               (enba_peap == ManagementSummaryTable::NO_RECENT_DATA_MESSAGE ||
                enba_pgap == ManagementSummaryTable::NO_RECENT_DATA_MESSAGE) ? 'Y' : ''
              },
@@ -639,7 +640,7 @@ module Benchmarking
         type: %i[table],
         drilldown:  { type: :adult_dashboard, content_class: AdviceStorageHeaters },
         admin_only: false,
-        column_heading_explanation: :last_year_previous_year_definition_html             
+        column_heading_explanation: :last_year_previous_year_definition_html
       },
       change_in_solar_pv_since_last_year: {
         benchmark_class:  BenchmarkChangeInSolarPVSinceLastYear,
@@ -683,7 +684,7 @@ module Benchmarking
         sort_by:  [1], # column 1 i.e. Annual kWh
         type: %i[table],
         admin_only: false,
-        column_heading_explanation: :last_year_definition_html        
+        column_heading_explanation: :last_year_definition_html
       },
       electricity_targets: {
         benchmark_class:  BenchmarkElectricityTarget,
@@ -832,7 +833,7 @@ module Benchmarking
         where:   ->{ !sole_opvk.nil? },
         sort_by: [1],
         type: %i[table],
-        admin_only: false        
+        admin_only: false
       },
       annual_heating_costs_per_floor_area: {
         benchmark_class:  BenchmarkContentHeatingPerFloorArea,
@@ -1181,17 +1182,17 @@ module Benchmarking
 
           # kWh
           { data: ->{ a22e_pppk }, name: :previous_year, units: :kwh },
-          { data: ->{ a22e_cppk }, name: :last_year,  units: :kwh }, 
+          { data: ->{ a22e_cppk }, name: :last_year,  units: :kwh },
           { data: ->{ percent_change(a22e_pppk, a22e_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # CO2
           { data: ->{ a22e_pppc }, name: :previous_year, units: :co2 },
-          { data: ->{ a22e_cppc }, name: :last_year,  units: :co2 }, 
+          { data: ->{ a22e_cppc }, name: :last_year,  units: :co2 },
           { data: ->{ percent_change(a22e_pppc, a22e_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # £
           { data: ->{ a22e_ppp£ }, name: :previous_year, units: :£ },
-          { data: ->{ a22e_cpp£ }, name: :last_year,  units: :£ }, 
+          { data: ->{ a22e_cpp£ }, name: :last_year,  units: :£ },
           { data: ->{ percent_change(a22e_ppp£, a22e_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           TARIFF_CHANGED_COL
@@ -1217,17 +1218,17 @@ module Benchmarking
           # kWh
           { data: ->{ a22g_pppu }, name: :previous_year_temperature_unadjusted, units: :kwh },
           { data: ->{ a22g_pppk }, name: :previous_year_temperature_adjusted, units: :kwh },
-          { data: ->{ a22g_cppk }, name: :last_year,  units: :kwh }, 
+          { data: ->{ a22g_cppk }, name: :last_year,  units: :kwh },
           { data: ->{ percent_change(a22g_pppk, a22g_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # CO2
           { data: ->{ a22g_pppc }, name: :previous_year, units: :co2 },
-          { data: ->{ a22g_cppc }, name: :last_year,  units: :co2 }, 
+          { data: ->{ a22g_cppc }, name: :last_year,  units: :co2 },
           { data: ->{ percent_change(a22g_pppc, a22g_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # £
           { data: ->{ a22g_ppp£ }, name: :previous_year, units: :£ },
-          { data: ->{ a22g_cpp£ }, name: :last_year,  units: :£ }, 
+          { data: ->{ a22g_cpp£ }, name: :last_year,  units: :£ },
           { data: ->{ percent_change(a22g_ppp£, a22g_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           TARIFF_CHANGED_COL
@@ -1253,17 +1254,17 @@ module Benchmarking
           # kWh
           { data: ->{ a22s_pppu }, name: :previous_year_temperature_unadjusted, units: :kwh },
           { data: ->{ a22s_pppk }, name: :previous_year_temperature_adjusted, units: :kwh },
-          { data: ->{ a22s_cppk }, name: :last_year,  units: :kwh }, 
+          { data: ->{ a22s_cppk }, name: :last_year,  units: :kwh },
           { data: ->{ percent_change(a22s_pppk, a22s_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # CO2
           { data: ->{ a22s_pppc }, name: :previous_year, units: :co2 },
-          { data: ->{ a22s_cppc }, name: :last_year,  units: :co2 }, 
+          { data: ->{ a22s_cppc }, name: :last_year,  units: :co2 },
           { data: ->{ percent_change(a22s_pppc, a22s_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # £
           { data: ->{ a22s_ppp£ }, name: :previous_year, units: :£ },
-          { data: ->{ a22s_cpp£ }, name: :last_year,  units: :£ }, 
+          { data: ->{ a22s_cpp£ }, name: :last_year,  units: :£ },
           { data: ->{ percent_change(a22s_ppp£, a22s_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           TARIFF_CHANGED_COL
@@ -1288,17 +1289,17 @@ module Benchmarking
 
           # kWh
           { data: ->{ lue1_pppk }, name: :previous_year, units: :kwh },
-          { data: ->{ lue1_cppk }, name: :last_year,  units: :kwh }, 
+          { data: ->{ lue1_cppk }, name: :last_year,  units: :kwh },
           { data: ->{ percent_change(lue1_pppk, lue1_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # CO2
           { data: ->{ lue1_pppc }, name: :previous_year, units: :co2 },
-          { data: ->{ lue1_cppc }, name: :last_year,  units: :co2 }, 
+          { data: ->{ lue1_cppc }, name: :last_year,  units: :co2 },
           { data: ->{ percent_change(lue1_pppc, lue1_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # £
           { data: ->{ lue1_ppp£ }, name: :previous_year, units: :£ },
-          { data: ->{ lue1_cpp£ }, name: :last_year,  units: :£ }, 
+          { data: ->{ lue1_cpp£ }, name: :last_year,  units: :£ },
           { data: ->{ percent_change(lue1_ppp£, lue1_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
 
         ],
@@ -1323,17 +1324,17 @@ module Benchmarking
           # kWh
           { data: ->{ lug1_pppu }, name: :previous_year_temperature_unadjusted, units: :kwh },
           { data: ->{ lug1_pppk }, name: :previous_year_temperature_adjusted, units: :kwh },
-          { data: ->{ lug1_cppk }, name: :last_year,  units: :kwh }, 
+          { data: ->{ lug1_cppk }, name: :last_year,  units: :kwh },
           { data: ->{ percent_change(lug1_pppk, lug1_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # CO2
           { data: ->{ lug1_pppc }, name: :previous_year, units: :co2 },
-          { data: ->{ lug1_cppc }, name: :last_year,  units: :co2 }, 
+          { data: ->{ lug1_cppc }, name: :last_year,  units: :co2 },
           { data: ->{ percent_change(lug1_pppc, lug1_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # £
           { data: ->{ lug1_ppp£ }, name: :previous_year, units: :£ },
-          { data: ->{ lug1_cpp£ }, name: :last_year,  units: :£ }, 
+          { data: ->{ lug1_cpp£ }, name: :last_year,  units: :£ },
           { data: ->{ percent_change(lug1_ppp£, lug1_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
 
         ],
@@ -1346,7 +1347,7 @@ module Benchmarking
         where:   ->{ !lug1_ppp£.nil? },
         sort_by:  [9],
         type: %i[table],
-        admin_only: true        
+        admin_only: true
       },
       layer_up_powerdown_day_november_2022_storage_heater_table: {
         benchmark_class:  BenchmarkChangeAdhocComparisonStorageHeaterTable,
@@ -1358,17 +1359,17 @@ module Benchmarking
           # kWh
           { data: ->{ lus1_pppu }, name: :previous_year_temperature_unadjusted, units: :kwh },
           { data: ->{ lus1_pppk }, name: :previous_year_temperature_adjusted, units: :kwh },
-          { data: ->{ lus1_cppk }, name: :last_year,  units: :kwh }, 
+          { data: ->{ lus1_cppk }, name: :last_year,  units: :kwh },
           { data: ->{ percent_change(lus1_pppk, lus1_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # CO2
           { data: ->{ lus1_pppc }, name: :previous_year, units: :co2 },
-          { data: ->{ lus1_cppc }, name: :last_year,  units: :co2 }, 
+          { data: ->{ lus1_cppc }, name: :last_year,  units: :co2 },
           { data: ->{ percent_change(lus1_pppc, lus1_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # £
           { data: ->{ lus1_ppp£ }, name: :previous_year, units: :£ },
-          { data: ->{ lus1_cpp£ }, name: :last_year,  units: :£ }, 
+          { data: ->{ lus1_cpp£ }, name: :last_year,  units: :£ },
           { data: ->{ percent_change(lus1_ppp£, lus1_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
 
         ],
@@ -1381,7 +1382,7 @@ module Benchmarking
         where:   ->{ !lus1_ppp£.nil? },
         sort_by:  [9],
         type: %i[table],
-        admin_only: true        
+        admin_only: true
       },
 
 
@@ -1452,17 +1453,17 @@ module Benchmarking
 
           # kWh
           { data: ->{ s22e_pppk }, name: :previous_year, units: :kwh },
-          { data: ->{ s22e_cppk }, name: :last_year,  units: :kwh }, 
+          { data: ->{ s22e_cppk }, name: :last_year,  units: :kwh },
           { data: ->{ percent_change(s22e_pppk, s22e_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # CO2
           { data: ->{ s22e_pppc }, name: :previous_year, units: :co2 },
-          { data: ->{ s22e_cppc }, name: :last_year,  units: :co2 }, 
+          { data: ->{ s22e_cppc }, name: :last_year,  units: :co2 },
           { data: ->{ percent_change(s22e_pppc, s22e_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # £
           { data: ->{ s22e_ppp£ }, name: :previous_year, units: :£ },
-          { data: ->{ s22e_cpp£ }, name: :last_year,  units: :£ }, 
+          { data: ->{ s22e_cpp£ }, name: :last_year,  units: :£ },
           { data: ->{ percent_change(s22e_ppp£, s22e_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           TARIFF_CHANGED_COL
@@ -1488,17 +1489,17 @@ module Benchmarking
           # kWh
           { data: ->{ s22g_pppu }, name: :previous_year_temperature_unadjusted, units: :kwh },
           { data: ->{ s22g_pppk }, name: :previous_year_temperature_adjusted, units: :kwh },
-          { data: ->{ s22g_cppk }, name: :last_year,  units: :kwh }, 
+          { data: ->{ s22g_cppk }, name: :last_year,  units: :kwh },
           { data: ->{ percent_change(s22g_pppk, s22g_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # CO2
           { data: ->{ s22g_pppc }, name: :previous_year, units: :co2 },
-          { data: ->{ s22g_cppc }, name: :last_year,  units: :co2 }, 
+          { data: ->{ s22g_cppc }, name: :last_year,  units: :co2 },
           { data: ->{ percent_change(s22g_pppc, s22g_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # £
           { data: ->{ s22g_ppp£ }, name: :previous_year, units: :£ },
-          { data: ->{ s22g_cpp£ }, name: :last_year,  units: :£ }, 
+          { data: ->{ s22g_cpp£ }, name: :last_year,  units: :£ },
           { data: ->{ percent_change(s22g_ppp£, s22g_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           TARIFF_CHANGED_COL
@@ -1524,17 +1525,17 @@ module Benchmarking
           # kWh
           { data: ->{ s22s_pppu }, name: :previous_year_temperature_unadjusted, units: :kwh },
           { data: ->{ s22s_pppk }, name: :previous_year_temperature_adjusted, units: :kwh },
-          { data: ->{ s22s_cppk }, name: :last_year,  units: :kwh }, 
+          { data: ->{ s22s_cppk }, name: :last_year,  units: :kwh },
           { data: ->{ percent_change(s22s_pppk, s22s_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # CO2
           { data: ->{ s22s_pppc }, name: :previous_year, units: :co2 },
-          { data: ->{ s22s_cppc }, name: :last_year,  units: :co2 }, 
+          { data: ->{ s22s_cppc }, name: :last_year,  units: :co2 },
           { data: ->{ percent_change(s22s_pppc, s22s_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           # £
           { data: ->{ s22s_ppp£ }, name: :previous_year, units: :£ },
-          { data: ->{ s22s_cpp£ }, name: :last_year,  units: :£ }, 
+          { data: ->{ s22s_cpp£ }, name: :last_year,  units: :£ },
           { data: ->{ percent_change(s22s_ppp£, s22s_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           TARIFF_CHANGED_COL
@@ -1546,6 +1547,183 @@ module Benchmarking
           { name: :cost,     span: 3 }
         ],
         where:   ->{ !s22s_ppp£.nil? },
+        sort_by:  [9],
+        type: %i[table],
+        admin_only: true
+      },
+      easter_shutdown_2023_energy_comparison: {
+        benchmark_class:  BenchmarkEaster2023ShutdownComparison,
+        name:       'Easter shutdown 2023 energy use comparison',
+        columns:  [
+          tariff_changed_school_name,
+
+          # kWh
+
+          { data: ->{ sum_if_complete([e23e_pppk, e23g_pppk, e23s_pppk], [e23e_cppk, e23g_cppk, e23s_cppk]) }, name: :last_school_week, units: :kwh },
+          { data: ->{ sum_data([e23e_cppk, e23g_cppk, e23s_cppk]) },                                name: :holiday,  units: :kwh },
+          {
+            data: ->{ percent_change(
+                                      sum_if_complete([e23e_pppk, e23g_pppk, e23s_pppk], [e23e_cppk, e23g_cppk, e23s_cppk]),
+                                      sum_data([e23e_cppk, e23g_cppk, e23s_cppk]),
+                                      true
+                                    ) },
+            name: :change_pct, units: :relative_percent_0dp
+          },
+
+          # CO2
+          { data: ->{ sum_if_complete([e23e_pppc, e23g_pppc, s22s_pppc], [e23e_cppc, e23g_cppc, e23s_cppc]) }, name: :last_school_week, units: :co2 },
+          { data: ->{ sum_data([e23e_cppc, e23g_cppc, e23s_cppc]) },                                name: :holiday,  units: :co2 },
+          {
+            data: ->{ percent_change(
+                                      sum_if_complete([e23e_pppc, e23g_pppc, e23s_pppc], [e23e_cppc, e23g_cppc, e23s_cppc]),
+                                      sum_data([e23e_cppc, e23g_cppc, e23s_cppc]),
+                                      true
+                                    ) },
+            name: :change_pct, units: :relative_percent_0dp
+          },
+
+          # £
+
+          { data: ->{ sum_if_complete([e23e_ppp£, e23g_ppp£, e23s_ppp£], [e23e_cpp£, e23g_cpp£, e23s_cpp£]) }, name: :last_school_week, units: :£ },
+          { data: ->{ sum_data([e23e_cpp£, e23g_cpp£, e23s_cpp£]) },                                name: :holiday,  units: :£ },
+          {
+            data: ->{ percent_change(
+                                      sum_if_complete([e23e_ppp£, e23g_ppp£, e23s_ppp£], [e23e_cpp£, e23g_cpp£, e23s_cpp£]),
+                                      sum_data([e23e_cpp£, e23g_cpp£, e23s_cpp£]),
+                                      true
+                                    ) },
+            name: :change_£, units: :relative_percent_0dp, chart_data: true
+          },
+
+          # Metering
+
+          { data: ->{
+              [
+                e23e_ppp£.nil? ? nil : :electricity,
+                e23g_ppp£.nil? ? nil : :gas,
+                e23s_ppp£.nil? ? nil : :storage_heaters
+              ].compact.join(', ')
+            },
+            name: :metering,
+            units: String
+          },
+          TARIFF_CHANGED_COL
+        ],
+        column_groups: [
+          { name: '',         span: 1 },
+          { name: :kwh,      span: 3 },
+          { name: :co2_kg, span: 3 },
+          { name: :cost,     span: 3 },
+          { name: '',         span: 1 }
+        ],
+        where:   ->{ !sum_data([e23e_ppp£, e23g_ppp£, e23s_ppp£], true).nil? },
+        sort_by:  [9],
+        type: %i[table],
+        admin_only: true
+      },
+      easter_shutdown_2023_electricity_table: {
+        benchmark_class:  BenchmarkEasterShutdown2023ElectricityTable,
+        filter_out:     :dont_make_available_directly,
+        name:       'Easter shutdown 2023 electricity use comparison',
+        columns:  [
+          tariff_changed_school_name,
+
+          # kWh
+          { data: ->{ e23e_pppk }, name: :last_school_week, units: :kwh },
+          { data: ->{ e23e_cppk }, name: :holiday,  units: :kwh },
+          { data: ->{ percent_change(e23e_pppk, e23e_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          # CO2
+          { data: ->{ e23e_pppc }, name: :last_school_week, units: :co2 },
+          { data: ->{ e23e_cppc }, name: :holiday,  units: :co2 },
+          { data: ->{ percent_change(e23e_pppc, e23e_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          # £
+          { data: ->{ e23e_ppp£ }, name: :last_school_week, units: :£ },
+          { data: ->{ e23e_cpp£ }, name: :holiday,  units: :£ },
+          { data: ->{ percent_change(e23e_ppp£, e23e_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          TARIFF_CHANGED_COL
+        ],
+        column_groups: [
+          { name: '',         span: 1 },
+          { name: :kwh,      span: 3 },
+          { name: :co2_kg, span: 3 },
+          { name: :cost,     span: 3 }
+        ],
+        where:   ->{ !e23e_ppp£.nil? },
+        sort_by:  [9],
+        type: %i[table],
+        admin_only: true
+      },
+      easter_shutdown_2023_gas_table: {
+        benchmark_class:  BenchmarkEasterShutdown2023GasTable,
+        filter_out:     :dont_make_available_directly,
+        name:       'Easter shutdown 2023 gas use comparison',
+        columns:  [
+          tariff_changed_school_name,
+
+          # kWh
+          { data: ->{ e23g_pppu }, name: :last_school_week_temperature_unadjusted, units: :kwh },
+          { data: ->{ e23g_pppk }, name: :last_school_week_temperature_adjusted, units: :kwh },
+          { data: ->{ e23g_cppk }, name: :holiday,  units: :kwh },
+          { data: ->{ percent_change(e23g_pppk, e23g_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          # CO2
+          { data: ->{ e23g_pppc }, name: :last_school_week, units: :co2 },
+          { data: ->{ e23g_cppc }, name: :holiday,  units: :co2 },
+          { data: ->{ percent_change(e23g_pppc, e23g_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          # £
+          { data: ->{ e23g_ppp£ }, name: :last_school_week, units: :£ },
+          { data: ->{ e23g_cpp£ }, name: :holiday,  units: :£ },
+          { data: ->{ percent_change(e23g_ppp£, e23g_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          TARIFF_CHANGED_COL
+        ],
+        column_groups: [
+          { name: '',         span: 1 },
+          { name: :kwh,      span: 4 },
+          { name: :co2_kg, span: 3 },
+          { name: :cost,     span: 3 }
+        ],
+        where:   ->{ !e23g_ppp£.nil? },
+        sort_by:  [9],
+        type: %i[table],
+        admin_only: true
+      },
+      easter_shutdown_2023_storage_heater_table: {
+        benchmark_class:  BenchmarkEasterShutdown2023StorageHeaterTable,
+        filter_out:     :dont_make_available_directly,
+        name:       'Easter shutdown 2023 storage heater use comparison',
+        columns:  [
+          tariff_changed_school_name,
+
+          # kWh
+          { data: ->{ e23s_pppu }, name: :last_school_week_temperature_unadjusted, units: :kwh },
+          { data: ->{ e23s_pppk }, name: :last_school_week_temperature_adjusted, units: :kwh },
+          { data: ->{ e23s_cppk }, name: :holiday,  units: :kwh },
+          { data: ->{ percent_change(e23s_pppk, e23s_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          # CO2
+          { data: ->{ e23s_pppc }, name: :last_school_week, units: :co2 },
+          { data: ->{ e23s_cppc }, name: :holiday,  units: :co2 },
+          { data: ->{ percent_change(e23s_pppc, s22s_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          # £
+          { data: ->{ e23s_ppp£ }, name: :last_school_week, units: :£ },
+          { data: ->{ e23s_cpp£ }, name: :holiday,  units: :£ },
+          { data: ->{ percent_change(e23s_ppp£, e23s_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          TARIFF_CHANGED_COL
+        ],
+        column_groups: [
+          { name: '',         span: 1 },
+          { name: :kwh,      span: 4 },
+          { name: :co2_kg, span: 3 },
+          { name: :cost,     span: 3 }
+        ],
+        where:   ->{ !e23s_ppp£.nil? },
         sort_by:  [9],
         type: %i[table],
         admin_only: true

--- a/lib/dashboard/benchmarking/benchmark_content_general.rb
+++ b/lib/dashboard/benchmarking/benchmark_content_general.rb
@@ -38,7 +38,7 @@ module Benchmarking
       text =  I18n.t('analytics.benchmarking.content.change_in_energy_use_since_joined_full_data.introduction_text_html')
       ERB.new(text).result(binding)
     end
-  end  
+  end
   #=======================================================================================
   class BenchmarkContentTotalAnnualEnergy < BenchmarkContentBase
     include BenchmarkingNoTextMixin
@@ -69,7 +69,7 @@ module Benchmarking
     end
   end
   #=======================================================================================
-  class BenchmarkBaseloadBase < BenchmarkContentBase   
+  class BenchmarkBaseloadBase < BenchmarkContentBase
     def content(school_ids: nil, filter: nil, user_type: nil)
       @baseload_impact_html = baseload_1_kw_change_range_£_html(school_ids, filter, user_type)
       super(school_ids: school_ids, filter: filter)
@@ -141,7 +141,7 @@ module Benchmarking
     #=======================================================================================
     class BenchmarkGasTarget < BenchmarkContentBase
       include BenchmarkingNoTextMixin
-  
+
       private def introduction_text
         text = I18n.t('analytics.benchmarking.content.gas_targets.introduction_text_html')
         ERB.new(text).result(binding)
@@ -183,7 +183,7 @@ module Benchmarking
     include BenchmarkingNoTextMixin
     private def introduction_text
       text = I18n.t('analytics.benchmarking.content.electricity_peak_kw_per_pupil.introduction_text_html')
-      ERB.new(text).result(binding)      
+      ERB.new(text).result(binding)
     end
   end
     #=======================================================================================
@@ -191,7 +191,7 @@ module Benchmarking
       include BenchmarkingNoTextMixin
       private def introduction_text
         text = I18n.t('analytics.benchmarking.content.solar_pv_benefit_estimate.introduction_text_html')
-        ERB.new(text).result(binding)      
+        ERB.new(text).result(binding)
       end
     end
     #=======================================================================================
@@ -313,7 +313,7 @@ module Benchmarking
   #=======================================================================================
   # shared wording save some translation costs
   class BenchmarkAnnualChangeBase < BenchmarkContentBase
-  end 
+  end
   #=======================================================================================
   class BenchmarkChangeInEnergySinceLastYear < BenchmarkAnnualChangeBase
     include BenchmarkingNoTextMixin
@@ -472,7 +472,7 @@ module Benchmarking
       text = '<p>' + I18n.t('analytics.benchmarking.content.footnotes.notes') + ':<ul>'
 
       if floor_area_or_pupils_change_rows.present?
-        text += change_rows_text(floor_area_or_pupils_change_rows.map { |row| school_name(row) }.sort.to_sentence, period_types) 
+        text += change_rows_text(floor_area_or_pupils_change_rows.map { |row| school_name(row) }.sort.to_sentence, period_types)
       end
 
       if infinite_increase_school_names.present?
@@ -693,7 +693,7 @@ module Benchmarking
     def storage_heater_content(school_ids:, filter:)
       extra_content(:layer_up_powerdown_day_november_2022_storage_heater_table, filter: filter)
     end
-    
+
     def extra_content(type, filter:)
       content_manager = Benchmarking::BenchmarkContentManager.new(@asof_date)
       db = @benchmark_manager.benchmark_database
@@ -721,11 +721,11 @@ module Benchmarking
     def electricity_content(school_ids:, filter:)
       extra_content(:autumn_term_2021_2022_electricity_table, filter: filter)
     end
-  
+
     def gas_content(school_ids:, filter:)
       extra_content(:autumn_term_2021_2022_gas_table, filter: filter)
     end
-  
+
     def storage_heater_content(school_ids:, filter:)
       extra_content(:autumn_term_2021_2022_storage_heater_table, filter: filter)
     end
@@ -753,11 +753,11 @@ module Benchmarking
     def electricity_content(school_ids:, filter:)
       extra_content(:sept_nov_2021_2022_electricity_table, filter: filter)
     end
-  
+
     def gas_content(school_ids:, filter:)
       extra_content(:sept_nov_2021_2022_gas_table, filter: filter)
     end
-  
+
     def storage_heater_content(school_ids:, filter:)
       extra_content(:sept_nov_2021_2022_storage_heater_table, filter: filter)
     end
@@ -778,4 +778,37 @@ module Benchmarking
   class BenchmarkSeptNov2022StorageHeaterTable < BenchmarkChangeAdhocComparisonGasTable
     include BenchmarkingNoTextMixin
   end
+
+  #=======================================================================================
+  class BenchmarkEaster2023ShutdownComparison < BenchmarkChangeAdhocComparison
+
+    def electricity_content(school_ids:, filter:)
+      extra_content(:easter_shutdown_2023_electricity_table, filter: filter)
+    end
+
+    def gas_content(school_ids:, filter:)
+      extra_content(:easter_shutdown_2023_gas_table, filter: filter)
+    end
+
+    def storage_heater_content(school_ids:, filter:)
+      extra_content(:easter_shutdown_2023_storage_heater_table, filter: filter)
+    end
+  end
+
+  class BenchmarkEasterShutdown2023ElectricityTable < BenchmarkContentBase
+    include BenchmarkingNoTextMixin
+  end
+
+  class BenchmarkEasterShutdown2023GasTable < BenchmarkContentBase
+    include BenchmarkingNoTextMixin
+
+    private def introduction_text
+      I18n.t('analytics.benchmarking.content.benchmark_sept_nov_2022_gas_table.introduction_text')
+    end
+  end
+
+  class BenchmarkEasterShutdown2023StorageHeaterTable < BenchmarkChangeAdhocComparisonGasTable
+    include BenchmarkingNoTextMixin
+  end
+
 end

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -7,8 +7,8 @@ module Logging
   logger.level = :debug
 end
 
-asof_date = Date.new(2021, 1, 3)
-schools = ['acme*']
+asof_date = Date.new(2023, 4, 12)
+schools = ['k*']
 
 overrides = {
   schools:  schools,
@@ -33,8 +33,11 @@ overrides = {
     #AlertGasAnnualVersusBenchmark,
     #AlertGasLongTermTrend
     # AlertChangeInElectricityBaseloadShortTerm
-    AlertPreviousYearHolidayComparisonElectricity,
-    AlertPreviousHolidayComparisonElectricity
+    #AlertPreviousYearHolidayComparisonElectricity,
+    #AlertPreviousHolidayComparisonElectricity,
+    #AlertLayerUpPowerdown11November2022ElectricityComparison,
+    AlertEaster2023ShutdownElectricityComparison,
+    AlertEaster2023ShutdownGasComparison
     ],
   control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving html_template_variables], log: [:invalid_alerts] } },
   no_alerts:   { alerts: [], control: { asof_date: asof_date } }

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -37,7 +37,8 @@ overrides = {
     #AlertPreviousHolidayComparisonElectricity,
     #AlertLayerUpPowerdown11November2022ElectricityComparison,
     AlertEaster2023ShutdownElectricityComparison,
-    AlertEaster2023ShutdownGasComparison
+    AlertEaster2023ShutdownGasComparison,
+    AlertEaster2023ShutdownStorageHeaterComparison
     ],
   control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving html_template_variables], log: [:invalid_alerts] } },
   no_alerts:   { alerts: [], control: { asof_date: asof_date } }

--- a/script/standard/test_benchmarks.rb
+++ b/script/standard/test_benchmarks.rb
@@ -8,16 +8,16 @@ module Logging
   logger.level = :error
 end
 
-run_date = Date.new(2022, 11, 5)
+run_date = Date.new(2023, 4, 12)
 
-overrides = { 
+overrides = {
   schools: ['*'], # ['king-ja*', 'crook*', 'hunw*', 'combe*'], # ['king-james-e*', 'wyb*', 'batheas*', 'the-dur*'], # ['shrew*', 'bathamp*'],
   cache_school: false,
   benchmarks: {
-    calculate_and_save_variables: false,
+    calculate_and_save_variables: true,
     asof_date: run_date,
     pages: %i[
-      baseload_per_pupil
+      easter_shutdown_2023_energy_comparison
     ],
     run_content: { asof_date: run_date } # , filter: ->{ !gpyc_difp.nil? && !gpyc_difp.infinite?.nil? } }
   }

--- a/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
+++ b/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
@@ -75,7 +75,8 @@ describe Benchmarking::BenchmarkManager, type: :service do
               autumn_term_2021_2022_energy_comparison: 'Autumn Term 2021 versus 2022 energy use',
               change_in_energy_use_since_joined_energy_sparks: 'Change in energy use since the school joined Energy Sparks',
               layer_up_powerdown_day_november_2022: 'Change in energy for layer up power down day 11 November 2022 (compared with 12 Nov 2021)',
-              sept_nov_2021_2022_energy_comparison: 'September to November 2021 versus 2022 energy use'
+              sept_nov_2021_2022_energy_comparison: 'September to November 2021 versus 2022 energy use',
+              easter_shutdown_2023_energy_comparison: 'Easter shutdown 2023 comparison'
             }
           }
         ]
@@ -152,7 +153,8 @@ describe Benchmarking::BenchmarkManager, type: :service do
               autumn_term_2021_2022_energy_comparison: 'Autumn Term 2021 versus 2022 energy use',
               change_in_energy_use_since_joined_energy_sparks: 'Change in energy use since the school joined Energy Sparks',
               layer_up_powerdown_day_november_2022: 'Change in energy for layer up power down day 11 November 2022 (compared with 12 Nov 2021)',
-              sept_nov_2021_2022_energy_comparison: 'September to November 2021 versus 2022 energy use'
+              sept_nov_2021_2022_energy_comparison: 'September to November 2021 versus 2022 energy use',
+              easter_shutdown_2023_energy_comparison: 'Easter shutdown 2023 comparison'
             }
           }
         ]


### PR DESCRIPTION
Adds new alerts and benchmark configuration for Easter 2023 shutdown comparison. The comparison is intended to compare energy use during the easter holiday with the school week prior to the holiday

* Adds new period comparison mixin to find a holiday and previous school week (rather than using fixed dates which may not be correct across schools)
* Adds new alert classes to generate variables for gas, electricity and storage heater
* Adds new benchmark classes and configurations for comparison tables, based on previous arbitrary period comparisons

TODO:

* [x] Check correct variables are being used in tables, which currently just copy existing setup

