### PR TITLE
Improve labelling of chart on long term usage page

### DIFF
--- a/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
@@ -1071,13 +1071,15 @@ class ChartManager
     },
     # 8 finance tab charts
     electricity_by_month_year_0_1_finance_advice: {
+      x_axis:           :month,
       name:             'Energy Costs',
       timescale:        [{ up_to_a_year: 0 }, { up_to_a_year: -1 }],
       ignore_single_series_failure: true,
       inherits_from:    :electricity_by_month_year_0_1
     },
     electricity_cost_comparison_last_2_years_accounting: {
-      name:             '',
+      name:              '',
+      x_axis:            :month,
       inherits_from:     :electricity_cost_comparison_last_2_years,
       timescale:         [{ up_to_a_year: 0 }, { up_to_a_year: -1 }],
       ignore_single_series_failure: true,
@@ -1115,6 +1117,7 @@ class ChartManager
       inherits_from:    :daytype_breakdown_electricity
     },
     gas_by_month_year_0_1_finance_advice: {
+      x_axis:           :month,
       name:             'Gas Costs',
       timescale:        [{ up_to_a_year: 0 }, { up_to_a_year: -1 }],
       ignore_single_series_failure: true,

--- a/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
@@ -1063,7 +1063,7 @@ class ChartManager
       chart1_type:      :column,
       # chart1_subtype:   :stacked,
       series_breakdown: :none,
-      x_axis:           :month,
+      x_axis:           :month_excluding_year,
       timescale:        [{ year: 0 }, { year: -1 }],
       meter_definition: :allelectricity,
       yaxis_units:      :kwh,

--- a/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
@@ -1165,6 +1165,7 @@ class ChartManager
       meter_definition: :allheat
     },
     electricity_cost_comparison_last_2_years: {
+      x_axis:           :month,
       chart1_type:      :column,
       inherits_from:    :electricity_by_month_year_0_1,
       yaxis_units:      :£

--- a/lib/dashboard/charting_and_reports/charts/x_axis_bucketor.rb
+++ b/lib/dashboard/charting_and_reports/charts/x_axis_bucketor.rb
@@ -44,6 +44,8 @@ class XBucketBase
     case type
     when :month
       XBucketMonth.new(type, periods)
+    when :month_excluding_year
+      XBucketMonthExcludingYear.new(type, periods)
     when :week
       XBucketWeek.new(type, periods)
     when :day
@@ -63,6 +65,27 @@ class XBucketBase
     else
       raise "Unknown x bucket type " + type.to_s
     end
+  end
+end
+
+class XBucketMonthExcludingYear < XBucketBase
+  def initialize(type, periods)
+    super(type, periods)
+  end
+
+  def key(date, _halfhour_index)
+    I18n.l(date, format: "%b")
+  end
+
+  def create_x_axis
+    first_day_of_month = data_start_date # .beginning_of_month
+    while first_day_of_month <= data_end_date
+      @x_axis.push(I18n.l(first_day_of_month, format: '%b'))
+      last_day_of_month = first_day_of_month.beginning_of_month.next_month - 1 # can't use end_of_month as there is a active_support error: undefined method `days_in_month'
+      @x_axis_bucket_date_ranges.push([first_day_of_month, last_day_of_month])
+      first_day_of_month = first_day_of_month.next_month.beginning_of_month
+    end
+    @x_axis_bucket_date_ranges.last[1] = data_end_date if @x_axis_bucket_date_ranges.last[1] > data_end_date
   end
 end
 


### PR DESCRIPTION
This PR improves the x-axis labels for the monthly electricity & gas "consumption comparison over the last two years" charts so the x axis shows just the month (instead of e.g. "Jul 2022")
![Screenshot 2023-05-26 at 11 03 02](https://github.com/Energy-Sparks/energy-sparks_analytics/assets/25906/3b469e06-801a-4835-9788-310bd06a25f1)

The pr also recovers the original `x_axis` for any inherited charts where the short date is still required 
```
inherits from `electricity_by_month_year_0_1`
  - `gas_by_month_year_0_1` (the `x_axis` needs to be `month_excluding_year` too so all ok to inherit the change)
  - `electricity_cost_comparison_last_2_years` (x_axis set back to `month`)
  - `electricity_by_month_year_0_1_finance_advice` (x_axis set back to `month`)

inherits from `gas_by_month_year_0_1` 
  - `gas_by_month_year_0_1_finance_advice` (set back to `month`)
```