### PR TITLE
Fix up analytics name method

### DIFF
--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -337,7 +337,7 @@ module Dashboard
     end
 
     def analytics_name
-      return mxpn.to_s unless name.present?
+      return mpxn.to_s unless name.present?
 
       bracketed_text = name.include?(mpxn.to_s) ? 'MPAN' : mpxn.to_s
       "#{name} (#{bracketed_text})"

--- a/spec/app/models/dashboard/meter_spec.rb
+++ b/spec/app/models/dashboard/meter_spec.rb
@@ -56,6 +56,25 @@ describe Dashboard::Meter do
       end
     end
 
+    describe '#analytics_name' do
+      let(:identifier)  { "1456789" }
+      let(:name)        { nil }
+
+      let(:meter) { build(:meter, identifier: identifier, name: name) }
+
+      it 'returns mpxn by default' do
+        expect(meter.analytics_name).to eq(identifier)
+      end
+
+      context 'with name' do
+        let(:name)  { "Kitchen" }
+
+        it 'returns bracketed text' do
+          expect(meter.analytics_name).to eq("Kitchen (1456789)")
+        end
+      end
+    end
+
     # TODO check on fuel type not currently applied
     # it "raises error for unknown fuel type" do
     #   expect {


### PR DESCRIPTION
Fixes a typo introduced in a recent change to meter labelling.