### PR TITLE
Make new out of hours benchmarks public, limit schools in storage heater benchmark

### DIFF
--- a/lib/dashboard/benchmarking/benchmark_configuration.rb
+++ b/lib/dashboard/benchmarking/benchmark_configuration.rb
@@ -1721,7 +1721,7 @@ module Benchmarking
         ],
         sort_by:  [1],
         type: %i[table],
-        admin_only: true,
+        admin_only: false,
         column_heading_explanation: :last_year_definition_html
       },
       annual_change_in_gas_out_of_hours_use: {
@@ -1752,7 +1752,7 @@ module Benchmarking
         ],
         sort_by:  [1],
         type: %i[table],
-        admin_only: true,
+        admin_only: false,
         column_heading_explanation: :last_year_definition_html
       },
       annual_change_in_storage_heater_out_of_hours_use: {
@@ -1781,9 +1781,10 @@ module Benchmarking
           { name: :co2_kg,     span: 3 },
           { name: :cost,    span: 3 },
         ],
+        where:   ->{ !shoo_aook.nil? },
         sort_by:  [1],
         type: %i[table],
-        admin_only: true,
+        admin_only: false,
         column_heading_explanation: :last_year_definition_html
       },
     }.freeze

--- a/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
+++ b/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
@@ -197,7 +197,8 @@ describe Benchmarking::BenchmarkManager, type: :service do
               electricity_targets: 'Progress against electricity target',
               recent_change_in_baseload: 'Recent change in baseload',
               seasonal_baseload_variation: 'Seasonal baseload variation',
-              weekday_baseload_variation: 'Weekday baseload variation'
+              weekday_baseload_variation: 'Weekday baseload variation',
+              annual_change_in_electricity_out_of_hours_use: 'Annual change in electricity used out of school hours'
             }
           },
           {
@@ -219,7 +220,9 @@ describe Benchmarking::BenchmarkManager, type: :service do
               hot_water_efficiency: 'Hot Water Efficiency',
               storage_heater_consumption_during_holiday: 'Storage heater use during current holiday',
               thermostat_sensitivity: 'Annual saving through 1C reduction in thermostat temperature',
-              thermostatic_control: 'Quality of thermostatic control'
+              thermostatic_control: 'Quality of thermostatic control',
+              annual_change_in_gas_out_of_hours_use: 'Annual change in gas used out of school hours',
+              annual_change_in_storage_heater_out_of_hours_use: 'Annual change in storage heater usage out of school hours'
             }
           },
           {


### PR DESCRIPTION
Minor change to make the three 3 benchmarks public, and reduce list of schools in the storage heater benchmark to just those with data.