### PR TITLE
API fixes to reduce errors from n3rgy

### DIFF
--- a/lib/dashboard/data_sources/metering/n3rgy/n3rgy_data.rb
+++ b/lib/dashboard/data_sources/metering/n3rgy/n3rgy_data.rb
@@ -157,7 +157,7 @@ module MeterReadingsFeeds
       raw_readings.map do |reading|
         [
           DateTime.parse(reading['timestamp']),
-          reading['value'] * adjust_kwh_units
+          reading['value'].nil? ? nil : reading['value'] * adjust_kwh_units
         ]
       end
     end

--- a/lib/dashboard/data_sources/metering/n3rgy/n3rgy_data_api.rb
+++ b/lib/dashboard/data_sources/metering/n3rgy/n3rgy_data_api.rb
@@ -105,7 +105,7 @@ module MeterReadingsFeeds
       url += fuel_type.to_s + '/' unless fuel_type.nil?
       url += data_type.to_s + '/' unless data_type.nil?
       url += element.to_s unless element.nil?
-      url += half_hourly_query(start_date, end_date + 1) unless start_date.nil? || end_date.nil?
+      url += half_hourly_query(start_date, end_date) unless start_date.nil? || end_date.nil?
       url
     end
 

--- a/spec/lib/dashboard/data_sources/n3rgy/n3rgy_data_api_spec.rb
+++ b/spec/lib/dashboard/data_sources/n3rgy/n3rgy_data_api_spec.rb
@@ -172,7 +172,7 @@ describe MeterReadingsFeeds::N3rgyDataApi do
         [200, {}, response.to_json]
       end
       date = Date.parse("2020-01-01")
-      data = api.get_consumption_data(mpxn: mpxn, fuel_type: fuel_type, start_date: date, end_date: date)
+      data = api.get_consumption_data(mpxn: mpxn, fuel_type: fuel_type, start_date: date, end_date: date + 1)
       expect(data["resource"]).to eql "/2234567891000/electricity/consumption/1"
       stubs.verify_stubbed_calls
     end


### PR DESCRIPTION
Latest release of n3rgy API has some changes which are impacting loading:

- `availableCacheRange` now returns dates including the current day. Previously it seems this only returned dates up until previous day. As a result we were always requesting `end_date + `. When the cache range has data for today, this ends up with us requesting an invalid range.
- missing half-hourly values. Since the update we've seen some missing half-hourly readings in both recent and historical data. Our code wasn't handling this as it assumed readings were always available. Unclear why this is happening, but possibly they are re-requesting data from meters.