### PR TITLE
Add new solar generation summary benchmark

### DIFF
--- a/config/locales/benchmarking/content_base.yml
+++ b/config/locales/benchmarking/content_base.yml
@@ -50,6 +50,7 @@ en:
         change_in_gas_since_last_year: Annual change in gas use
         change_in_solar_pv_since_last_year: Annual change in solar PV production and resulting CO2 savings
         change_in_storage_heaters_since_last_year: Annual change in storage heater
+        solar_generation_summary: Solar generation summary
         data:
           metering:
             electricity: Electricity
@@ -294,6 +295,11 @@ en:
           weekend: Weekend
           winter_baseload_kw: Winter baseload kW
           year_before_joined: Year before joined
+          solar_generation: Generation (kWh)
+          solar_export: Export (kWh)
+          solar_self_consume: Self consumption (kWh)
+          solar_mains_consume: Mains consumption (kWh)
+          solar_mains_onsite: Total onsite consumption (kWh)
         no_schools_to_report_for_filter: There are no schools to report using this filter for this benchmark
         the_tariff_has_changed_during_the_last_year_html: |-
           <p>
@@ -302,6 +308,12 @@ en:
                 are calculated using the relevant tariff at the time
           </p>
       content:
+        solar_generation_summary:
+          introduction_text_html: |-
+            <p>
+            Summarises the performance of solar panels installed on these schools over the last 12 months. Equivalent to the
+            "Benefits of having installed solar panels" table on the school's individual solar analysis.
+            </p>
         annual_change_in_electricity_out_of_hours_use:
           introduction_text_html: |-
             <p>

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -601,7 +601,8 @@ class AlertAnalysisBase < ContentBase
       AlertSeptNov20212022StorageHeaterComparison                 => 's22s',
       AlertEaster2023ShutdownElectricityComparison                => 'e23e',
       AlertEaster2023ShutdownGasComparison                        => 'e23g',
-      AlertEaster2023ShutdownStorageHeaterComparison              => 'e23s'
+      AlertEaster2023ShutdownStorageHeaterComparison              => 'e23s',
+      AlertSolarGeneration                                        => 'sgen'
     }
   end
 

--- a/lib/dashboard/alerts/electricity/alert_solar_generation.rb
+++ b/lib/dashboard/alerts/electricity/alert_solar_generation.rb
@@ -1,0 +1,75 @@
+class AlertSolarGeneration < AlertElectricityOnlyBase
+
+  attr_reader :annual_electricity_kwh, :annual_mains_consumed_kwh, :annual_solar_pv_kwh, :annual_exported_solar_pv_kwh, :annual_solar_pv_consumed_onsite_kwh
+
+  def initialize(school)
+    super(school, :solargeneration)
+    @relevance = @school.solar_pv_panels? ? :relevant : :never_relevant
+  end
+
+  def self.template_variables
+    specific = {'Solar Generation' => TEMPLATE_VARIABLES}
+    specific.merge(self.superclass.template_variables)
+  end
+
+  def enough_data
+    return :not_enough unless @relevance == :relevant
+    solar_benefits_service.enough_data? ? :enough : :not_enough
+  end
+
+  def timescale
+    'year'
+  end
+
+  TEMPLATE_VARIABLES = {
+    annual_electricity_kwh: {
+      description: 'Total annual kwh, including self consumption',
+      units:  :kwh,
+      benchmark_code: 'sack'
+    },
+    annual_mains_consumed_kwh: {
+      description: 'Total annual mains consumption kwh',
+      units:  :kwh,
+      benchmark_code: 'samk'
+    },
+    annual_solar_pv_kwh: {
+      description: 'Total annual pv generation in kwh',
+      units:  :kwh,
+      benchmark_code: 'sagk'
+    },
+    annual_exported_solar_pv_kwh: {
+      description: 'Total annual solar export in kwh',
+      units:  :kwh,
+      benchmark_code: 'saek'
+    },
+    annual_solar_pv_consumed_onsite_kwh: {
+      description: 'Total annual solar self consumption in kwh',
+      units:  :kwh,
+      benchmark_code: 'sask'
+    }
+  }
+
+  def calculate(asof_date)
+    solar_generation_summary = solar_benefits_service.create_model
+
+    #total including self consumption
+    @annual_electricity_kwh = solar_generation_summary.annual_electricity_including_onsite_solar_pv_consumption_kwh
+    #mains consumption
+    @annual_mains_consumed_kwh =  solar_generation_summary.annual_consumed_from_national_grid_kwh
+    #solar generation
+    @annual_solar_pv_kwh = solar_generation_summary.annual_solar_pv_kwh
+    #exported solar
+    @annual_exported_solar_pv_kwh = solar_generation_summary.annual_exported_solar_pv_kwh
+    #self consumption
+    @annual_solar_pv_consumed_onsite_kwh = solar_generation_summary.annual_solar_pv_consumed_onsite_kwh
+
+    @rating = 5.0
+  end
+  alias_method :analyse_private, :calculate
+
+  private
+
+  def solar_benefits_service
+    SolarPhotovoltaics::ExistingBenefitsService.new(meter_collection: @school)
+  end
+end

--- a/lib/dashboard/benchmarking/benchmark_configuration.rb
+++ b/lib/dashboard/benchmarking/benchmark_configuration.rb
@@ -144,7 +144,8 @@ module Benchmarking
       ],
       solar_benchmarks: [
         :change_in_solar_pv_since_last_year,
-        :solar_pv_benefit_estimate
+        :solar_pv_benefit_estimate,
+        :solar_generation_summary
       ],
       date_limited_comparisons: [
         :layer_up_powerdown_day_november_2022,
@@ -1787,6 +1788,27 @@ module Benchmarking
         admin_only: false,
         column_heading_explanation: :last_year_definition_html
       },
+      solar_generation_summary: {
+        benchmark_class: BenchmarkContentSolarGenerationSummary,
+        name:     'Solar generation summary',
+        columns:  [
+          { data: 'addp_name', name: :name,     units: String, chart_data: false },
+          #generation
+          { data: 'sgen_sagk', name: :solar_generation, units: :kwh},
+          #self consume
+          { data: 'sgen_sask', name: :solar_self_consume, units: :kwh},
+          #export
+          { data: 'sgen_saek', name: :solar_export, units: :kwh},
+          #mains,
+          { data: 'sgen_samk', name: :solar_mains_consume, units: :kwh},
+          #mains, plus self consume
+          { data: 'sgen_sack', name: :solar_mains_onsite, units: :kwh},
+        ],
+        where:   ->{ !sgen_sagk.nil? },
+        sort_by:  [0],
+        type: %i[table],
+        admin_only: true
+      }
     }.freeze
   end
 end

--- a/lib/dashboard/benchmarking/benchmark_content_general.rb
+++ b/lib/dashboard/benchmarking/benchmark_content_general.rb
@@ -99,6 +99,16 @@ module Benchmarking
     end
   end
   #=======================================================================================
+  class BenchmarkContentSolarGenerationSummary < BenchmarkContentBase
+    include BenchmarkingNoTextMixin
+
+    private def introduction_text
+      text = I18n.t('analytics.benchmarking.content.solar_generation_summary.introduction_text_html')
+      ERB.new(text).result(binding)
+    end
+  end
+
+  #=======================================================================================
   class BenchmarkBaseloadBase < BenchmarkContentBase
     def content(school_ids: nil, filter: nil, user_type: nil)
       @baseload_impact_html = baseload_1_kw_change_range_£_html(school_ids, filter, user_type)

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -7,9 +7,9 @@ require_rel '../../test_support'
 #   logger.level = :debug
 # end
 
-asof_date = Date.new(2023, 6, 2)
+asof_date = Date.new(2023, 6, 4)
 # schools = ['t*']
-schools = ['k*']
+schools = ['*']
 
 overrides = {
   schools:  schools,
@@ -19,7 +19,7 @@ overrides = {
 #    AlertThermostaticControl
 #    AlertEnergyAnnualVersusBenchmark,
 #    AlertSchoolWeekComparisonGas,
-    AlertOutOfHoursElectricityUsage,
+#    AlertOutOfHoursElectricityUsage,
 #    AlertElectricityBaseloadVersusBenchmark,
 #    AlertHeatingComingOnTooEarly,
 #    AlertPreviousYearHolidayComparisonElectricity,
@@ -41,7 +41,8 @@ overrides = {
 #    AlertEaster2023ShutdownElectricityComparison,
 #    AlertEaster2023ShutdownGasComparison,
 #    AlertEaster2023ShutdownStorageHeaterComparison
-    AlertOutOfHoursElectricityUsagePreviousYear
+#    AlertOutOfHoursElectricityUsagePreviousYear
+     AlertSolarGeneration
     ],
   control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving html_template_variables], log: [:invalid_alerts] } },
   no_alerts:   { alerts: [], control: { asof_date: asof_date } }

--- a/script/standard/test_benchmarks.rb
+++ b/script/standard/test_benchmarks.rb
@@ -8,7 +8,7 @@ module Logging
   logger.level = :error
 end
 
-run_date = Date.new(2023,6,2)
+run_date = Date.new(2023,6,6)
 
 overrides = {
   schools: ['*'], # ['king-ja*', 'crook*', 'hunw*', 'combe*'], # ['king-james-e*', 'wyb*', 'batheas*', 'the-dur*'], # ['shrew*', 'bathamp*'],
@@ -17,9 +17,7 @@ overrides = {
     calculate_and_save_variables: true,
     asof_date: run_date,
     pages: %i[
-      annual_change_in_electricity_out_of_hours_use
-      annual_change_in_gas_out_of_hours_use
-      annual_change_in_storage_heater_out_of_hours_use
+      solar_generation_summary
     ],
     run_content: { asof_date: run_date } # , filter: ->{ !gpyc_difp.nil? && !gpyc_difp.infinite?.nil? } }
   }

--- a/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
+++ b/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
@@ -68,7 +68,8 @@ describe Benchmarking::BenchmarkManager, type: :service do
             description: "These benchmarks compare schools' solar PV production and the benefits of installing solar.",
             benchmarks: {
               change_in_solar_pv_since_last_year: 'Annual change in solar PV production and resulting CO2 savings',
-              solar_pv_benefit_estimate: 'Benefit of solar PV installation'
+              solar_pv_benefit_estimate: 'Benefit of solar PV installation',
+              solar_generation_summary: 'Solar generation summary'
             }
           },
           {
@@ -149,7 +150,8 @@ describe Benchmarking::BenchmarkManager, type: :service do
             description: "These benchmarks compare schools' solar PV production and the benefits of installing solar.",
             benchmarks: {
               change_in_solar_pv_since_last_year: 'Annual change in solar PV production and resulting CO2 savings',
-              solar_pv_benefit_estimate: 'Benefit of solar PV installation'
+              solar_pv_benefit_estimate: 'Benefit of solar PV installation',
+              solar_generation_summary: 'Solar generation summary'
             }
           },
           {


### PR DESCRIPTION
To support testing of the revised solar export / self consumption applications I've added a new admin-only benchmark that summarises the key figures for the solar panel peformance:

- generation
- self consumption
- export
- main consumption
- mains + self consumption

