### PR TITLE
Further easter shutdown benchmark changes

### DIFF
--- a/config/locales/benchmarking/content_base.yml
+++ b/config/locales/benchmarking/content_base.yml
@@ -579,6 +579,25 @@ en:
           introduction_text_html: "<p>This benchmark shows the cost of electricity and gas used last year for the upcoming holidays. For example, if the next holidays are the Summer holidays 2023, the data shown will be for Summer 2022. This allows you to identify which schools in your group need to take the most action to cut holiday waste.</p>"
         hot_water_efficiency:
           introduction_text_html: "<p> This benchmark analyses the efficiency of schools' hot water systems and the potential savings from either improving the timing control of existing hot water systems or replacing it completely with point of use electric hot water systems. <p>"
+        easter_shutdown_2023_energy_comparison:
+          introduction_text_html: |-
+            <p>
+            This benchmark shows the change in energy consumption between the most recent holiday, and the last week of the previous school term.
+            </p>
+            <p>
+            This comparison compares the latest available data for the most recent holiday with an adjusted figure for the last week of the school term, scaling to the same number of days and adjusting for changes in outside temperature and the latest tariff. The change in £ is the saving or increased cost for the most recent holiday to date compared to term time consumption.
+            </p>
+            <p>
+              Schools' solar PV production has been removed from the comparison.
+            </p>
+            <p>
+              CO2 values for electricity (including where the CO2 is
+              aggregated across electricity, gas, storage heaters) is difficult
+              to compare for short periods as it is dependent on the carbon intensity
+              of the national grid on the days being compared and this could vary by up to
+              300&percnt; from day to day.
+            </p>
+
         layer_up_powerdown_day_november_2022:
           introduction_text_html: |-
             <p>

--- a/config/locales/benchmarking/content_base.yml
+++ b/config/locales/benchmarking/content_base.yml
@@ -131,7 +131,9 @@ en:
           change_in_heating_costs_between_last_2_years: Change in heating costs between last 2 years
           change_kwh: Change kWh
           change_pct: Change %
+          change_pct_co2: Change CO2 %
           change_£: Change £
+          change_co2: Change CO2
           change_£current: Change £ (latest tariff)
           co2_last_year: CO2 (last year)
           co2_previous_year: CO2 (previous year)

--- a/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
@@ -57,7 +57,7 @@ class AlertPeriodComparisonBase < AlertAnalysisBase
       difference_kwh:       { description: 'Difference in kwh between last 2 periods',      units:  { kwh: fuel_type }, benchmark_code: 'difk' },
       difference_£:         { description: 'Difference in £ between last 2 periods (using historic tariffs)',  units:  :£, benchmark_code: 'dif£'},
       difference_£current:  { description: 'Difference in £ between last 2 periods (using latest tariffs)',    units:  :£current, benchmark_code: 'dif€'},
-      difference_co2:     { description: 'Difference in co2 kg between last 2 periods', units:  :co2 },
+      difference_co2:     { description: 'Difference in co2 kg between last 2 periods', units:  :co2, benchmark_code: 'difc' },
       abs_difference_kwh: { description: 'Difference in kwh between last 2 periods - absolute',    units:  { kwh: fuel_type } },
       abs_difference_£:        { description: 'Difference in £ between last 2 periods - absolute (using historic tariffs)', units:  :£},
       abs_difference_£current: { description: 'Difference in £ between last 2 periods - absolute (using latest tariffs)',   units:  :£current},

--- a/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
@@ -548,6 +548,7 @@ class AlertHolidayComparisonBase < AlertPeriodComparisonBase
   end
 
   protected def truncate_period_to_available_meter_data(period)
+    return nil if period.nil?
     return period if period.start_date >= aggregate_meter.amr_data.start_date && period.end_date <= aggregate_meter.amr_data.end_date
     start_date = [period.start_date, aggregate_meter.amr_data.start_date].max
     end_date = [period.end_date, aggregate_meter.amr_data.end_date].min

--- a/lib/dashboard/benchmarking/benchmark_configuration.rb
+++ b/lib/dashboard/benchmarking/benchmark_configuration.rb
@@ -1558,9 +1558,10 @@ module Benchmarking
           tariff_changed_school_name,
 
           # kWh
-
-          { data: ->{ sum_if_complete([e23e_pppk, e23g_pppk, e23s_pppk], [e23e_cppk, e23g_cppk, e23s_cppk]) }, name: :last_school_week, units: :kwh },
-          { data: ->{ sum_data([e23e_cppk, e23g_cppk, e23s_cppk]) },                                name: :holiday,  units: :kwh },
+          {
+            data: ->{ sum_data([e23e_difk, e23g_difk, e23s_difk]) },
+            name: :change_kwh,  units: :kwh
+          },
           {
             data: ->{ percent_change(
                                       sum_if_complete([e23e_pppk, e23g_pppk, e23s_pppk], [e23e_cppk, e23g_cppk, e23s_cppk]),
@@ -1571,8 +1572,10 @@ module Benchmarking
           },
 
           # CO2
-          { data: ->{ sum_if_complete([e23e_pppc, e23g_pppc, s22s_pppc], [e23e_cppc, e23g_cppc, e23s_cppc]) }, name: :last_school_week, units: :co2 },
-          { data: ->{ sum_data([e23e_cppc, e23g_cppc, e23s_cppc]) },                                name: :holiday,  units: :co2 },
+          {
+            data: ->{ sum_data([e23e_cppc, e23g_cppc, e23s_cppc]) },
+            name: :change_co2,  units: :co2
+          },
           {
             data: ->{ percent_change(
                                       sum_if_complete([e23e_pppc, e23g_pppc, e23s_pppc], [e23e_cppc, e23g_cppc, e23s_cppc]),
@@ -1583,9 +1586,10 @@ module Benchmarking
           },
 
           # £
-
-          { data: ->{ sum_if_complete([e23e_ppp£, e23g_ppp£, e23s_ppp£], [e23e_cpp£, e23g_cpp£, e23s_cpp£]) }, name: :last_school_week, units: :£ },
-          { data: ->{ sum_data([e23e_cpp£, e23g_cpp£, e23s_cpp£]) },                                name: :holiday,  units: :£ },
+          {
+            data: ->{ sum_data([e23e_cpp£, e23g_cpp£, e23s_cpp£]) },
+            name: :change_£current,  units: :£
+          },
           {
             data: ->{ percent_change(
                                       sum_if_complete([e23e_ppp£, e23g_ppp£, e23s_ppp£], [e23e_cpp£, e23g_cpp£, e23s_cpp£]),
@@ -1611,13 +1615,13 @@ module Benchmarking
         ],
         column_groups: [
           { name: '',         span: 1 },
-          { name: :kwh,      span: 3 },
-          { name: :co2_kg, span: 3 },
-          { name: :cost,     span: 3 },
+          { name: :kwh,      span: 2 },
+          { name: :co2_kg, span: 2 },
+          { name: :cost,     span: 2 },
           { name: '',         span: 1 }
         ],
         where:   ->{ !sum_data([e23e_ppp£, e23g_ppp£, e23s_ppp£], true).nil? },
-        sort_by:  [9],
+        sort_by:  [6],
         type: %i[table],
         admin_only: true
       },
@@ -1628,31 +1632,18 @@ module Benchmarking
         columns:  [
           tariff_changed_school_name,
 
-          # kWh
-          { data: ->{ e23e_pppk }, name: :last_school_week, units: :kwh },
-          { data: ->{ e23e_cppk }, name: :holiday,  units: :kwh },
-          { data: ->{ percent_change(e23e_pppk, e23e_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
-
-          # CO2
-          { data: ->{ e23e_pppc }, name: :last_school_week, units: :co2 },
-          { data: ->{ e23e_cppc }, name: :holiday,  units: :co2 },
-          { data: ->{ percent_change(e23e_pppc, e23e_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
-
-          # £
-          { data: ->{ e23e_ppp£ }, name: :last_school_week, units: :£ },
-          { data: ->{ e23e_cpp£ }, name: :holiday,  units: :£ },
-          { data: ->{ percent_change(e23e_ppp£, e23e_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
+          { data: ->{ e23e_difk },  name: :change_kwh, units: :kwh },
+          { data: ->{ e23e_difc },  name: :change_co2, units: :co2 },
+          { data: ->{ e23e_dif€ },  name: :change_£current, units: :£_0dp },
+          # percent overall
+          { data: ->{ e23e_difp }, name: :change_pct, units: :relative_percent_0dp },
+          # percent co2
+          { data: ->{ percent_change(e23e_pppc, e23e_cppc, true) }, name: :change_pct_co2, units: :relative_percent_0dp },
 
           TARIFF_CHANGED_COL
         ],
-        column_groups: [
-          { name: '',         span: 1 },
-          { name: :kwh,      span: 3 },
-          { name: :co2_kg, span: 3 },
-          { name: :cost,     span: 3 }
-        ],
         where:   ->{ !e23e_ppp£.nil? },
-        sort_by:  [9],
+        sort_by:  [4],
         type: %i[table],
         admin_only: true
       },
@@ -1663,32 +1654,16 @@ module Benchmarking
         columns:  [
           tariff_changed_school_name,
 
-          # kWh
-          { data: ->{ e23g_pppu }, name: :last_school_week_temperature_unadjusted, units: :kwh },
-          { data: ->{ e23g_pppk }, name: :last_school_week_temperature_adjusted, units: :kwh },
-          { data: ->{ e23g_cppk }, name: :holiday,  units: :kwh },
-          { data: ->{ percent_change(e23g_pppk, e23g_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
-
-          # CO2
-          { data: ->{ e23g_pppc }, name: :last_school_week, units: :co2 },
-          { data: ->{ e23g_cppc }, name: :holiday,  units: :co2 },
-          { data: ->{ percent_change(e23g_pppc, e23g_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
-
-          # £
-          { data: ->{ e23g_ppp£ }, name: :last_school_week, units: :£ },
-          { data: ->{ e23g_cpp£ }, name: :holiday,  units: :£ },
-          { data: ->{ percent_change(e23g_ppp£, e23g_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
+          { data: ->{ e23g_difk },  name: :change_kwh, units: :kwh },
+          { data: ->{ e23g_difc },  name: :change_co2, units: :co2 },
+          { data: ->{ e23g_dif€ },  name: :change_£current, units: :£_0dp },
+          # percent
+          { data: ->{ e23g_difp }, name: :change_pct, units: :relative_percent_0dp },
 
           TARIFF_CHANGED_COL
         ],
-        column_groups: [
-          { name: '',         span: 1 },
-          { name: :kwh,      span: 4 },
-          { name: :co2_kg, span: 3 },
-          { name: :cost,     span: 3 }
-        ],
         where:   ->{ !e23g_ppp£.nil? },
-        sort_by:  [9],
+        sort_by:  [4],
         type: %i[table],
         admin_only: true
       },
@@ -1699,32 +1674,18 @@ module Benchmarking
         columns:  [
           tariff_changed_school_name,
 
-          # kWh
-          { data: ->{ e23s_pppu }, name: :last_school_week_temperature_unadjusted, units: :kwh },
-          { data: ->{ e23s_pppk }, name: :last_school_week_temperature_adjusted, units: :kwh },
-          { data: ->{ e23s_cppk }, name: :holiday,  units: :kwh },
-          { data: ->{ percent_change(e23s_pppk, e23s_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
-
-          # CO2
-          { data: ->{ e23s_pppc }, name: :last_school_week, units: :co2 },
-          { data: ->{ e23s_cppc }, name: :holiday,  units: :co2 },
-          { data: ->{ percent_change(e23s_pppc, e23s_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
-
-          # £
-          { data: ->{ e23s_ppp£ }, name: :last_school_week, units: :£ },
-          { data: ->{ e23s_cpp£ }, name: :holiday,  units: :£ },
-          { data: ->{ percent_change(e23s_ppp£, e23s_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
+          { data: ->{ e23s_difk },  name: :change_kwh, units: :kwh },
+          { data: ->{ e23s_difc },  name: :change_co2, units: :co2 },
+          { data: ->{ e23s_dif€ },  name: :change_£current, units: :£_0dp },
+          # percent
+          { data: ->{ e23s_difp }, name: :change_pct, units: :relative_percent_0dp },
+          # percent co2
+          { data: ->{ percent_change(e23s_pppc, e23s_cppc, true) }, name: :change_pct_co2, units: :relative_percent_0dp },
 
           TARIFF_CHANGED_COL
         ],
-        column_groups: [
-          { name: '',         span: 1 },
-          { name: :kwh,      span: 4 },
-          { name: :co2_kg, span: 3 },
-          { name: :cost,     span: 3 }
-        ],
         where:   ->{ !e23s_ppp£.nil? },
-        sort_by:  [9],
+        sort_by:  [4],
         type: %i[table],
         admin_only: true
       }

--- a/lib/dashboard/benchmarking/benchmark_content_general.rb
+++ b/lib/dashboard/benchmarking/benchmark_content_general.rb
@@ -793,6 +793,12 @@ module Benchmarking
     def storage_heater_content(school_ids:, filter:)
       extra_content(:easter_shutdown_2023_storage_heater_table, filter: filter)
     end
+
+    private def introduction_text
+      text = I18n.t('analytics.benchmarking.content.easter_shutdown_2023_energy_comparison.introduction_text_html')
+      ERB.new(text).result(binding)
+    end
+
   end
 
   class BenchmarkEasterShutdown2023ElectricityTable < BenchmarkContentBase


### PR DESCRIPTION
* Change introduction text
* Fix issue when school has bad calendar data
* Change gas, electricity and storage heater tables to just show the `difference_kwh`, `difference_£current` and `difference_co2` variables (adding the latter to the list of benchmark variables)
* Remove redundant columns in electricity usage, add co2 % column for gas/storage
* Rework the total energy usage table to total up just the differences, leave % calculation unchange