### PR TITLE
More bug fixes for Easter shutdown benchmark

### DIFF
--- a/config/locales/benchmarking/content_base.yml
+++ b/config/locales/benchmarking/content_base.yml
@@ -133,6 +133,7 @@ en:
           change_kwh: Change kWh
           change_pct: Change %
           change_pct_co2: Change CO2 %
+          change_pct_combo: Change kWh/£ %
           change_£: Change £
           change_£current: Change £ (latest tariff)
           co2_last_year: CO2 (last year)

--- a/lib/dashboard/alerts/gas/alert_weekend_gas_consumption_short_term.rb
+++ b/lib/dashboard/alerts/gas/alert_weekend_gas_consumption_short_term.rb
@@ -21,7 +21,7 @@ class AlertWeekendGasConsumptionShortTerm < AlertGasModelBase
   attr_reader :weekend_dates_string
   attr_reader :frost_protection_hours
   attr_reader :last_week_end_kwh_including_frost, :last_week_end_£_including_frost
-  attr_reader :last_week_end_£current_including_frost, :last_weekend_cost_co2_including_frost 
+  attr_reader :last_week_end_£current_including_frost, :last_weekend_cost_co2_including_frost
 
   def initialize(school)
     super(school, :weekendgasconsumption)
@@ -192,9 +192,6 @@ class AlertWeekendGasConsumptionShortTerm < AlertGasModelBase
 
     @weekend_dates = previous_weekend_dates(asof_date)
     @weekend_dates_string = @weekend_dates.map { |d| d.strftime('%d%b%Y') }.join(',')
-
-    puts "Got here"
-    puts @weekend_dates_string
 
     @last_week_end_kwh, @frost_protection_hours, @last_week_end_kwh_including_frost =
           kwh_usage_outside_frost_period(@weekend_dates, FROST_PROTECTION_TEMPERATURE, :kwh)

--- a/lib/dashboard/benchmarking/benchmark_configuration.rb
+++ b/lib/dashboard/benchmarking/benchmark_configuration.rb
@@ -1573,7 +1573,7 @@ module Benchmarking
 
           # CO2
           {
-            data: ->{ sum_data([e23e_cppc, e23g_cppc, e23s_cppc]) },
+            data: ->{ sum_data([e23e_difc, e23g_difc, e23s_difc]) },
             name: :change_co2,  units: :co2
           },
           {
@@ -1587,16 +1587,16 @@ module Benchmarking
 
           # £
           {
-            data: ->{ sum_data([e23e_cpp£, e23g_cpp£, e23s_cpp£]) },
+            data: ->{ sum_data([e23e_dif€, e23g_dif€, e23s_dif€]) },
             name: :change_£current,  units: :£
           },
           {
             data: ->{ percent_change(
-                                      sum_if_complete([e23e_ppp£, e23g_ppp£, e23s_ppp£], [e23e_cpp£, e23g_cpp£, e23s_cpp£]),
-                                      sum_data([e23e_cpp£, e23g_cpp£, e23s_cpp£]),
+                                      sum_if_complete([e23e_ppp€, e23g_ppp€, e23s_ppp€], [e23e_cpp€, e23g_cpp€, e23s_cpp€]),
+                                      sum_data([e23e_cpp€, e23g_cpp€, e23s_cpp€]),
                                       true
                                     ) },
-            name: :change_£, units: :relative_percent_0dp, chart_data: true
+            name: :change_pct, units: :relative_percent_0dp, chart_data: true
           },
 
           # Metering
@@ -1635,8 +1635,8 @@ module Benchmarking
           { data: ->{ e23e_difk },  name: :change_kwh, units: :kwh },
           { data: ->{ e23e_difc },  name: :change_co2, units: :co2 },
           { data: ->{ e23e_dif€ },  name: :change_£current, units: :£_0dp },
-          # percent overall
-          { data: ->{ e23e_difp }, name: :change_pct, units: :relative_percent_0dp },
+          #percent
+          { data: ->{ percent_change(e23e_pppk, e23e_cppk, true) }, name: :change_pct_combo, units: :relative_percent_0dp },
           # percent co2
           { data: ->{ percent_change(e23e_pppc, e23e_cppc, true) }, name: :change_pct_co2, units: :relative_percent_0dp },
 
@@ -1658,7 +1658,7 @@ module Benchmarking
           { data: ->{ e23g_difc },  name: :change_co2, units: :co2 },
           { data: ->{ e23g_dif€ },  name: :change_£current, units: :£_0dp },
           # percent
-          { data: ->{ e23g_difp }, name: :change_pct, units: :relative_percent_0dp },
+          { data: ->{ percent_change(e23g_pppk, e23g_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
 
           TARIFF_CHANGED_COL
         ],
@@ -1677,8 +1677,8 @@ module Benchmarking
           { data: ->{ e23s_difk },  name: :change_kwh, units: :kwh },
           { data: ->{ e23s_difc },  name: :change_co2, units: :co2 },
           { data: ->{ e23s_dif€ },  name: :change_£current, units: :£_0dp },
-          # percent
-          { data: ->{ e23s_difp }, name: :change_pct, units: :relative_percent_0dp },
+          #percent
+          { data: ->{ percent_change(e23s_pppk, e23s_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
           # percent co2
           { data: ->{ percent_change(e23s_pppc, e23s_cppc, true) }, name: :change_pct_co2, units: :relative_percent_0dp },
 

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -7,8 +7,8 @@ module Logging
   logger.level = :debug
 end
 
-asof_date = Date.new(2023, 4, 12)
-schools = ['k*']
+asof_date = Date.new(2023, 4, 20)
+schools = ['t*']
 
 overrides = {
   schools:  schools,
@@ -36,9 +36,9 @@ overrides = {
     #AlertPreviousYearHolidayComparisonElectricity,
     #AlertPreviousHolidayComparisonElectricity,
     #AlertLayerUpPowerdown11November2022ElectricityComparison,
-    AlertEaster2023ShutdownElectricityComparison,
+    #AlertEaster2023ShutdownElectricityComparison,
     AlertEaster2023ShutdownGasComparison,
-    AlertEaster2023ShutdownStorageHeaterComparison
+    #AlertEaster2023ShutdownStorageHeaterComparison
     ],
   control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving html_template_variables], log: [:invalid_alerts] } },
   no_alerts:   { alerts: [], control: { asof_date: asof_date } }

--- a/script/standard/test_benchmarks.rb
+++ b/script/standard/test_benchmarks.rb
@@ -8,7 +8,7 @@ module Logging
   logger.level = :error
 end
 
-run_date = Date.new(2023, 4, 12)
+run_date = Date.new(2023, 4, 20)
 
 overrides = {
   schools: ['*'], # ['king-ja*', 'crook*', 'hunw*', 'combe*'], # ['king-james-e*', 'wyb*', 'batheas*', 'the-dur*'], # ['shrew*', 'bathamp*'],


### PR DESCRIPTION
* Fix total energy use table
* Change how percentage change is calculated to avoid "Infinity" values
* Ensure we're using £current throughout
* Relabel a column