### PR TITLE
Add kwh reduction as a variable for priority actions

### DIFF
--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -265,11 +265,9 @@ class AlertAnalysisBase < ContentBase
 
   def assign_commmon_saving_variables(one_year_saving_£:, capital_cost:, one_year_saving_co2:)
     @one_year_saving_£ = as_range(one_year_saving_£)
-    #TODO one_year_saving_£ can never be nil
     @ten_year_saving_£ = @one_year_saving_£.nil? ? 0.0 : Range.new(@one_year_saving_£.first * 10.0, @one_year_saving_£.last * 10.0)
 
     #PRIORITY
-    #TODO one_year_saving_£ can never be nil
     @average_one_year_saving_£ = @one_year_saving_£.nil? ? 0.0 : ((@one_year_saving_£.first + @one_year_saving_£.last) / 2.0)
     @average_ten_year_saving_£ = @average_one_year_saving_£ * 10.0
 
@@ -279,7 +277,6 @@ class AlertAnalysisBase < ContentBase
 
     @capital_cost = as_range(capital_cost)
     #PRIORITY - dashboard only
-    #TODO capital_cost can never be nil
     @average_capital_cost = @capital_cost.nil? ? 0.0 : ((@capital_cost.first + @capital_cost.last)/ 2.0)
 
     @average_payback_years = @average_one_year_saving_£ == 0.0 ? 0.0 : @average_capital_cost / @average_one_year_saving_£

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -265,9 +265,11 @@ class AlertAnalysisBase < ContentBase
 
   def assign_commmon_saving_variables(one_year_saving_£:, capital_cost:, one_year_saving_co2:)
     @one_year_saving_£ = as_range(one_year_saving_£)
+    #TODO one_year_saving_£ can never be nil
     @ten_year_saving_£ = @one_year_saving_£.nil? ? 0.0 : Range.new(@one_year_saving_£.first * 10.0, @one_year_saving_£.last * 10.0)
 
     #PRIORITY
+    #TODO one_year_saving_£ can never be nil
     @average_one_year_saving_£ = @one_year_saving_£.nil? ? 0.0 : ((@one_year_saving_£.first + @one_year_saving_£.last) / 2.0)
     @average_ten_year_saving_£ = @average_one_year_saving_£ * 10.0
 
@@ -277,6 +279,7 @@ class AlertAnalysisBase < ContentBase
 
     @capital_cost = as_range(capital_cost)
     #PRIORITY - dashboard only
+    #TODO capital_cost can never be nil
     @average_capital_cost = @capital_cost.nil? ? 0.0 : ((@capital_cost.first + @capital_cost.last)/ 2.0)
 
     @average_payback_years = @average_one_year_saving_£ == 0.0 ? 0.0 : @average_capital_cost / @average_one_year_saving_£

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -22,6 +22,7 @@ class AlertAnalysisBase < ContentBase
 
   attr_reader :capital_cost, :one_year_saving_£, :ten_year_saving_£, :payback_years
   attr_reader :one_year_saving_co2, :ten_year_saving_co2
+  attr_reader :one_year_saving_kwh
   attr_reader :average_capital_cost, :average_one_year_saving_£, :average_payback_years
   attr_reader :average_ten_year_saving_£
   attr_reader :error_message, :backtrace
@@ -163,6 +164,10 @@ class AlertAnalysisBase < ContentBase
       description: 'School URN',
       units:  Integer
     },
+    one_year_saving_kwh: {
+      description: 'Estimated one year kwh reduction range',
+      units: :kwh
+    },
     one_year_saving_£: {
       description: 'Estimated one year saving range',
       units: :£_range
@@ -263,22 +268,20 @@ class AlertAnalysisBase < ContentBase
     @help_url = ALERT_HELP_URL + '#' + bookmark
   end
 
-  def assign_commmon_saving_variables(one_year_saving_£:, capital_cost: nil, one_year_saving_co2:)
+  def assign_commmon_saving_variables(one_year_saving_kwh: nil, one_year_saving_£:, capital_cost: nil, one_year_saving_co2:)
     @one_year_saving_£ = as_range(one_year_saving_£)
     @ten_year_saving_£ = @one_year_saving_£.nil? ? 0.0 : Range.new(@one_year_saving_£.first * 10.0, @one_year_saving_£.last * 10.0)
 
-    #PRIORITY
     @average_one_year_saving_£ = @one_year_saving_£.nil? ? 0.0 : ((@one_year_saving_£.first + @one_year_saving_£.last) / 2.0)
     @average_ten_year_saving_£ = @average_one_year_saving_£ * 10.0
 
-    #PRIORITY
     @one_year_saving_co2 = one_year_saving_co2
     @ten_year_saving_co2 = one_year_saving_co2 * 10.0
 
-    @capital_cost = as_range(capital_cost)
-    #PRIORITY - dashboard only
-    @average_capital_cost = @capital_cost.nil? ? 0.0 : ((@capital_cost.first + @capital_cost.last)/ 2.0)
+    @one_year_saving_kwh = one_year_saving_kwh
 
+    @capital_cost = as_range(capital_cost)
+    @average_capital_cost = @capital_cost.nil? ? 0.0 : ((@capital_cost.first + @capital_cost.last)/ 2.0)
     @average_payback_years = @average_one_year_saving_£ == 0.0 ? 0.0 : @average_capital_cost / @average_one_year_saving_£
   end
 

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -270,22 +270,30 @@ class AlertAnalysisBase < ContentBase
     Range.new(min_saving, max_saving)
   end
 
+  #RENAME
+  #CHANGE to named parameters
+  #EXTRACT Float to Range
+  #Simplify calls to provide Float unless actual difference
+  #Remove nil parameters
+  #ADD kwh saving parameter
+  #Declare and set variable
   def set_savings_capital_costs_payback(one_year_saving_£, capital_cost, one_year_saving_co2)
-    one_year_saving_£ = Range.new(one_year_saving_£, one_year_saving_£) if one_year_saving_£.is_a?(Float)
+    @one_year_saving_£ = one_year_saving_£.is_a?(Float) ? Range.new(one_year_saving_£, one_year_saving_£) : one_year_saving_£
+    @ten_year_saving_£ = @one_year_saving_£.nil? ? 0.0 : Range.new(@one_year_saving_£.first * 10.0, @one_year_saving_£.last * 10.0)
 
+    #PRIORITY
+    @average_one_year_saving_£ = @one_year_saving_£.nil? ? 0.0 : ((@one_year_saving_£.first + @one_year_saving_£.last) / 2.0)
+    @average_ten_year_saving_£ = @average_one_year_saving_£ * 10.0
+
+    #PRIORITY
     @one_year_saving_co2 = one_year_saving_co2
     @ten_year_saving_co2 = one_year_saving_co2 * 10.0
 
-    capital_cost = Range.new(capital_cost, capital_cost) if capital_cost.is_a?(Float)
-    @capital_cost = capital_cost
-    @average_capital_cost = capital_cost.nil? ? 0.0 : ((capital_cost.first + capital_cost.last)/ 2.0)
+    @capital_cost = capital_cost.is_a?(Float) ? Range.new(capital_cost, capital_cost) : capital_cost
+    #PRIORITY - dashboard only
+    @average_capital_cost = @capital_cost.nil? ? 0.0 : ((@capital_cost.first + @capital_cost.last)/ 2.0)
 
-    @one_year_saving_£ = one_year_saving_£
-    @ten_year_saving_£ = one_year_saving_£.nil? ? 0.0 : Range.new(one_year_saving_£.first * 10.0, one_year_saving_£.last * 10.0)
-    @average_one_year_saving_£ = one_year_saving_£.nil? ? 0.0 : ((one_year_saving_£.first + one_year_saving_£.last) / 2.0)
-    @average_ten_year_saving_£ = @average_one_year_saving_£ * 10.0
-
-    @average_payback_years = (@one_year_saving_£.nil? || @one_year_saving_£ == 0.0 || @average_capital_cost.nil?) ? 0.0 : @average_capital_cost / @average_one_year_saving_£
+    @average_payback_years = @average_one_year_saving_£ == 0.0 ? 0.0 : @average_capital_cost / @average_one_year_saving_£
   end
 
   def pupils

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -270,14 +270,12 @@ class AlertAnalysisBase < ContentBase
     Range.new(min_saving, max_saving)
   end
 
-  #RENAME
-  #CHANGE to named parameters
   #EXTRACT Float to Range
   #Simplify calls to provide Float unless actual difference
   #Remove nil parameters
   #ADD kwh saving parameter
   #Declare and set variable
-  def set_savings_capital_costs_payback(one_year_saving_£, capital_cost, one_year_saving_co2)
+  def assign_commmon_saving_variables(one_year_saving_£:, capital_cost:, one_year_saving_co2:)
     @one_year_saving_£ = one_year_saving_£.is_a?(Float) ? Range.new(one_year_saving_£, one_year_saving_£) : one_year_saving_£
     @ten_year_saving_£ = @one_year_saving_£.nil? ? 0.0 : Range.new(@one_year_saving_£.first * 10.0, @one_year_saving_£.last * 10.0)
 
@@ -294,6 +292,10 @@ class AlertAnalysisBase < ContentBase
     @average_capital_cost = @capital_cost.nil? ? 0.0 : ((@capital_cost.first + @capital_cost.last)/ 2.0)
 
     @average_payback_years = @average_one_year_saving_£ == 0.0 ? 0.0 : @average_capital_cost / @average_one_year_saving_£
+  end
+
+  def set_savings_capital_costs_payback(one_year_saving_£, capital_cost, one_year_saving_co2)
+    assign_commmon_saving_variables(one_year_saving_£: one_year_saving_£, capital_cost: capital_cost, one_year_saving_co2: one_year_saving_co2)
   end
 
   def pupils

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -285,10 +285,6 @@ class AlertAnalysisBase < ContentBase
     @average_payback_years = @average_one_year_saving_£ == 0.0 ? 0.0 : @average_capital_cost / @average_one_year_saving_£
   end
 
-  def set_savings_capital_costs_payback(one_year_saving_£, capital_cost, one_year_saving_co2)
-    assign_commmon_saving_variables(one_year_saving_£: one_year_saving_£, capital_cost: capital_cost, one_year_saving_co2: one_year_saving_co2)
-  end
-
   private def as_range(value)
     value.is_a?(Float) ? Range.new(value, value) : value
   end

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -264,7 +264,7 @@ class AlertAnalysisBase < ContentBase
   end
 
   def assign_commmon_saving_variables(one_year_saving_£:, capital_cost:, one_year_saving_co2:)
-    @one_year_saving_£ = one_year_saving_£.is_a?(Float) ? Range.new(one_year_saving_£, one_year_saving_£) : one_year_saving_£
+    @one_year_saving_£ = as_range(one_year_saving_£)
     @ten_year_saving_£ = @one_year_saving_£.nil? ? 0.0 : Range.new(@one_year_saving_£.first * 10.0, @one_year_saving_£.last * 10.0)
 
     #PRIORITY
@@ -275,7 +275,7 @@ class AlertAnalysisBase < ContentBase
     @one_year_saving_co2 = one_year_saving_co2
     @ten_year_saving_co2 = one_year_saving_co2 * 10.0
 
-    @capital_cost = capital_cost.is_a?(Float) ? Range.new(capital_cost, capital_cost) : capital_cost
+    @capital_cost = as_range(capital_cost)
     #PRIORITY - dashboard only
     @average_capital_cost = @capital_cost.nil? ? 0.0 : ((@capital_cost.first + @capital_cost.last)/ 2.0)
 
@@ -284,6 +284,10 @@ class AlertAnalysisBase < ContentBase
 
   def set_savings_capital_costs_payback(one_year_saving_£, capital_cost, one_year_saving_co2)
     assign_commmon_saving_variables(one_year_saving_£: one_year_saving_£, capital_cost: capital_cost, one_year_saving_co2: one_year_saving_co2)
+  end
+
+  private def as_range(value)
+    value.is_a?(Float) ? Range.new(value, value) : value
   end
 
   def pupils

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -263,7 +263,7 @@ class AlertAnalysisBase < ContentBase
     @help_url = ALERT_HELP_URL + '#' + bookmark
   end
 
-  def assign_commmon_saving_variables(one_year_saving_£:, capital_cost:, one_year_saving_co2:)
+  def assign_commmon_saving_variables(one_year_saving_£:, capital_cost: nil, one_year_saving_co2:)
     @one_year_saving_£ = as_range(one_year_saving_£)
     @ten_year_saving_£ = @one_year_saving_£.nil? ? 0.0 : Range.new(@one_year_saving_£.first * 10.0, @one_year_saving_£.last * 10.0)
 

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -263,18 +263,6 @@ class AlertAnalysisBase < ContentBase
     @help_url = ALERT_HELP_URL + '#' + bookmark
   end
 
-  def calculate_payback_years_deprecated
-    return (0.0..0.0) if one_year_saving_£.nil? || capital_cost.nil? || capital_cost == (0.0..0.0)
-    min_saving = one_year_saving_£.last.nil? ? 0.0 : capital_cost.first / one_year_saving_£.last
-    max_saving = one_year_saving_£.first.nil? ?  0.0 : capital_cost.last / one_year_saving_£.first
-    Range.new(min_saving, max_saving)
-  end
-
-  #EXTRACT Float to Range
-  #Simplify calls to provide Float unless actual difference
-  #Remove nil parameters
-  #ADD kwh saving parameter
-  #Declare and set variable
   def assign_commmon_saving_variables(one_year_saving_£:, capital_cost:, one_year_saving_co2:)
     @one_year_saving_£ = one_year_saving_£.is_a?(Float) ? Range.new(one_year_saving_£, one_year_saving_£) : one_year_saving_£
     @ten_year_saving_£ = @one_year_saving_£.nil? ? 0.0 : Range.new(@one_year_saving_£.first * 10.0, @one_year_saving_£.last * 10.0)

--- a/lib/dashboard/alerts/common/alert_impending_holiday.rb
+++ b/lib/dashboard/alerts/common/alert_impending_holiday.rb
@@ -255,10 +255,11 @@ class AlertImpendingHoliday < AlertGasOnlyBase
     @last_year_holiday = same_holiday_previous_year(@holiday_period)
     set_last_year_holiday_consumption_variables(@last_year_holiday.start_date, @last_year_holiday.end_date, @last_year_holiday.nil?)
 
-    potential_saving_kwh = nil_to_zero(@electricity_potential_saving_£) + nil_to_zero(@gas_potential_saving_£)
+    potential_saving_kwh = nil_to_zero(@electricity_potential_saving_kwh) + nil_to_zero(@gas_potential_saving_kwh)
+    potential_saving_£ = nil_to_zero(@electricity_potential_saving_£) + nil_to_zero(@gas_potential_saving_£)
     potential_saving_co2 = nil_to_zero(@electricity_potential_saving_co2) + nil_to_zero(@gas_potential_saving_co2)
-    #set_savings_capital_costs_payback(potential_saving_kwh, 0.0, potential_saving_co2)
-    assign_commmon_saving_variables(one_year_saving_£: potential_saving_kwh, capital_cost: 0.0, one_year_saving_co2: potential_saving_co2)
+
+    assign_commmon_saving_variables(one_year_saving_kwh: potential_saving_kwh, one_year_saving_£: potential_saving_£, capital_cost: 0.0, one_year_saving_co2: potential_saving_co2)
 
     @saving_kwh = potential_saving_kwh
     @saving_co2 = potential_saving_co2

--- a/lib/dashboard/alerts/common/alert_impending_holiday.rb
+++ b/lib/dashboard/alerts/common/alert_impending_holiday.rb
@@ -257,7 +257,8 @@ class AlertImpendingHoliday < AlertGasOnlyBase
 
     potential_saving_kwh = nil_to_zero(@electricity_potential_saving_£) + nil_to_zero(@gas_potential_saving_£)
     potential_saving_co2 = nil_to_zero(@electricity_potential_saving_co2) + nil_to_zero(@gas_potential_saving_co2)
-    set_savings_capital_costs_payback(potential_saving_kwh, 0.0, potential_saving_co2)
+    #set_savings_capital_costs_payback(potential_saving_kwh, 0.0, potential_saving_co2)
+    assign_commmon_saving_variables(one_year_saving_£: potential_saving_kwh, capital_cost: 0.0, one_year_saving_co2: potential_saving_co2)
 
     @saving_kwh = potential_saving_kwh
     @saving_co2 = potential_saving_co2

--- a/lib/dashboard/alerts/common/alert_long_term_trend.rb
+++ b/lib/dashboard/alerts/common/alert_long_term_trend.rb
@@ -185,7 +185,6 @@ class AlertLongTermTrend < AlertAnalysisBase
 
     @rating = calculate_rating_from_range(-0.1, 0.15, percent_change_kwh_temp_adj)
 
-    #set_savings_capital_costs_payback(Range.new(year_change_£, year_change_£), nil, @year_change_co2)
     assign_commmon_saving_variables(one_year_saving_kwh: year_change_kwh, one_year_saving_£: year_change_£, one_year_saving_co2: @year_change_co2)
   end
   alias_method :analyse_private, :calculate

--- a/lib/dashboard/alerts/common/alert_long_term_trend.rb
+++ b/lib/dashboard/alerts/common/alert_long_term_trend.rb
@@ -186,7 +186,7 @@ class AlertLongTermTrend < AlertAnalysisBase
     @rating = calculate_rating_from_range(-0.1, 0.15, percent_change_kwh_temp_adj)
 
     #set_savings_capital_costs_payback(Range.new(year_change_£, year_change_£), nil, @year_change_co2)
-    assign_commmon_saving_variables(one_year_saving_£: year_change_£, one_year_saving_co2: @year_change_co2)
+    assign_commmon_saving_variables(one_year_saving_kwh: year_change_kwh, one_year_saving_£: year_change_£, one_year_saving_co2: @year_change_co2)
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/common/alert_long_term_trend.rb
+++ b/lib/dashboard/alerts/common/alert_long_term_trend.rb
@@ -6,7 +6,7 @@ class AlertLongTermTrend < AlertAnalysisBase
   attr_reader :this_year_co2, :last_year_co2, :year_change_co2, :percent_change_co2
   attr_reader :last_year_co2_temp_adj, :year_change_co2_temp_adj, :percent_change_co2_temp_adj
   attr_reader :degreeday_adjustment, :degreedays_this_year, :degreedays_last_year
-  
+
   attr_reader :this_year_kwh, :last_year_kwh, :last_year_kwh_temp_adj
   attr_reader :year_change_kwh, :year_change_kwh_temp_adj
   attr_reader :percent_change_kwh, :percent_change_kwh_temp_adj
@@ -185,7 +185,8 @@ class AlertLongTermTrend < AlertAnalysisBase
 
     @rating = calculate_rating_from_range(-0.1, 0.15, percent_change_kwh_temp_adj)
 
-    set_savings_capital_costs_payback(Range.new(year_change_£, year_change_£), nil, @year_change_co2)
+    #set_savings_capital_costs_payback(Range.new(year_change_£, year_change_£), nil, @year_change_co2)
+    assign_commmon_saving_variables(one_year_saving_£: year_change_£, one_year_saving_co2: @year_change_co2)
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/common/alert_out_of_hours_base_usage.rb
+++ b/lib/dashboard/alerts/common/alert_out_of_hours_base_usage.rb
@@ -190,7 +190,6 @@ class AlertOutOfHoursBaseUsage < AlertAnalysisBase
     @potential_saving_£   = @potential_saving_kwh * @fuel_cost_current
     @potential_saving_co2 = @potential_saving_kwh * co2_intensity_per_kwh
 
-    #set_savings_capital_costs_payback(Range.new(@potential_saving_£, @potential_saving_£), nil, @potential_saving_co2)
     assign_commmon_saving_variables(one_year_saving_kwh: @potential_saving_kwh, one_year_saving_£: @potential_saving_£, one_year_saving_co2: @potential_saving_co2)
 
     @rating = calculate_rating_from_range(good_out_of_hours_use_percent, bad_out_of_hours_use_percent, out_of_hours_percent)

--- a/lib/dashboard/alerts/common/alert_out_of_hours_base_usage.rb
+++ b/lib/dashboard/alerts/common/alert_out_of_hours_base_usage.rb
@@ -191,7 +191,7 @@ class AlertOutOfHoursBaseUsage < AlertAnalysisBase
     @potential_saving_co2 = @potential_saving_kwh * co2_intensity_per_kwh
 
     #set_savings_capital_costs_payback(Range.new(@potential_saving_£, @potential_saving_£), nil, @potential_saving_co2)
-    assign_commmon_saving_variables(one_year_saving_£: @potential_saving_£, one_year_saving_co2: @potential_saving_co2)
+    assign_commmon_saving_variables(one_year_saving_kwh: @potential_saving_kwh, one_year_saving_£: @potential_saving_£, one_year_saving_co2: @potential_saving_co2)
 
     @rating = calculate_rating_from_range(good_out_of_hours_use_percent, bad_out_of_hours_use_percent, out_of_hours_percent)
 

--- a/lib/dashboard/alerts/common/alert_out_of_hours_base_usage.rb
+++ b/lib/dashboard/alerts/common/alert_out_of_hours_base_usage.rb
@@ -190,7 +190,8 @@ class AlertOutOfHoursBaseUsage < AlertAnalysisBase
     @potential_saving_£   = @potential_saving_kwh * @fuel_cost_current
     @potential_saving_co2 = @potential_saving_kwh * co2_intensity_per_kwh
 
-    set_savings_capital_costs_payback(Range.new(@potential_saving_£, @potential_saving_£), nil, @potential_saving_co2)
+    #set_savings_capital_costs_payback(Range.new(@potential_saving_£, @potential_saving_£), nil, @potential_saving_co2)
+    assign_commmon_saving_variables(one_year_saving_£: @potential_saving_£, one_year_saving_co2: @potential_saving_co2)
 
     @rating = calculate_rating_from_range(good_out_of_hours_use_percent, bad_out_of_hours_use_percent, out_of_hours_percent)
 

--- a/lib/dashboard/alerts/common/alert_targets.rb
+++ b/lib/dashboard/alerts/common/alert_targets.rb
@@ -405,7 +405,6 @@ class AlertTargetBase < AlertAnalysisBase
     potential_saving_co2 = previous_year_co2 - current_year_target_co2
     potential_saving_kwh = previous_year_kwh - current_year_target_kwh
 
-    #set_savings_capital_costs_payback(potential_savings_range, nil, potential_saving_co2)
     assign_commmon_saving_variables(one_year_saving_kwh: potential_saving_kwh, one_year_saving_£: potential_savings_range, one_year_saving_co2: potential_saving_co2)
   end
   alias_method :analyse_private, :calculate

--- a/lib/dashboard/alerts/common/alert_targets.rb
+++ b/lib/dashboard/alerts/common/alert_targets.rb
@@ -403,9 +403,10 @@ class AlertTargetBase < AlertAnalysisBase
     @rating = calculate_rating_from_range(0.95, 1.05, rating_target_percent)
 
     potential_saving_co2 = previous_year_co2 - current_year_target_co2
+    potential_saving_kwh = previous_year_kwh - current_year_target_kwh
 
     #set_savings_capital_costs_payback(potential_savings_range, nil, potential_saving_co2)
-    assign_commmon_saving_variables(one_year_saving_£: potential_savings_range, one_year_saving_co2: potential_saving_co2)
+    assign_commmon_saving_variables(one_year_saving_kwh: potential_saving_kwh, one_year_saving_£: potential_savings_range, one_year_saving_co2: potential_saving_co2)
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/common/alert_targets.rb
+++ b/lib/dashboard/alerts/common/alert_targets.rb
@@ -404,7 +404,8 @@ class AlertTargetBase < AlertAnalysisBase
 
     potential_saving_co2 = previous_year_co2 - current_year_target_co2
 
-    set_savings_capital_costs_payback(potential_savings_range, nil, potential_saving_co2)
+    #set_savings_capital_costs_payback(potential_savings_range, nil, potential_saving_co2)
+    assign_commmon_saving_variables(one_year_saving_£: potential_savings_range, one_year_saving_co2: potential_saving_co2)
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/electricity/alert_change_in_daily_electricity_short_term.rb
+++ b/lib/dashboard/alerts/electricity/alert_change_in_daily_electricity_short_term.rb
@@ -134,10 +134,11 @@ class AlertChangeInDailyElectricityShortTerm < AlertElectricityOnlyBase
 
     @percent_change_in_consumption = ((@last_weeks_consumption_kwh - @week_befores_consumption_kwh) / @week_befores_consumption_kwh)
 
+    saving_kwh  = average_school_days_in_year * (@last_weeks_consumption_kwh - @week_befores_consumption_kwh) / days_in_week
     saving_£    = average_school_days_in_year * (@last_weeks_consumption_£   - @week_befores_consumption_£)   / days_in_week
     saving_co2  = average_school_days_in_year * (@last_weeks_consumption_co2 - @week_befores_consumption_co2) / days_in_week
     #set_savings_capital_costs_payback(Range.new(saving_£, saving_£), nil, saving_co2)
-    assign_commmon_saving_variables(one_year_saving_£: saving_£, one_year_saving_co2: saving_co2)
+    assign_commmon_saving_variables(one_year_saving_kwh: saving_kwh, one_year_saving_£: saving_£, one_year_saving_co2: saving_co2)
 
     @rating = calculate_rating_from_range(-0.05, 0.15, @percent_change_in_consumption)
     @status = @signifcant_increase_in_electricity_consumption ? :bad : :good

--- a/lib/dashboard/alerts/electricity/alert_change_in_daily_electricity_short_term.rb
+++ b/lib/dashboard/alerts/electricity/alert_change_in_daily_electricity_short_term.rb
@@ -137,7 +137,7 @@ class AlertChangeInDailyElectricityShortTerm < AlertElectricityOnlyBase
     saving_kwh  = average_school_days_in_year * (@last_weeks_consumption_kwh - @week_befores_consumption_kwh) / days_in_week
     saving_£    = average_school_days_in_year * (@last_weeks_consumption_£   - @week_befores_consumption_£)   / days_in_week
     saving_co2  = average_school_days_in_year * (@last_weeks_consumption_co2 - @week_befores_consumption_co2) / days_in_week
-    #set_savings_capital_costs_payback(Range.new(saving_£, saving_£), nil, saving_co2)
+
     assign_commmon_saving_variables(one_year_saving_kwh: saving_kwh, one_year_saving_£: saving_£, one_year_saving_co2: saving_co2)
 
     @rating = calculate_rating_from_range(-0.05, 0.15, @percent_change_in_consumption)

--- a/lib/dashboard/alerts/electricity/alert_change_in_daily_electricity_short_term.rb
+++ b/lib/dashboard/alerts/electricity/alert_change_in_daily_electricity_short_term.rb
@@ -136,7 +136,8 @@ class AlertChangeInDailyElectricityShortTerm < AlertElectricityOnlyBase
 
     saving_£    = average_school_days_in_year * (@last_weeks_consumption_£   - @week_befores_consumption_£)   / days_in_week
     saving_co2  = average_school_days_in_year * (@last_weeks_consumption_co2 - @week_befores_consumption_co2) / days_in_week
-    set_savings_capital_costs_payback(Range.new(saving_£, saving_£), nil, saving_co2)
+    #set_savings_capital_costs_payback(Range.new(saving_£, saving_£), nil, saving_co2)
+    assign_commmon_saving_variables(one_year_saving_£: saving_£, one_year_saving_co2: saving_co2)
 
     @rating = calculate_rating_from_range(-0.05, 0.15, @percent_change_in_consumption)
     @status = @signifcant_increase_in_electricity_consumption ? :bad : :good

--- a/lib/dashboard/alerts/electricity/alert_electricity_annual_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/alert_electricity_annual_versus_benchmark.rb
@@ -308,6 +308,7 @@ class AlertElectricityAnnualVersusBenchmark < AlertElectricityOnlyBase
 
     #set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£current, @one_year_saving_versus_exemplar_£current), capital_cost, @one_year_saving_versus_exemplar_co2)
     assign_commmon_saving_variables(
+      one_year_saving_kwh: @one_year_saving_versus_exemplar_kwh,
       one_year_saving_£: @one_year_saving_versus_exemplar_£current,
       one_year_saving_co2: @one_year_saving_versus_exemplar_co2)
 

--- a/lib/dashboard/alerts/electricity/alert_electricity_annual_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/alert_electricity_annual_versus_benchmark.rb
@@ -306,7 +306,10 @@ class AlertElectricityAnnualVersusBenchmark < AlertElectricityOnlyBase
     @one_year_electricity_per_floor_area_£current = @last_year_£current / fa
     @one_year_electricity_per_floor_area_co2      = @last_year_co2      / fa
 
-    set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£current, @one_year_saving_versus_exemplar_£current), capital_cost, @one_year_saving_versus_exemplar_co2)
+    #set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£current, @one_year_saving_versus_exemplar_£current), capital_cost, @one_year_saving_versus_exemplar_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_£: @one_year_saving_versus_exemplar_£current,
+      one_year_saving_co2: @one_year_saving_versus_exemplar_co2)
 
     @per_pupil_electricity_benchmark_£          = @one_year_benchmark_by_pupil_£ / pup
     @per_pupil_electricity_benchmark_£current   = @one_year_benchmark_by_pupil_£current / pup

--- a/lib/dashboard/alerts/electricity/alert_electricity_annual_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/alert_electricity_annual_versus_benchmark.rb
@@ -306,7 +306,6 @@ class AlertElectricityAnnualVersusBenchmark < AlertElectricityOnlyBase
     @one_year_electricity_per_floor_area_£current = @last_year_£current / fa
     @one_year_electricity_per_floor_area_co2      = @last_year_co2      / fa
 
-    #set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£current, @one_year_saving_versus_exemplar_£current), capital_cost, @one_year_saving_versus_exemplar_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: @one_year_saving_versus_exemplar_kwh,
       one_year_saving_£: @one_year_saving_versus_exemplar_£current,

--- a/lib/dashboard/alerts/electricity/alert_peak_kw_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/alert_peak_kw_versus_benchmark.rb
@@ -87,7 +87,8 @@ class AlertElectricityPeakKWVersusBenchmark < AlertElectricityOnlyBase
 
     #set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£, @one_year_saving_versus_exemplar_£), nil, @one_year_saving_versus_exemplar_co2)
     assign_commmon_saving_variables(
-      one_year_saving_£: one_year_saving_versus_exemplar_£,
+      one_year_saving_kwh: @one_year_saving_versus_exemplar_kwh,
+      one_year_saving_£: @one_year_saving_versus_exemplar_£,
       one_year_saving_co2: @one_year_saving_versus_exemplar_co2)
 
     @term = :longterm

--- a/lib/dashboard/alerts/electricity/alert_peak_kw_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/alert_peak_kw_versus_benchmark.rb
@@ -85,7 +85,6 @@ class AlertElectricityPeakKWVersusBenchmark < AlertElectricityOnlyBase
 
     @rating = calculate_rating_from_range(benchmark_kw_m2, 0.02, @average_school_day_last_year_kw_per_floor_area)
 
-    #set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£, @one_year_saving_versus_exemplar_£), nil, @one_year_saving_versus_exemplar_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: @one_year_saving_versus_exemplar_kwh,
       one_year_saving_£: @one_year_saving_versus_exemplar_£,

--- a/lib/dashboard/alerts/electricity/alert_peak_kw_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/alert_peak_kw_versus_benchmark.rb
@@ -85,7 +85,10 @@ class AlertElectricityPeakKWVersusBenchmark < AlertElectricityOnlyBase
 
     @rating = calculate_rating_from_range(benchmark_kw_m2, 0.02, @average_school_day_last_year_kw_per_floor_area)
 
-    set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£, @one_year_saving_versus_exemplar_£), nil, @one_year_saving_versus_exemplar_co2)
+    #set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£, @one_year_saving_versus_exemplar_£), nil, @one_year_saving_versus_exemplar_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_£: one_year_saving_versus_exemplar_£,
+      one_year_saving_co2: @one_year_saving_versus_exemplar_co2)
 
     @term = :longterm
   end

--- a/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator.rb
+++ b/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator.rb
@@ -86,6 +86,7 @@ class AlertSolarPVBenefitEstimator < AlertElectricityOnlyBase
     #set_savings_capital_costs_payback(savings_range, optimum_scenario[:capital_cost_£], optimum_scenario[:total_annual_saving_co2])
 
     assign_commmon_saving_variables(
+      one_year_saving_kwh: optimum_scenario[:reduction_in_mains_kwh],
       one_year_saving_£: @one_year_saving_£current,
       capital_cost: optimum_scenario[:capital_cost_£],
       one_year_saving_co2: optimum_scenario[:total_annual_saving_co2])
@@ -207,6 +208,7 @@ class AlertSolarPVBenefitEstimator < AlertElectricityOnlyBase
       existing_annual_£:            £,
       new_mains_consumption_kwh:    kwh_totals[:new_mains_consumption],
       new_mains_consumption_£:      kwh_totals[:new_mains_consumption_£],
+      reduction_in_mains_kwh:       (kwh - kwh_totals[:new_mains_consumption]),
       reduction_in_mains_percent:   (kwh - kwh_totals[:new_mains_consumption]) / kwh,
       solar_consumed_onsite_kwh:    kwh_totals[:solar_consumed_onsite],
       exported_kwh:                 kwh_totals[:exported],

--- a/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator.rb
+++ b/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator.rb
@@ -82,8 +82,13 @@ class AlertSolarPVBenefitEstimator < AlertElectricityOnlyBase
     promote_optimum_variables(optimum_scenario)
 
     @one_year_saving_£current = optimum_scenario[:total_annual_saving_£]
-    savings_range = Range.new(@one_year_saving_£current, @one_year_saving_£current)
-    set_savings_capital_costs_payback(savings_range, optimum_scenario[:capital_cost_£], optimum_scenario[:total_annual_saving_co2])
+    #savings_range = Range.new(@one_year_saving_£current, @one_year_saving_£current)
+    #set_savings_capital_costs_payback(savings_range, optimum_scenario[:capital_cost_£], optimum_scenario[:total_annual_saving_co2])
+
+    assign_commmon_saving_variables(
+      one_year_saving_£: @one_year_saving_£current,
+      capital_cost: optimum_scenario[:capital_cost_£],
+      one_year_saving_co2: optimum_scenario[:total_annual_saving_co2])
 
     @rating = 5.0
   end
@@ -153,7 +158,7 @@ class AlertSolarPVBenefitEstimator < AlertElectricityOnlyBase
 
   def format_t(value, unit, medium)
     return value if medium == :raw
-    FormatEnergyUnit.format(unit, value, medium, false, true) 
+    FormatEnergyUnit.format(unit, value, medium, false, true)
   end
 
   def kwp_scenario_including_optimum(optimum_kwp)

--- a/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator.rb
+++ b/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator.rb
@@ -82,8 +82,6 @@ class AlertSolarPVBenefitEstimator < AlertElectricityOnlyBase
     promote_optimum_variables(optimum_scenario)
 
     @one_year_saving_£current = optimum_scenario[:total_annual_saving_£]
-    #savings_range = Range.new(@one_year_saving_£current, @one_year_saving_£current)
-    #set_savings_capital_costs_payback(savings_range, optimum_scenario[:capital_cost_£], optimum_scenario[:total_annual_saving_co2])
 
     assign_commmon_saving_variables(
       one_year_saving_kwh: optimum_scenario[:reduction_in_mains_kwh],

--- a/lib/dashboard/alerts/electricity/baseload/alert_change_in_electricity_baseload_short_term.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_change_in_electricity_baseload_short_term.rb
@@ -212,7 +212,9 @@ class AlertChangeInElectricityBaseloadShortTerm < AlertBaseloadBase
 
     @saving_in_annual_costs_through_10_percent_baseload_reduction = @last_year_baseload_£current * 0.1
 
-    set_savings_capital_costs_payback(Range.new(@next_year_change_in_baseload_£current, @next_year_change_in_baseload_£current), nil, @next_year_change_in_baseload_co2)
+    #set_savings_capital_costs_payback(Range.new(@next_year_change_in_baseload_£current, @next_year_change_in_baseload_£current), nil, @next_year_change_in_baseload_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_£: @next_year_change_in_baseload_£current, one_year_saving_co2: @next_year_change_in_baseload_co2)
 
     @rating = calculate_rating_from_range(-0.05, 0.15, @predicted_percent_increase_in_usage)
 

--- a/lib/dashboard/alerts/electricity/baseload/alert_change_in_electricity_baseload_short_term.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_change_in_electricity_baseload_short_term.rb
@@ -214,7 +214,9 @@ class AlertChangeInElectricityBaseloadShortTerm < AlertBaseloadBase
 
     #set_savings_capital_costs_payback(Range.new(@next_year_change_in_baseload_£current, @next_year_change_in_baseload_£current), nil, @next_year_change_in_baseload_co2)
     assign_commmon_saving_variables(
-      one_year_saving_£: @next_year_change_in_baseload_£current, one_year_saving_co2: @next_year_change_in_baseload_co2)
+      one_year_saving_kwh: @next_year_change_in_baseload_kwh,
+      one_year_saving_£: @next_year_change_in_baseload_£current,
+      one_year_saving_co2: @next_year_change_in_baseload_co2)
 
     @rating = calculate_rating_from_range(-0.05, 0.15, @predicted_percent_increase_in_usage)
 

--- a/lib/dashboard/alerts/electricity/baseload/alert_change_in_electricity_baseload_short_term.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_change_in_electricity_baseload_short_term.rb
@@ -212,7 +212,6 @@ class AlertChangeInElectricityBaseloadShortTerm < AlertBaseloadBase
 
     @saving_in_annual_costs_through_10_percent_baseload_reduction = @last_year_baseload_£current * 0.1
 
-    #set_savings_capital_costs_payback(Range.new(@next_year_change_in_baseload_£current, @next_year_change_in_baseload_£current), nil, @next_year_change_in_baseload_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: @next_year_change_in_baseload_kwh,
       one_year_saving_£: @next_year_change_in_baseload_£current,

--- a/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
@@ -254,7 +254,10 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
     @one_year_baseload_per_floor_area_co2  = @average_baseload_last_year_co2  / floor_area(asof_date - 365, asof_date)
 
     #set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£, @one_year_saving_versus_exemplar_£), nil, @one_year_saving_versus_exemplar_co2)
-    assign_commmon_saving_variables(one_year_saving_£: @one_year_saving_versus_exemplar_£, one_year_saving_co2: @one_year_saving_versus_exemplar_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_kwh: @one_year_saving_versus_exemplar_kwh,
+      one_year_saving_£: @one_year_saving_versus_exemplar_£,
+      one_year_saving_co2: @one_year_saving_versus_exemplar_co2)
 
     # rating: benchmark value = 4.0, exemplar = 10.0
     percent_from_benchmark_to_exemplar = (@average_baseload_last_year_kwh - @one_year_benchmark_by_pupil_kwh) / (@one_year_exemplar_by_pupil_kwh - @one_year_benchmark_by_pupil_kwh)

--- a/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
@@ -253,7 +253,8 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
     @one_year_baseload_per_floor_area_£    = @average_baseload_last_year_£    / floor_area(asof_date - 365, asof_date)
     @one_year_baseload_per_floor_area_co2  = @average_baseload_last_year_co2  / floor_area(asof_date - 365, asof_date)
 
-    set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£, @one_year_saving_versus_exemplar_£), nil, @one_year_saving_versus_exemplar_co2)
+    #set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£, @one_year_saving_versus_exemplar_£), nil, @one_year_saving_versus_exemplar_co2)
+    assign_commmon_saving_variables(one_year_saving_£: @one_year_saving_versus_exemplar_£, one_year_saving_co2: @one_year_saving_versus_exemplar_co2)
 
     # rating: benchmark value = 4.0, exemplar = 10.0
     percent_from_benchmark_to_exemplar = (@average_baseload_last_year_kwh - @one_year_benchmark_by_pupil_kwh) / (@one_year_exemplar_by_pupil_kwh - @one_year_benchmark_by_pupil_kwh)

--- a/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
@@ -253,7 +253,6 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
     @one_year_baseload_per_floor_area_£    = @average_baseload_last_year_£    / floor_area(asof_date - 365, asof_date)
     @one_year_baseload_per_floor_area_co2  = @average_baseload_last_year_co2  / floor_area(asof_date - 365, asof_date)
 
-    #set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£, @one_year_saving_versus_exemplar_£), nil, @one_year_saving_versus_exemplar_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: @one_year_saving_versus_exemplar_kwh,
       one_year_saving_£: @one_year_saving_versus_exemplar_£,

--- a/lib/dashboard/alerts/electricity/baseload/alert_intraweek_baseload_variation.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_intraweek_baseload_variation.rb
@@ -136,7 +136,8 @@ class AlertIntraweekBaseloadVariation < AlertBaseloadBase
     @annual_cost_£current = @annual_cost_kwh * blended_baseload_rate_£current_per_kwh
     @annual_co2           = @annual_cost_kwh * blended_co2_per_kwh
 
-    set_savings_capital_costs_payback(Range.new(@annual_cost_£current, @annual_cost_£), nil, @annual_co2)
+    #set_savings_capital_costs_payback(Range.new(@annual_cost_£current, @annual_cost_£), nil, @annual_co2)
+    assign_commmon_saving_variables(one_year_saving_£: Range.new(@annual_cost_£current, @annual_cost_£), one_year_saving_co2: @annual_co2)
 
     @rating = calculate_rating_from_range(0.1, 0.3, @percent_intraday_variation.magnitude)
 

--- a/lib/dashboard/alerts/electricity/baseload/alert_intraweek_baseload_variation.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_intraweek_baseload_variation.rb
@@ -137,7 +137,10 @@ class AlertIntraweekBaseloadVariation < AlertBaseloadBase
     @annual_co2           = @annual_cost_kwh * blended_co2_per_kwh
 
     #set_savings_capital_costs_payback(Range.new(@annual_cost_£current, @annual_cost_£), nil, @annual_co2)
-    assign_commmon_saving_variables(one_year_saving_£: Range.new(@annual_cost_£current, @annual_cost_£), one_year_saving_co2: @annual_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_kwh: @annual_cost_kwh,
+      one_year_saving_£: Range.new(@annual_cost_£current, @annual_cost_£),
+      one_year_saving_co2: @annual_co2)
 
     @rating = calculate_rating_from_range(0.1, 0.3, @percent_intraday_variation.magnitude)
 

--- a/lib/dashboard/alerts/electricity/baseload/alert_intraweek_baseload_variation.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_intraweek_baseload_variation.rb
@@ -136,7 +136,6 @@ class AlertIntraweekBaseloadVariation < AlertBaseloadBase
     @annual_cost_£current = @annual_cost_kwh * blended_baseload_rate_£current_per_kwh
     @annual_co2           = @annual_cost_kwh * blended_co2_per_kwh
 
-    #set_savings_capital_costs_payback(Range.new(@annual_cost_£current, @annual_cost_£), nil, @annual_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: @annual_cost_kwh,
       one_year_saving_£: Range.new(@annual_cost_£current, @annual_cost_£),

--- a/lib/dashboard/alerts/electricity/baseload/alert_seasonal_baseload_variation.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_seasonal_baseload_variation.rb
@@ -107,7 +107,10 @@ class AlertSeasonalBaseloadVariation < AlertBaseloadBase
     @annual_co2           = @annual_cost_kwh * blended_co2_per_kwh
 
     #set_savings_capital_costs_payback(Range.new(@annual_cost_£current, @annual_cost_£ ), nil, @annual_co2)
-    assign_commmon_saving_variables(one_year_saving_£: Range.new(@annual_cost_£current, @annual_cost_£ ), one_year_saving_co2: @annual_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_kwh: @annual_cost_kwh,
+      one_year_saving_£: Range.new(@annual_cost_£current, @annual_cost_£ ),
+      one_year_saving_co2: @annual_co2)
 
     @rating = calculate_rating_from_range(0, 0.50, @percent_seasonal_variation.magnitude)
 

--- a/lib/dashboard/alerts/electricity/baseload/alert_seasonal_baseload_variation.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_seasonal_baseload_variation.rb
@@ -106,7 +106,6 @@ class AlertSeasonalBaseloadVariation < AlertBaseloadBase
     @annual_cost_£current = @annual_cost_kwh * blended_baseload_rate_£current_per_kwh
     @annual_co2           = @annual_cost_kwh * blended_co2_per_kwh
 
-    #set_savings_capital_costs_payback(Range.new(@annual_cost_£current, @annual_cost_£ ), nil, @annual_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: @annual_cost_kwh,
       one_year_saving_£: Range.new(@annual_cost_£current, @annual_cost_£ ),

--- a/lib/dashboard/alerts/electricity/baseload/alert_seasonal_baseload_variation.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_seasonal_baseload_variation.rb
@@ -106,7 +106,8 @@ class AlertSeasonalBaseloadVariation < AlertBaseloadBase
     @annual_cost_£current = @annual_cost_kwh * blended_baseload_rate_£current_per_kwh
     @annual_co2           = @annual_cost_kwh * blended_co2_per_kwh
 
-    set_savings_capital_costs_payback(Range.new(@annual_cost_£current, @annual_cost_£ ), nil, @annual_co2)
+    #set_savings_capital_costs_payback(Range.new(@annual_cost_£current, @annual_cost_£ ), nil, @annual_co2)
+    assign_commmon_saving_variables(one_year_saving_£: Range.new(@annual_cost_£current, @annual_cost_£ ), one_year_saving_co2: @annual_co2)
 
     @rating = calculate_rating_from_range(0, 0.50, @percent_seasonal_variation.magnitude)
 

--- a/lib/dashboard/alerts/electricity/tariffs/alert_agreed_supply_capacity_limit.rb
+++ b/lib/dashboard/alerts/electricity/tariffs/alert_agreed_supply_capacity_limit.rb
@@ -78,7 +78,8 @@ class AlertMeterASCLimit < AlertElectricityOnlyBase
       @asc_limit_kw = aggregate_asc_limit_kw(@opportunities)
       @maximum_kw_meter_period_kw = aggregate_peak_kw(@opportunities)
       annual_saving_£ = aggregate_annual_saving_£(@opportunities)
-      set_savings_capital_costs_payback(Range.new(annual_saving_£, annual_saving_£), nil, 0.0)
+      #set_savings_capital_costs_payback(Range.new(annual_saving_£, annual_saving_£), nil, 0.0)
+      assign_commmon_saving_variables(one_year_saving_£: annual_saving_£, one_year_saving_co2: 0.0)
       @rating = calculate_rating_from_range(400.0, 3000.0, annual_saving_£)
     else
       @rating = 10.0

--- a/lib/dashboard/alerts/electricity/tariffs/alert_agreed_supply_capacity_limit.rb
+++ b/lib/dashboard/alerts/electricity/tariffs/alert_agreed_supply_capacity_limit.rb
@@ -78,7 +78,7 @@ class AlertMeterASCLimit < AlertElectricityOnlyBase
       @asc_limit_kw = aggregate_asc_limit_kw(@opportunities)
       @maximum_kw_meter_period_kw = aggregate_peak_kw(@opportunities)
       annual_saving_£ = aggregate_annual_saving_£(@opportunities)
-      #set_savings_capital_costs_payback(Range.new(annual_saving_£, annual_saving_£), nil, 0.0)
+
       assign_commmon_saving_variables(one_year_saving_£: annual_saving_£, one_year_saving_co2: 0.0)
       @rating = calculate_rating_from_range(400.0, 3000.0, annual_saving_£)
     else

--- a/lib/dashboard/alerts/electricity/tariffs/alert_differential_tariff_opportunity.rb
+++ b/lib/dashboard/alerts/electricity/tariffs/alert_differential_tariff_opportunity.rb
@@ -72,7 +72,8 @@ class AlertDifferentialTariffOpportunity < AlertElectricityOnlyBase
 
     @differential_tariff_opportunity_table, _total_saving = calculate_differential_tariff_opportunity_table(saving_info_by_meter)
 
-    set_savings_capital_costs_payback(Range.new(@total_potential_savings_£, @total_potential_savings_£), nil, 0.0)
+    #set_savings_capital_costs_payback(Range.new(@total_potential_savings_£, @total_potential_savings_£), nil, 0.0)
+    assign_commmon_saving_variables(one_year_saving_£: @total_potential_savings_£, one_year_saving_co2: 0.0)
 
     @rating = calculate_rating_from_range(100.0, 1000.0, @total_potential_savings_£)
   end

--- a/lib/dashboard/alerts/electricity/tariffs/alert_differential_tariff_opportunity.rb
+++ b/lib/dashboard/alerts/electricity/tariffs/alert_differential_tariff_opportunity.rb
@@ -72,7 +72,6 @@ class AlertDifferentialTariffOpportunity < AlertElectricityOnlyBase
 
     @differential_tariff_opportunity_table, _total_saving = calculate_differential_tariff_opportunity_table(saving_info_by_meter)
 
-    #set_savings_capital_costs_payback(Range.new(@total_potential_savings_£, @total_potential_savings_£), nil, 0.0)
     assign_commmon_saving_variables(one_year_saving_£: @total_potential_savings_£, one_year_saving_co2: 0.0)
 
     @rating = calculate_rating_from_range(100.0, 1000.0, @total_potential_savings_£)

--- a/lib/dashboard/alerts/electricity/tariffs/alert_meter_consolidation_opportunity.rb
+++ b/lib/dashboard/alerts/electricity/tariffs/alert_meter_consolidation_opportunity.rb
@@ -97,7 +97,8 @@ class AlertMeterConsolidationOpportunityBase < AlertAnalysisBase
     @high_annual_saving = @annual_total_standing_charge - (sorted_standing_charges.first * 365.0)
     one_year_saving_£ = Range.new(low_annual_saving, @high_annual_saving)
     capital_cost = Range.new(COST_OF_1_METER_CONSOLIDATION_£, COST_OF_1_METER_CONSOLIDATION_£ * (sorted_standing_charges.length - 1))
-    set_savings_capital_costs_payback(one_year_saving_£, capital_cost, 0.0)
+    #set_savings_capital_costs_payback(one_year_saving_£, capital_cost, 0.0)
+    assign_commmon_saving_variables(one_year_saving_£: one_year_saving_£, capital_cost: capital_cost, one_year_saving_co2: 0.0)
     @rating = number_of_live_meters <= 1 ? 10.0 : 0.0
   end
   alias_method :analyse_private, :calculate
@@ -146,4 +147,3 @@ class AlertGasMeterConsolidationOpportunity < AlertMeterConsolidationOpportunity
     @school.heat_meters
   end
 end
-

--- a/lib/dashboard/alerts/electricity/tariffs/alert_meter_consolidation_opportunity.rb
+++ b/lib/dashboard/alerts/electricity/tariffs/alert_meter_consolidation_opportunity.rb
@@ -97,7 +97,7 @@ class AlertMeterConsolidationOpportunityBase < AlertAnalysisBase
     @high_annual_saving = @annual_total_standing_charge - (sorted_standing_charges.first * 365.0)
     one_year_saving_£ = Range.new(low_annual_saving, @high_annual_saving)
     capital_cost = Range.new(COST_OF_1_METER_CONSOLIDATION_£, COST_OF_1_METER_CONSOLIDATION_£ * (sorted_standing_charges.length - 1))
-    #set_savings_capital_costs_payback(one_year_saving_£, capital_cost, 0.0)
+
     assign_commmon_saving_variables(one_year_saving_£: one_year_saving_£, capital_cost: capital_cost, one_year_saving_co2: 0.0)
     @rating = number_of_live_meters <= 1 ? 10.0 : 0.0
   end

--- a/lib/dashboard/alerts/gas/alert_change_in_daily_gas_short_term.rb
+++ b/lib/dashboard/alerts/gas/alert_change_in_daily_gas_short_term.rb
@@ -194,7 +194,8 @@ class AlertChangeInDailyGasShortTerm < AlertGasModelBase
     saving_co2 = heating_weeks * (@predicted_this_week_co2 - @predicted_last_week_co2)
     saving_co2 = 0.0 if saving_co2.nan?
 
-    set_savings_capital_costs_payback(Range.new(saving_£, saving_£), nil, saving_co2)
+    #set_savings_capital_costs_payback(Range.new(saving_£, saving_£), nil, saving_co2)
+    assign_commmon_saving_variables(one_year_saving_£: saving_£, one_year_saving_co2: saving_co2)
 
     # PH, 16Aug2019 - as this alert is being deprecated, make more fault tolerant: St Louis school only
     @difference_in_actual_versus_predicted_change_percent = 0.0 if @difference_in_actual_versus_predicted_change_percent.nan?

--- a/lib/dashboard/alerts/gas/alert_change_in_daily_gas_short_term.rb
+++ b/lib/dashboard/alerts/gas/alert_change_in_daily_gas_short_term.rb
@@ -189,7 +189,7 @@ class AlertChangeInDailyGasShortTerm < AlertGasModelBase
     heating_weeks = @heating_model.number_of_heating_days / days_in_week
 
     saving_kwh = heating_weeks * @predicted_changein_kwh
-    saving_kwh = 0.0 is saving_kwh.nan?
+    saving_kwh = 0.0 if saving_kwh.nan?
 
     saving_£ = heating_weeks * @predicted_change_in_cost
     saving_£ = 0.0 if saving_£.nan?

--- a/lib/dashboard/alerts/gas/alert_change_in_daily_gas_short_term.rb
+++ b/lib/dashboard/alerts/gas/alert_change_in_daily_gas_short_term.rb
@@ -197,7 +197,6 @@ class AlertChangeInDailyGasShortTerm < AlertGasModelBase
     saving_co2 = heating_weeks * @predicted_change_in_co2
     saving_co2 = 0.0 if saving_co2.nan?
 
-    #set_savings_capital_costs_payback(Range.new(saving_£, saving_£), nil, saving_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: saving_kwh,
       one_year_saving_£: saving_£,

--- a/lib/dashboard/alerts/gas/alert_change_in_daily_gas_short_term.rb
+++ b/lib/dashboard/alerts/gas/alert_change_in_daily_gas_short_term.rb
@@ -188,14 +188,20 @@ class AlertChangeInDailyGasShortTerm < AlertGasModelBase
 
     heating_weeks = @heating_model.number_of_heating_days / days_in_week
 
-    saving_£ = heating_weeks * (@predicted_this_week_cost - @predicted_last_week_cost)
+    saving_kwh = heating_weeks * @predicted_changein_kwh
+    saving_kwh = 0.0 is saving_kwh.nan?
+
+    saving_£ = heating_weeks * @predicted_change_in_cost
     saving_£ = 0.0 if saving_£.nan?
 
-    saving_co2 = heating_weeks * (@predicted_this_week_co2 - @predicted_last_week_co2)
+    saving_co2 = heating_weeks * @predicted_change_in_co2
     saving_co2 = 0.0 if saving_co2.nan?
 
     #set_savings_capital_costs_payback(Range.new(saving_£, saving_£), nil, saving_co2)
-    assign_commmon_saving_variables(one_year_saving_£: saving_£, one_year_saving_co2: saving_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_kwh: saving_kwh,
+      one_year_saving_£: saving_£,
+      one_year_saving_co2: saving_co2)
 
     # PH, 16Aug2019 - as this alert is being deprecated, make more fault tolerant: St Louis school only
     @difference_in_actual_versus_predicted_change_percent = 0.0 if @difference_in_actual_versus_predicted_change_percent.nan?

--- a/lib/dashboard/alerts/gas/alert_gas_annual_versus_benchmark.rb
+++ b/lib/dashboard/alerts/gas/alert_gas_annual_versus_benchmark.rb
@@ -395,7 +395,9 @@ class AlertGasAnnualVersusBenchmark < AlertGasModelBase
     raise_calculation_error_if_missing(percent_difference_from_average_per_floor_area: @percent_difference_from_average_per_floor_area)
 
     #set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£, @one_year_saving_versus_exemplar_£), nil, @one_year_saving_versus_exemplar_co2)
-    assign_commmon_saving_variables(one_year_saving_£: @one_year_saving_versus_exemplar_£,
+    assign_commmon_saving_variables(
+      one_year_saving_kwh: @one_year_saving_versus_exemplar_kwh,
+      one_year_saving_£: @one_year_saving_versus_exemplar_£,
       one_year_saving_co2: @one_year_saving_versus_exemplar_co2)
 
     # rating: benchmark value = 4.0, exemplar = 10.0

--- a/lib/dashboard/alerts/gas/alert_gas_annual_versus_benchmark.rb
+++ b/lib/dashboard/alerts/gas/alert_gas_annual_versus_benchmark.rb
@@ -394,7 +394,9 @@ class AlertGasAnnualVersusBenchmark < AlertGasModelBase
     #BACKWARDS COMPATIBILITY: previously would have failed here as percent_change can return nil
     raise_calculation_error_if_missing(percent_difference_from_average_per_floor_area: @percent_difference_from_average_per_floor_area)
 
-    set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£, @one_year_saving_versus_exemplar_£), nil, @one_year_saving_versus_exemplar_co2)
+    #set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£, @one_year_saving_versus_exemplar_£), nil, @one_year_saving_versus_exemplar_co2)
+    assign_commmon_saving_variables(one_year_saving_£: @one_year_saving_versus_exemplar_£,
+      one_year_saving_co2: @one_year_saving_versus_exemplar_co2)
 
     # rating: benchmark value = 4.0, exemplar = 10.0
     percent_from_benchmark_to_exemplar = (@last_year_kwh - @one_year_benchmark_floor_area_kwh) / (@one_year_exemplar_floor_area_kwh - @one_year_benchmark_floor_area_kwh)

--- a/lib/dashboard/alerts/gas/alert_gas_annual_versus_benchmark.rb
+++ b/lib/dashboard/alerts/gas/alert_gas_annual_versus_benchmark.rb
@@ -394,7 +394,6 @@ class AlertGasAnnualVersusBenchmark < AlertGasModelBase
     #BACKWARDS COMPATIBILITY: previously would have failed here as percent_change can return nil
     raise_calculation_error_if_missing(percent_difference_from_average_per_floor_area: @percent_difference_from_average_per_floor_area)
 
-    #set_savings_capital_costs_payback(Range.new(@one_year_saving_versus_exemplar_£, @one_year_saving_versus_exemplar_£), nil, @one_year_saving_versus_exemplar_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: @one_year_saving_versus_exemplar_kwh,
       one_year_saving_£: @one_year_saving_versus_exemplar_£,

--- a/lib/dashboard/alerts/gas/alert_weekend_gas_consumption_short_term.rb
+++ b/lib/dashboard/alerts/gas/alert_weekend_gas_consumption_short_term.rb
@@ -235,7 +235,8 @@ class AlertWeekendGasConsumptionShortTerm < AlertGasModelBase
     potential_savings_£current  = 52.0 * (@last_weekend_cost_£current   - @average_weekend_gas_£current)
     potential_savings_co2 = 52.0 * (@last_weekend_cost_co2 - @average_weekend_gas_co2)
 
-    set_savings_capital_costs_payback(potential_savings_£current, 0.0, potential_savings_co2)
+    #set_savings_capital_costs_payback(potential_savings_£current, 0.0, potential_savings_co2)
+    assign_commmon_saving_variables(one_year_saving_£: potential_savings_£current, capital_cost: 0.0, one_year_saving_co2: potential_savings_co2)
 
     @rating = @last_weekend_cost_£current < MAX_COST ? 10.0 : combined_rating
 

--- a/lib/dashboard/alerts/gas/alert_weekend_gas_consumption_short_term.rb
+++ b/lib/dashboard/alerts/gas/alert_weekend_gas_consumption_short_term.rb
@@ -231,12 +231,17 @@ class AlertWeekendGasConsumptionShortTerm < AlertGasModelBase
     of_annual_rating = calculate_rating_from_range(0.02, 0.12, @projected_percent_of_annual)
     combined_rating = increase_rating_on_year * of_annual_rating * increase_rating_on_last_5_weeks / 100.0
 
+    potential_savings_kwh       = 52.0 * (@last_year_weekend_gas_kwh    - @average_weekend_gas_kwh)
     potential_savings_£         = 52.0 * (@last_weekend_cost_£          - @average_weekend_gas_£)
     potential_savings_£current  = 52.0 * (@last_weekend_cost_£current   - @average_weekend_gas_£current)
-    potential_savings_co2 = 52.0 * (@last_weekend_cost_co2 - @average_weekend_gas_co2)
+    potential_savings_co2       = 52.0 * (@last_weekend_cost_co2        - @average_weekend_gas_co2)
 
     #set_savings_capital_costs_payback(potential_savings_£current, 0.0, potential_savings_co2)
-    assign_commmon_saving_variables(one_year_saving_£: potential_savings_£current, capital_cost: 0.0, one_year_saving_co2: potential_savings_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_kwh: potential_savings_kwh,
+      one_year_saving_£: potential_savings_£current,
+      capital_cost: 0.0,
+      one_year_saving_co2: potential_savings_co2)
 
     @rating = @last_weekend_cost_£current < MAX_COST ? 10.0 : combined_rating
 

--- a/lib/dashboard/alerts/gas/alert_weekend_gas_consumption_short_term.rb
+++ b/lib/dashboard/alerts/gas/alert_weekend_gas_consumption_short_term.rb
@@ -236,7 +236,6 @@ class AlertWeekendGasConsumptionShortTerm < AlertGasModelBase
     potential_savings_£current  = 52.0 * (@last_weekend_cost_£current   - @average_weekend_gas_£current)
     potential_savings_co2       = 52.0 * (@last_weekend_cost_co2        - @average_weekend_gas_co2)
 
-    #set_savings_capital_costs_payback(potential_savings_£current, 0.0, potential_savings_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: potential_savings_kwh,
       one_year_saving_£: potential_savings_£current,

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_coming_on_too_early.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_coming_on_too_early.rb
@@ -99,6 +99,7 @@ class AlertHeatingComingOnTooEarly < AlertGasModelBase
 
     #set_savings_capital_costs_payback(Range.new(0.0, @one_year_optimum_start_saving_£current), Range.new(0.0, 700.0), @one_year_optimum_start_saving_co2)
     assign_commmon_saving_variables(
+      one_year_saving_kwh: @one_year_optimum_start_saving_kwh,
       one_year_saving_£: Range.new(0.0, @one_year_optimum_start_saving_£current),
       capital_cost: Range.new(0.0, 700.0),
       one_year_saving_co2: @one_year_optimum_start_saving_co2)

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_coming_on_too_early.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_coming_on_too_early.rb
@@ -97,7 +97,11 @@ class AlertHeatingComingOnTooEarly < AlertGasModelBase
     @one_year_optimum_start_saving_£current, _p                = hm_1_year_saving(asof_date, :£current)
     @one_year_optimum_start_saving_co2, _p                     = hm_1_year_saving(asof_date, :co2)
 
-    set_savings_capital_costs_payback(Range.new(0.0, @one_year_optimum_start_saving_£current), Range.new(0.0, 700.0), @one_year_optimum_start_saving_co2)
+    #set_savings_capital_costs_payback(Range.new(0.0, @one_year_optimum_start_saving_£current), Range.new(0.0, 700.0), @one_year_optimum_start_saving_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_£: Range.new(0.0, @one_year_optimum_start_saving_£current),
+      capital_cost: Range.new(0.0, 700.0),
+      one_year_saving_co2: @one_year_optimum_start_saving_co2)
 
     @rating = calculate_rating_from_range(1.0, 0.0, rating_7_day)
 

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_coming_on_too_early.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_coming_on_too_early.rb
@@ -97,7 +97,6 @@ class AlertHeatingComingOnTooEarly < AlertGasModelBase
     @one_year_optimum_start_saving_£current, _p                = hm_1_year_saving(asof_date, :£current)
     @one_year_optimum_start_saving_co2, _p                     = hm_1_year_saving(asof_date, :co2)
 
-    #set_savings_capital_costs_payback(Range.new(0.0, @one_year_optimum_start_saving_£current), Range.new(0.0, 700.0), @one_year_optimum_start_saving_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: @one_year_optimum_start_saving_kwh,
       one_year_saving_£: Range.new(0.0, @one_year_optimum_start_saving_£current),

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_off.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_off.rb
@@ -154,7 +154,6 @@ class AlertTurnHeatingOff < AlertGasModelBase
 
     calculate_forecast_benefit(@today)
 
-    #set_savings_capital_costs_payback(@future_saving_£, 0.0, @future_saving_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: @future_saving_kwh,
       one_year_saving_£: @future_saving_£,

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_off.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_off.rb
@@ -154,7 +154,8 @@ class AlertTurnHeatingOff < AlertGasModelBase
 
     calculate_forecast_benefit(@today)
 
-    set_savings_capital_costs_payback(@future_saving_£, 0.0, @future_saving_co2)
+    #set_savings_capital_costs_payback(@future_saving_£, 0.0, @future_saving_co2)
+    assign_commmon_saving_variables(one_year_saving_£: @future_saving_£, capital_cost: 0.0, one_year_saving_co2: @future_saving_co2)
 
     set_up_to_dateness_of_meter
 

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_off.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_off.rb
@@ -155,7 +155,11 @@ class AlertTurnHeatingOff < AlertGasModelBase
     calculate_forecast_benefit(@today)
 
     #set_savings_capital_costs_payback(@future_saving_£, 0.0, @future_saving_co2)
-    assign_commmon_saving_variables(one_year_saving_£: @future_saving_£, capital_cost: 0.0, one_year_saving_co2: @future_saving_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_kwh: @future_saving_kwh,
+      one_year_saving_£: @future_saving_£,
+      capital_cost: 0.0,
+      one_year_saving_co2: @future_saving_co2)
 
     set_up_to_dateness_of_meter
 

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_temperature_change_advice.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_temperature_change_advice.rb
@@ -61,7 +61,8 @@ class AlertHeatingSensitivityAdvice < AlertGasModelBase
     @annual_saving_1_C_change_kwh *= (365 / (asof_date - start_date)) # scale to 1 year
     @annual_saving_1_C_change_£   = @annual_saving_1_C_change_kwh * aggregate_meter.amr_data.current_tariff_rate_£_per_kwh
     @annual_saving_1_C_change_co2 = @annual_saving_1_C_change_kwh * EnergyEquivalences::UK_GAS_CO2_KG_KWH
-    set_savings_capital_costs_payback(Range.new(@annual_saving_1_C_change_£, @annual_saving_1_C_change_£), nil, @annual_saving_1_C_change_co2)
+    #set_savings_capital_costs_payback(Range.new(@annual_saving_1_C_change_£, @annual_saving_1_C_change_£), nil, @annual_saving_1_C_change_co2)
+    assign_commmon_saving_variables(one_year_saving_£: @annual_saving_1_C_change_£, one_year_saving_co2: @annual_saving_1_C_change_co2)
 
     @fabric_boiler_efficiency_kwh_c_per_1000_m2_floor_area_day = 1000.0 * heating_model.average_heating_b_kwh_per_1_C_per_day / floor_area(asof_date - 365, asof_date)
     @rating = @annual_saving_1_C_change_£ > MIN_REPORTED_SENSITIVITY_£ ? 5.0 : 10.0

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_temperature_change_advice.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_temperature_change_advice.rb
@@ -62,7 +62,10 @@ class AlertHeatingSensitivityAdvice < AlertGasModelBase
     @annual_saving_1_C_change_£   = @annual_saving_1_C_change_kwh * aggregate_meter.amr_data.current_tariff_rate_£_per_kwh
     @annual_saving_1_C_change_co2 = @annual_saving_1_C_change_kwh * EnergyEquivalences::UK_GAS_CO2_KG_KWH
     #set_savings_capital_costs_payback(Range.new(@annual_saving_1_C_change_£, @annual_saving_1_C_change_£), nil, @annual_saving_1_C_change_co2)
-    assign_commmon_saving_variables(one_year_saving_£: @annual_saving_1_C_change_£, one_year_saving_co2: @annual_saving_1_C_change_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_kwh: @annual_saving_1_C_change_kwh,
+      one_year_saving_£: @annual_saving_1_C_change_£,
+      one_year_saving_co2: @annual_saving_1_C_change_co2)
 
     @fabric_boiler_efficiency_kwh_c_per_1000_m2_floor_area_day = 1000.0 * heating_model.average_heating_b_kwh_per_1_C_per_day / floor_area(asof_date - 365, asof_date)
     @rating = @annual_saving_1_C_change_£ > MIN_REPORTED_SENSITIVITY_£ ? 5.0 : 10.0

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_temperature_change_advice.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_temperature_change_advice.rb
@@ -61,7 +61,6 @@ class AlertHeatingSensitivityAdvice < AlertGasModelBase
     @annual_saving_1_C_change_kwh *= (365 / (asof_date - start_date)) # scale to 1 year
     @annual_saving_1_C_change_£   = @annual_saving_1_C_change_kwh * aggregate_meter.amr_data.current_tariff_rate_£_per_kwh
     @annual_saving_1_C_change_co2 = @annual_saving_1_C_change_kwh * EnergyEquivalences::UK_GAS_CO2_KG_KWH
-    #set_savings_capital_costs_payback(Range.new(@annual_saving_1_C_change_£, @annual_saving_1_C_change_£), nil, @annual_saving_1_C_change_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: @annual_saving_1_C_change_kwh,
       one_year_saving_£: @annual_saving_1_C_change_£,

--- a/lib/dashboard/alerts/gas/boiler control/alert_school_heating_days.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_school_heating_days.rb
@@ -132,7 +132,8 @@ class AlertHeatingOnSchoolDaysDeprecated < AlertHeatingDaysBase
     @one_year_saving_reduced_days_to_exemplar_co2 = gas_co2(@one_year_saving_reduced_days_to_exemplar_kwh)
 
     one_year_saving_£ = Range.new(@one_year_saving_reduced_days_to_average_£, @one_year_saving_reduced_days_to_exemplar_£)
-    set_savings_capital_costs_payback(one_year_saving_£, nil, @one_year_saving_reduced_days_to_exemplar_co2)
+    #set_savings_capital_costs_payback(one_year_saving_£, nil, @one_year_saving_reduced_days_to_exemplar_co2)
+    assign_commmon_saving_variables(one_year_saving_£: one_year_saving_£, one_year_saving_co2: @one_year_saving_reduced_days_to_exemplar_co2)
 
     @rating = statistics.school_day_heating_rating_out_of_10(days)
 

--- a/lib/dashboard/alerts/gas/boiler control/alert_school_heating_days.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_school_heating_days.rb
@@ -133,7 +133,10 @@ class AlertHeatingOnSchoolDaysDeprecated < AlertHeatingDaysBase
 
     one_year_saving_£ = Range.new(@one_year_saving_reduced_days_to_average_£, @one_year_saving_reduced_days_to_exemplar_£)
     #set_savings_capital_costs_payback(one_year_saving_£, nil, @one_year_saving_reduced_days_to_exemplar_co2)
-    assign_commmon_saving_variables(one_year_saving_£: one_year_saving_£, one_year_saving_co2: @one_year_saving_reduced_days_to_exemplar_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_kwh: @one_year_saving_reduced_days_to_exemplar_kwh,
+      one_year_saving_£: one_year_saving_£,
+      one_year_saving_co2: @one_year_saving_reduced_days_to_exemplar_co2)
 
     @rating = statistics.school_day_heating_rating_out_of_10(days)
 

--- a/lib/dashboard/alerts/gas/boiler control/alert_school_heating_days.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_school_heating_days.rb
@@ -132,7 +132,7 @@ class AlertHeatingOnSchoolDaysDeprecated < AlertHeatingDaysBase
     @one_year_saving_reduced_days_to_exemplar_co2 = gas_co2(@one_year_saving_reduced_days_to_exemplar_kwh)
 
     one_year_saving_£ = Range.new(@one_year_saving_reduced_days_to_average_£, @one_year_saving_reduced_days_to_exemplar_£)
-    #set_savings_capital_costs_payback(one_year_saving_£, nil, @one_year_saving_reduced_days_to_exemplar_co2)
+
     assign_commmon_saving_variables(
       one_year_saving_kwh: @one_year_saving_reduced_days_to_exemplar_kwh,
       one_year_saving_£: one_year_saving_£,

--- a/lib/dashboard/alerts/gas/boiler control/alert_seasonal_heating_schooldays.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_seasonal_heating_schooldays.rb
@@ -60,7 +60,11 @@ class AlertSeasonalHeatingSchoolDays < AlertHeatingDaysBase
 
     calculate_adhoc_values(asof_date)
 
-    set_savings_capital_costs_payback(warm_weather_heating_days_all_days_£current, 0.0, warm_weather_heating_days_all_days_co2)
+    #set_savings_capital_costs_payback(warm_weather_heating_days_all_days_£current, 0.0, warm_weather_heating_days_all_days_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_£: warm_weather_heating_days_all_days_£current,
+      capital_cost: 0.0,
+      one_year_saving_co2: warm_weather_heating_days_all_days_co2)
 
     @rating = calculate_rating_from_range(0.03, 0.12, percent_of_annual_heating)
 

--- a/lib/dashboard/alerts/gas/boiler control/alert_seasonal_heating_schooldays.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_seasonal_heating_schooldays.rb
@@ -60,7 +60,6 @@ class AlertSeasonalHeatingSchoolDays < AlertHeatingDaysBase
 
     calculate_adhoc_values(asof_date)
 
-    #set_savings_capital_costs_payback(warm_weather_heating_days_all_days_£current, 0.0, warm_weather_heating_days_all_days_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: warm_weather_heating_days_all_days_kwh,
       one_year_saving_£: warm_weather_heating_days_all_days_£current,

--- a/lib/dashboard/alerts/gas/boiler control/alert_seasonal_heating_schooldays.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_seasonal_heating_schooldays.rb
@@ -62,6 +62,7 @@ class AlertSeasonalHeatingSchoolDays < AlertHeatingDaysBase
 
     #set_savings_capital_costs_payback(warm_weather_heating_days_all_days_£current, 0.0, warm_weather_heating_days_all_days_co2)
     assign_commmon_saving_variables(
+      one_year_saving_kwh: warm_weather_heating_days_all_days_kwh,
       one_year_saving_£: warm_weather_heating_days_all_days_£current,
       capital_cost: 0.0,
       one_year_saving_co2: warm_weather_heating_days_all_days_co2)

--- a/lib/dashboard/alerts/gas/boiler control/alert_thermostatic_control.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_thermostatic_control.rb
@@ -99,7 +99,6 @@ class AlertThermostaticControl < AlertGasModelBase
     @potential_saving_kwh, @potential_saving_£ = calculate_annual_heating_deviance_from_model(asof_date)
     @potential_saving_co2 = gas_co2(@potential_saving_kwh)
 
-    #set_savings_capital_costs_payback(@potential_saving_£, 1000.0, @potential_saving_co2) # suggested £1,000 cost
     assign_commmon_saving_variables(
       one_year_saving_kwh: @potential_saving_kwh,
       one_year_saving_£: @potential_saving_£,

--- a/lib/dashboard/alerts/gas/boiler control/alert_thermostatic_control.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_thermostatic_control.rb
@@ -99,7 +99,8 @@ class AlertThermostaticControl < AlertGasModelBase
     @potential_saving_kwh, @potential_saving_£ = calculate_annual_heating_deviance_from_model(asof_date)
     @potential_saving_co2 = gas_co2(@potential_saving_kwh)
 
-    set_savings_capital_costs_payback(@potential_saving_£, 1000.0, @potential_saving_co2) # suggested £1,000 cost
+    #set_savings_capital_costs_payback(@potential_saving_£, 1000.0, @potential_saving_co2) # suggested £1,000 cost
+    assign_commmon_saving_variables(one_year_saving_£: @potential_saving_£, capital_cost: 1000.0, one_year_saving_co2: @potential_saving_co2) # suggested £1,000 cost
 
     @rating = r2_rating_out_of_10
 

--- a/lib/dashboard/alerts/gas/boiler control/alert_thermostatic_control.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_thermostatic_control.rb
@@ -100,7 +100,11 @@ class AlertThermostaticControl < AlertGasModelBase
     @potential_saving_co2 = gas_co2(@potential_saving_kwh)
 
     #set_savings_capital_costs_payback(@potential_saving_£, 1000.0, @potential_saving_co2) # suggested £1,000 cost
-    assign_commmon_saving_variables(one_year_saving_£: @potential_saving_£, capital_cost: 1000.0, one_year_saving_co2: @potential_saving_co2) # suggested £1,000 cost
+    assign_commmon_saving_variables(
+      one_year_saving_kwh: @potential_saving_kwh,
+      one_year_saving_£: @potential_saving_£,
+      capital_cost: 1000.0,
+      one_year_saving_co2: @potential_saving_co2) # suggested £1,000 cost
 
     @rating = r2_rating_out_of_10
 

--- a/lib/dashboard/alerts/gas/hot water/alert_hot_water_efficiency.rb
+++ b/lib/dashboard/alerts/gas/hot water/alert_hot_water_efficiency.rb
@@ -126,7 +126,11 @@ class AlertHotWaterEfficiency < AlertGasModelBase
 
       one_year_saving_£ = one_year_saving_calculation
       capital_costs_£ = @existing_gas_capex..@point_of_use_electric_capex
-      set_savings_capital_costs_payback(one_year_saving_£, electric_point_of_use_hotwater_costs, @electric_hot_water_saving_co2)
+      #set_savings_capital_costs_payback(one_year_saving_£, electric_point_of_use_hotwater_costs, @electric_hot_water_saving_co2)
+      assign_commmon_saving_variables(
+        one_year_saving_£: one_year_saving_£,
+        capital_cost: electric_point_of_use_hotwater_costs,
+        one_year_saving_co2: @electric_hot_water_saving_co2)
 
       @rating = calculate_rating_from_range(0.6, 0.05, @existing_gas_efficiency)
 

--- a/lib/dashboard/alerts/gas/hot water/alert_hot_water_efficiency.rb
+++ b/lib/dashboard/alerts/gas/hot water/alert_hot_water_efficiency.rb
@@ -126,7 +126,7 @@ class AlertHotWaterEfficiency < AlertGasModelBase
 
       one_year_saving_£ = one_year_saving_calculation
       capital_costs_£ = @existing_gas_capex..@point_of_use_electric_capex
-      #set_savings_capital_costs_payback(one_year_saving_£, electric_point_of_use_hotwater_costs, @electric_hot_water_saving_co2)
+
       assign_commmon_saving_variables(
         one_year_saving_£: one_year_saving_£,
         capital_cost: electric_point_of_use_hotwater_costs,

--- a/lib/dashboard/alerts/gas/hot water/alert_poorly_insulated_hotwater.rb
+++ b/lib/dashboard/alerts/gas/hot water/alert_poorly_insulated_hotwater.rb
@@ -85,7 +85,8 @@ class AlertHotWaterInsulationAdvice < AlertGasModelBase
     @annual_hotwater_poor_insulation_heatloss_estimate_percent = savings_percent
 
     one_year_saving_£ = Range.new(@annual_hotwater_poor_insulation_heatloss_estimate_£ * 0.7, @annual_hotwater_poor_insulation_heatloss_estimate_£ * 1.3)
-    set_savings_capital_costs_payback(one_year_saving_£, nil, @annual_hotwater_poor_insulation_heatloss_estimate_co2)
+    #set_savings_capital_costs_payback(one_year_saving_£, nil, @annual_hotwater_poor_insulation_heatloss_estimate_co2)
+    assign_commmon_saving_variables(one_year_saving_£: one_year_saving_£, one_year_saving_co2: @annual_hotwater_poor_insulation_heatloss_estimate_co2)
   end
 
   private def calculate(asof_date)

--- a/lib/dashboard/alerts/gas/hot water/alert_poorly_insulated_hotwater.rb
+++ b/lib/dashboard/alerts/gas/hot water/alert_poorly_insulated_hotwater.rb
@@ -86,7 +86,10 @@ class AlertHotWaterInsulationAdvice < AlertGasModelBase
 
     one_year_saving_£ = Range.new(@annual_hotwater_poor_insulation_heatloss_estimate_£ * 0.7, @annual_hotwater_poor_insulation_heatloss_estimate_£ * 1.3)
     #set_savings_capital_costs_payback(one_year_saving_£, nil, @annual_hotwater_poor_insulation_heatloss_estimate_co2)
-    assign_commmon_saving_variables(one_year_saving_£: one_year_saving_£, one_year_saving_co2: @annual_hotwater_poor_insulation_heatloss_estimate_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_kwh: @annual_hotwater_poor_insulation_heatloss_estimate_kwh,
+      one_year_saving_£: one_year_saving_£,
+      one_year_saving_co2: @annual_hotwater_poor_insulation_heatloss_estimate_co2)
   end
 
   private def calculate(asof_date)

--- a/lib/dashboard/alerts/gas/hot water/alert_poorly_insulated_hotwater.rb
+++ b/lib/dashboard/alerts/gas/hot water/alert_poorly_insulated_hotwater.rb
@@ -85,7 +85,7 @@ class AlertHotWaterInsulationAdvice < AlertGasModelBase
     @annual_hotwater_poor_insulation_heatloss_estimate_percent = savings_percent
 
     one_year_saving_£ = Range.new(@annual_hotwater_poor_insulation_heatloss_estimate_£ * 0.7, @annual_hotwater_poor_insulation_heatloss_estimate_£ * 1.3)
-    #set_savings_capital_costs_payback(one_year_saving_£, nil, @annual_hotwater_poor_insulation_heatloss_estimate_co2)
+
     assign_commmon_saving_variables(
       one_year_saving_kwh: @annual_hotwater_poor_insulation_heatloss_estimate_kwh,
       one_year_saving_£: one_year_saving_£,

--- a/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
@@ -243,7 +243,11 @@ class AlertPeriodComparisonBase < AlertAnalysisBase
     set_equivalence_variables(self.class.equivalence_template_variables)
 
     #set_savings_capital_costs_payback(@difference_£current, 0.0, @difference_co2)
-    assign_commmon_saving_variables(one_year_saving_£: @difference_£current, capital_cost: 0.0, one_year_saving_co2: @difference_co2)
+    assign_commmon_saving_variables(
+      one_year_saving_kwh: @difference_kwh,
+      one_year_saving_£: @difference_£current,
+      capital_cost: 0.0,
+      one_year_saving_co2: @difference_co2)
 
     @rating = calculate_rating(@change_in_weekly_percent, @change_in_weekly_£, fuel_type)
 

--- a/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
@@ -242,7 +242,9 @@ class AlertPeriodComparisonBase < AlertAnalysisBase
 
     set_equivalence_variables(self.class.equivalence_template_variables)
 
-    set_savings_capital_costs_payback(@difference_£current, 0.0, @difference_co2)
+    #set_savings_capital_costs_payback(@difference_£current, 0.0, @difference_co2)
+    assign_commmon_saving_variables(one_year_saving_£: @difference_£current, capital_cost: 0.0, one_year_saving_co2: @difference_co2)
+
     @rating = calculate_rating(@change_in_weekly_percent, @change_in_weekly_£, fuel_type)
 
     @bookmark_url = add_book_mark_to_base_url(url_bookmark)

--- a/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
@@ -242,7 +242,6 @@ class AlertPeriodComparisonBase < AlertAnalysisBase
 
     set_equivalence_variables(self.class.equivalence_template_variables)
 
-    #set_savings_capital_costs_payback(@difference_£current, 0.0, @difference_co2)
     assign_commmon_saving_variables(
       one_year_saving_kwh: @difference_kwh,
       one_year_saving_£: @difference_£current,

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -9,40 +9,40 @@ require_rel '../../test_support'
 
 asof_date = Date.new(2023, 6, 4)
 # schools = ['t*']
-schools = ['derb*']
+schools = ['*']
 
 overrides = {
   schools:  schools,
   cache_school: false,
   alerts:   { alerts: nil, control: { asof_date: asof_date} },
   alerts:   { alerts: [
-#    AlertThermostaticControl
-#    AlertEnergyAnnualVersusBenchmark,
-#    AlertSchoolWeekComparisonGas,
-#    AlertOutOfHoursElectricityUsage,
+    AlertThermostaticControl,
+    AlertEnergyAnnualVersusBenchmark,
+    AlertSchoolWeekComparisonGas,
+    AlertOutOfHoursElectricityUsage,
     AlertElectricityBaseloadVersusBenchmark,
-#    AlertHeatingComingOnTooEarly,
-#    AlertPreviousYearHolidayComparisonElectricity,
-#    AlertSolarPVBenefitEstimator,
-#    AlertElectricityAnnualVersusBenchmark,
-#    AlertElectricityLongTermTrend,
-#    AlertGasAnnualVersusBenchmark,
-#    AlertEnergyAnnualVersusBenchmark,
-#    AlertElectricityPeakKWVersusBenchmark,
-#    AlertElectricityBaseloadVersusBenchmark,
-#    AlertSeasonalBaseloadVariation,
-#    AlertIntraweekBaseloadVariation,
-#    AlertGasAnnualVersusBenchmark,
-#    AlertGasLongTermTrend,
-#    AlertChangeInElectricityBaseloadShortTerm,
-#    AlertPreviousYearHolidayComparisonElectricity,
-#    AlertPreviousHolidayComparisonElectricity,
-#    AlertLayerUpPowerdown11November2022ElectricityComparison,
-#    AlertEaster2023ShutdownElectricityComparison,
-#    AlertEaster2023ShutdownGasComparison,
-#    AlertEaster2023ShutdownStorageHeaterComparison
-#    AlertOutOfHoursElectricityUsagePreviousYear
-     AlertSolarGeneration
+    AlertHeatingComingOnTooEarly,
+    AlertPreviousYearHolidayComparisonElectricity,
+    AlertSolarPVBenefitEstimator,
+    AlertElectricityAnnualVersusBenchmark,
+    AlertElectricityLongTermTrend,
+    AlertGasAnnualVersusBenchmark,
+    AlertEnergyAnnualVersusBenchmark,
+    AlertElectricityPeakKWVersusBenchmark,
+    AlertElectricityBaseloadVersusBenchmark,
+    AlertSeasonalBaseloadVariation,
+    AlertIntraweekBaseloadVariation,
+    AlertGasAnnualVersusBenchmark,
+    AlertGasLongTermTrend,
+    AlertChangeInElectricityBaseloadShortTerm,
+    AlertPreviousYearHolidayComparisonElectricity,
+    AlertPreviousHolidayComparisonElectricity,
+    AlertLayerUpPowerdown11November2022ElectricityComparison,
+    AlertEaster2023ShutdownElectricityComparison,
+    AlertEaster2023ShutdownGasComparison,
+    AlertEaster2023ShutdownStorageHeaterComparison,
+    AlertOutOfHoursElectricityUsagePreviousYear
+#     AlertSolarGeneration
     ],
   control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving html_template_variables], log: [:invalid_alerts] } },
   no_alerts:   { alerts: [], control: { asof_date: asof_date } }

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -9,7 +9,7 @@ require_rel '../../test_support'
 
 asof_date = Date.new(2023, 6, 4)
 # schools = ['t*']
-schools = ['*']
+schools = ['derb*']
 
 overrides = {
   schools:  schools,
@@ -20,7 +20,7 @@ overrides = {
 #    AlertEnergyAnnualVersusBenchmark,
 #    AlertSchoolWeekComparisonGas,
 #    AlertOutOfHoursElectricityUsage,
-#    AlertElectricityBaseloadVersusBenchmark,
+    AlertElectricityBaseloadVersusBenchmark,
 #    AlertHeatingComingOnTooEarly,
 #    AlertPreviousYearHolidayComparisonElectricity,
 #    AlertSolarPVBenefitEstimator,

--- a/spec/lib/dashboard/alerts/common/alert_analysis_base_spec.rb
+++ b/spec/lib/dashboard/alerts/common/alert_analysis_base_spec.rb
@@ -23,19 +23,19 @@ describe AlertAnalysisBase do
     end
 
     it 'assigns one_year_saving_co2' do
-      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 0.0, capital_cost: 0.0, one_year_saving_co2: 100.0)
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 0.0, one_year_saving_co2: 100.0)
       expect(alert.one_year_saving_co2).to eq(100.0)
       expect(alert.ten_year_saving_co2).to eq(1000.0)
     end
 
     it 'assigns average_one_year_saving_£' do
-      alert.send(:assign_commmon_saving_variables, one_year_saving_£: nil, capital_cost: 0.0, one_year_saving_co2: 0.0)
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: nil, one_year_saving_co2: 0.0)
       expect(alert.one_year_saving_£).to eq(nil)
       expect(alert.ten_year_saving_£).to eq(0.0)
       expect(alert.average_one_year_saving_£).to eq 0.0
       expect(alert.average_ten_year_saving_£).to eq 0.0
 
-      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 100.0, capital_cost: 0.0, one_year_saving_co2: 0.0)
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 100.0, one_year_saving_co2: 0.0)
       expect(alert.one_year_saving_£).to eq(Range.new(100.0, 100.0))
       expect(alert.ten_year_saving_£).to eq(Range.new(1000.0, 1000.0))
       expect(alert.average_one_year_saving_£).to eq 100.0
@@ -43,7 +43,7 @@ describe AlertAnalysisBase do
     end
 
     it 'assigns average_one_year_saving_£ using ranges' do
-      alert.send(:assign_commmon_saving_variables, one_year_saving_£: Range.new(100.0,200.0), capital_cost: 0.0, one_year_saving_co2: 0.0)
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: Range.new(100.0,200.0), one_year_saving_co2: 0.0)
       expect(alert.one_year_saving_£).to eq(Range.new(100.0, 200.0))
       expect(alert.ten_year_saving_£).to eq(Range.new(1000.0, 2000.0))
       expect(alert.average_one_year_saving_£).to eq 150.0
@@ -51,7 +51,7 @@ describe AlertAnalysisBase do
     end
 
     it 'assigns average_capital_cost' do
-      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 0.0, capital_cost: nil, one_year_saving_co2: 0.0)
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 0.0, one_year_saving_co2: 0.0)
       expect(alert.capital_cost).to eq(nil)
       expect(alert.average_capital_cost).to eq 0.0
 
@@ -74,7 +74,13 @@ describe AlertAnalysisBase do
       expect(alert.average_payback_years).to eq 2.0
     end
 
-    it 'assigns one_year_saving_kwh'
+    it 'assigns one_year_saving_kwh' do
+      alert.send(:assign_commmon_saving_variables, one_year_saving_kwh: 100.0, one_year_saving_£: 0.0, one_year_saving_co2: 100.0)
+      expect(alert.one_year_saving_kwh).to eq(100.0)
+
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 0.0, one_year_saving_co2: 100.0)
+      expect(alert.one_year_saving_kwh).to eq(nil)
+    end
   end
 
   context '#set_savings_capital_costs_payback' do
@@ -88,50 +94,32 @@ describe AlertAnalysisBase do
     it 'assigns one_year_saving_co2' do
       alert.send(:set_savings_capital_costs_payback, 0.0, 0.0, 100.0)
       expect(alert.one_year_saving_co2).to eq(100.0)
-      expect(alert.ten_year_saving_co2).to eq(1000.0)
     end
 
     it 'assigns average_one_year_saving_£' do
       alert.send(:set_savings_capital_costs_payback, 100.0, 0.0, 0.0)
       expect(alert.one_year_saving_£).to eq(Range.new(100.0, 100.0))
-      expect(alert.ten_year_saving_£).to eq(Range.new(1000.0, 1000.0))
-      expect(alert.average_one_year_saving_£).to eq 100.0
-      expect(alert.average_ten_year_saving_£).to eq 1000.0
     end
 
     it 'assigns average_one_year_saving_£ using ranges' do
       alert.send(:set_savings_capital_costs_payback, Range.new(100.0,200.0), 0.0, 0.0)
       expect(alert.one_year_saving_£).to eq(Range.new(100.0, 200.0))
-      expect(alert.ten_year_saving_£).to eq(Range.new(1000.0, 2000.0))
-      expect(alert.average_one_year_saving_£).to eq 150.0
-      expect(alert.average_ten_year_saving_£).to eq 1500.0
     end
 
     it 'assigns average_capital_cost' do
       alert.send(:set_savings_capital_costs_payback, 0.0, 100.0, 0.0)
       expect(alert.capital_cost).to eq(Range.new(100.0, 100.0))
-      expect(alert.average_capital_cost).to eq 100.0
-
-      alert.send(:set_savings_capital_costs_payback, 0.0, nil, 0.0)
-      expect(alert.capital_cost).to eq(nil)
-      expect(alert.average_capital_cost).to eq 0.0
     end
 
     it 'assigns average_capital_cost with ranges' do
       alert.send(:set_savings_capital_costs_payback, 0.0, Range.new(100.0,200.0), 0.0)
       expect(alert.capital_cost).to eq(Range.new(100.0, 200.0))
-      expect(alert.average_capital_cost).to eq 150.0
     end
 
     it 'assigns average_payback_years' do
-      alert.send(:set_savings_capital_costs_payback, 0.0, 0.0, 0.0)
-      expect(alert.average_payback_years).to eq 0.0
-
       alert.send(:set_savings_capital_costs_payback, 100.0, 200.0, 0.0)
       expect(alert.average_payback_years).to eq 2.0
     end
-
-    it 'assigns one_year_saving_kwh'
   end
 
 end

--- a/spec/lib/dashboard/alerts/common/alert_analysis_base_spec.rb
+++ b/spec/lib/dashboard/alerts/common/alert_analysis_base_spec.rb
@@ -3,7 +3,7 @@ require 'dashboard'
 
 #Custom subclass for testing assigning of variables in base class methods.
 #For most complex tests use a proper double
-class CustomAlert < AlertAnalysisBase
+class CustomAnalysisAlert < AlertAnalysisBase
   def initialize(meter_collection, report_type)
     super(meter_collection, report_type)
   end
@@ -16,7 +16,7 @@ describe AlertAnalysisBase do
 
   context '#set_savings_capital_costs_payback' do
     let(:meter_collection)  { double('meter-collection') }
-    let(:alert)             { CustomAlert.new(meter_collection, 'analysis-test')}
+    let(:alert)             { CustomAnalysisAlert.new(meter_collection, 'analysis-test')}
 
     before(:each) do
       allow(meter_collection).to receive(:aggregated_heat_meters).and_return(nil)

--- a/spec/lib/dashboard/alerts/common/alert_analysis_base_spec.rb
+++ b/spec/lib/dashboard/alerts/common/alert_analysis_base_spec.rb
@@ -83,43 +83,4 @@ describe AlertAnalysisBase do
     end
   end
 
-  context '#set_savings_capital_costs_payback' do
-    let(:meter_collection)  { double('meter-collection') }
-    let(:alert)             { CustomAnalysisAlert.new(meter_collection, 'analysis-test')}
-
-    before(:each) do
-      allow(meter_collection).to receive(:aggregated_heat_meters).and_return(nil)
-    end
-
-    it 'assigns one_year_saving_co2' do
-      alert.send(:set_savings_capital_costs_payback, 0.0, 0.0, 100.0)
-      expect(alert.one_year_saving_co2).to eq(100.0)
-    end
-
-    it 'assigns average_one_year_saving_£' do
-      alert.send(:set_savings_capital_costs_payback, 100.0, 0.0, 0.0)
-      expect(alert.one_year_saving_£).to eq(Range.new(100.0, 100.0))
-    end
-
-    it 'assigns average_one_year_saving_£ using ranges' do
-      alert.send(:set_savings_capital_costs_payback, Range.new(100.0,200.0), 0.0, 0.0)
-      expect(alert.one_year_saving_£).to eq(Range.new(100.0, 200.0))
-    end
-
-    it 'assigns average_capital_cost' do
-      alert.send(:set_savings_capital_costs_payback, 0.0, 100.0, 0.0)
-      expect(alert.capital_cost).to eq(Range.new(100.0, 100.0))
-    end
-
-    it 'assigns average_capital_cost with ranges' do
-      alert.send(:set_savings_capital_costs_payback, 0.0, Range.new(100.0,200.0), 0.0)
-      expect(alert.capital_cost).to eq(Range.new(100.0, 200.0))
-    end
-
-    it 'assigns average_payback_years' do
-      alert.send(:set_savings_capital_costs_payback, 100.0, 200.0, 0.0)
-      expect(alert.average_payback_years).to eq 2.0
-    end
-  end
-
 end

--- a/spec/lib/dashboard/alerts/common/alert_analysis_base_spec.rb
+++ b/spec/lib/dashboard/alerts/common/alert_analysis_base_spec.rb
@@ -29,6 +29,12 @@ describe AlertAnalysisBase do
     end
 
     it 'assigns average_one_year_saving_£' do
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: nil, capital_cost: 0.0, one_year_saving_co2: 0.0)
+      expect(alert.one_year_saving_£).to eq(nil)
+      expect(alert.ten_year_saving_£).to eq(0.0)
+      expect(alert.average_one_year_saving_£).to eq 0.0
+      expect(alert.average_ten_year_saving_£).to eq 0.0
+
       alert.send(:assign_commmon_saving_variables, one_year_saving_£: 100.0, capital_cost: 0.0, one_year_saving_co2: 0.0)
       expect(alert.one_year_saving_£).to eq(Range.new(100.0, 100.0))
       expect(alert.ten_year_saving_£).to eq(Range.new(1000.0, 1000.0))
@@ -45,6 +51,10 @@ describe AlertAnalysisBase do
     end
 
     it 'assigns average_capital_cost' do
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 0.0, capital_cost: nil, one_year_saving_co2: 0.0)
+      expect(alert.capital_cost).to eq(nil)
+      expect(alert.average_capital_cost).to eq 0.0
+
       alert.send(:assign_commmon_saving_variables, one_year_saving_£: 0.0, capital_cost: 100.0, one_year_saving_co2: 0.0)
       expect(alert.capital_cost).to eq(Range.new(100.0, 100.0))
       expect(alert.average_capital_cost).to eq 100.0
@@ -101,6 +111,10 @@ describe AlertAnalysisBase do
       alert.send(:set_savings_capital_costs_payback, 0.0, 100.0, 0.0)
       expect(alert.capital_cost).to eq(Range.new(100.0, 100.0))
       expect(alert.average_capital_cost).to eq 100.0
+
+      alert.send(:set_savings_capital_costs_payback, 0.0, nil, 0.0)
+      expect(alert.capital_cost).to eq(nil)
+      expect(alert.average_capital_cost).to eq 0.0
     end
 
     it 'assigns average_capital_cost with ranges' do

--- a/spec/lib/dashboard/alerts/common/alert_analysis_base_spec.rb
+++ b/spec/lib/dashboard/alerts/common/alert_analysis_base_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+require 'dashboard'
+
+#Custom subclass for testing assigning of variables in base class methods.
+#For most complex tests use a proper double
+class CustomAlert < AlertAnalysisBase
+  def initialize(meter_collection, report_type)
+    super(meter_collection, report_type)
+  end
+  def aggregate_meter
+    nil
+  end
+end
+
+describe AlertAnalysisBase do
+
+  context '#set_savings_capital_costs_payback' do
+    let(:meter_collection)  { double('meter-collection') }
+    let(:alert)             { CustomAlert.new(meter_collection, 'analysis-test')}
+
+    before(:each) do
+      allow(meter_collection).to receive(:aggregated_heat_meters).and_return(nil)
+    end
+
+    it 'assigns one_year_saving_co2' do
+      alert.send(:set_savings_capital_costs_payback, 0.0, 0.0, 100.0)
+      expect(alert.one_year_saving_co2).to eq(100.0)
+      expect(alert.ten_year_saving_co2).to eq(1000.0)
+    end
+
+    it 'assigns average_one_year_saving_£' do
+      alert.send(:set_savings_capital_costs_payback, 100.0, 0.0, 0.0)
+      expect(alert.one_year_saving_£).to eq(Range.new(100.0, 100.0))
+      expect(alert.ten_year_saving_£).to eq(Range.new(1000.0, 1000.0))
+      expect(alert.average_one_year_saving_£).to eq 100.0
+      expect(alert.average_ten_year_saving_£).to eq 1000.0
+    end
+
+    it 'assigns average_one_year_saving_£ using ranges' do
+      alert.send(:set_savings_capital_costs_payback, Range.new(100.0,200.0), 0.0, 0.0)
+      expect(alert.one_year_saving_£).to eq(Range.new(100.0, 200.0))
+      expect(alert.ten_year_saving_£).to eq(Range.new(1000.0, 2000.0))
+      expect(alert.average_one_year_saving_£).to eq 150.0
+      expect(alert.average_ten_year_saving_£).to eq 1500.0
+    end
+
+    it 'assigns average_capital_cost' do
+      alert.send(:set_savings_capital_costs_payback, 0.0, 100.0, 0.0)
+      expect(alert.capital_cost).to eq(Range.new(100.0, 100.0))
+      expect(alert.average_capital_cost).to eq 100.0
+    end
+
+    it 'assigns average_capital_cost with ranges' do
+      alert.send(:set_savings_capital_costs_payback, 0.0, Range.new(100.0,200.0), 0.0)
+      expect(alert.capital_cost).to eq(Range.new(100.0, 200.0))
+      expect(alert.average_capital_cost).to eq 150.0
+    end
+
+    it 'assigns average_payback_years' do
+      alert.send(:set_savings_capital_costs_payback, 0.0, 0.0, 0.0)
+      expect(alert.average_payback_years).to eq 0.0
+
+      alert.send(:set_savings_capital_costs_payback, 100.0, 200.0, 0.0)
+      expect(alert.average_payback_years).to eq 2.0
+    end
+
+    it 'assigns one_year_saving_kwh'
+  end
+
+end

--- a/spec/lib/dashboard/alerts/common/alert_analysis_base_spec.rb
+++ b/spec/lib/dashboard/alerts/common/alert_analysis_base_spec.rb
@@ -14,6 +14,59 @@ end
 
 describe AlertAnalysisBase do
 
+  context '#assign_commmon_saving_variables' do
+    let(:meter_collection)  { double('meter-collection') }
+    let(:alert)             { CustomAnalysisAlert.new(meter_collection, 'analysis-test')}
+
+    before(:each) do
+      allow(meter_collection).to receive(:aggregated_heat_meters).and_return(nil)
+    end
+
+    it 'assigns one_year_saving_co2' do
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 0.0, capital_cost: 0.0, one_year_saving_co2: 100.0)
+      expect(alert.one_year_saving_co2).to eq(100.0)
+      expect(alert.ten_year_saving_co2).to eq(1000.0)
+    end
+
+    it 'assigns average_one_year_saving_£' do
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 100.0, capital_cost: 0.0, one_year_saving_co2: 0.0)
+      expect(alert.one_year_saving_£).to eq(Range.new(100.0, 100.0))
+      expect(alert.ten_year_saving_£).to eq(Range.new(1000.0, 1000.0))
+      expect(alert.average_one_year_saving_£).to eq 100.0
+      expect(alert.average_ten_year_saving_£).to eq 1000.0
+    end
+
+    it 'assigns average_one_year_saving_£ using ranges' do
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: Range.new(100.0,200.0), capital_cost: 0.0, one_year_saving_co2: 0.0)
+      expect(alert.one_year_saving_£).to eq(Range.new(100.0, 200.0))
+      expect(alert.ten_year_saving_£).to eq(Range.new(1000.0, 2000.0))
+      expect(alert.average_one_year_saving_£).to eq 150.0
+      expect(alert.average_ten_year_saving_£).to eq 1500.0
+    end
+
+    it 'assigns average_capital_cost' do
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 0.0, capital_cost: 100.0, one_year_saving_co2: 0.0)
+      expect(alert.capital_cost).to eq(Range.new(100.0, 100.0))
+      expect(alert.average_capital_cost).to eq 100.0
+    end
+
+    it 'assigns average_capital_cost with ranges' do
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 0.0, capital_cost: Range.new(100.0,200.0), one_year_saving_co2: 0.0)
+      expect(alert.capital_cost).to eq(Range.new(100.0, 200.0))
+      expect(alert.average_capital_cost).to eq 150.0
+    end
+
+    it 'assigns average_payback_years' do
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 0.0, capital_cost: 0.0, one_year_saving_co2: 0.0)
+      expect(alert.average_payback_years).to eq 0.0
+
+      alert.send(:assign_commmon_saving_variables, one_year_saving_£: 100.0, capital_cost: 200.0, one_year_saving_co2: 0.0)
+      expect(alert.average_payback_years).to eq 2.0
+    end
+
+    it 'assigns one_year_saving_kwh'
+  end
+
   context '#set_savings_capital_costs_payback' do
     let(:meter_collection)  { double('meter-collection') }
     let(:alert)             { CustomAnalysisAlert.new(meter_collection, 'analysis-test')}

--- a/spec/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator_spec.rb
+++ b/spec/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator_spec.rb
@@ -27,6 +27,7 @@ describe AlertSolarPVBenefitEstimator do
       school_activation_date: '',
       school_creation_date: '2020-10-08',
       urn: '654321',
+      one_year_saving_kwh: '57,000 kWh',
       one_year_saving_£: '£9,000',
       one_year_saving_co2: '12,000 kg CO2',
       ten_year_saving_co2: '120,000 kg CO2',
@@ -162,6 +163,7 @@ describe AlertSolarPVBenefitEstimator do
     alert.calculate(Date.new(2022, 7, 12))
     expect(BenchmarkMetrics.pricing).to eq(current_pricing)
     expect(alert.text_template_variables).to eq(default_pricing_template_variables)
+    expect(alert.text_template_variables[:one_year_saving_kwh]).to eq('57,000 kWh')
     expect(alert.text_template_variables[:one_year_saving_£current]).to eq('£9,000')
     expect(alert.text_template_variables[:one_year_saving_£]).to eq('£9,000')
     expect(alert.text_template_variables[:average_one_year_saving_£]).to eq('£9,000')


### PR DESCRIPTION
This PR covers updating the alerts to add a potential kwh saving to the common variables used to describe one year cost and co2 savings and capital costs. These variables are used to display the management priorities and we want to add the kwh reduction to that.

* [x] add spec for the `AlertAnalysisBase.set_savings_capital_costs_payback` method that assigns variables as basis for refactoring
* [x] refactor the above method implementation and tidy up the code
* [x] create a new method  `AlertAnalysisBase.assign_commmon_saving_variables` which uses keywords arguments to make it clearer which value is which, then revise the current method to call that
* [x] update all the alerts to use the new base class method, prior to it being removed, simplifying the passed arguments where possible
* [x] revise `assign_commmon_saving_variables` method to support adding an optional `one_year_saving_kwh` argument and a template variable declaration so the value is available to the application 
* [x] update alerts to add the `one_year_saving_kwh` argument where possible

For the last step above, the kwh reductions have been taken from: 

* existing template variables which already provided a kwh saving. In this case the new `one_year_saving_kwh` variable is just an alias for an existing value, giving it a consistent name for use by the application
* OR calculated from other variables already produced in the alert. In the majority of cases the potential kwh saving is calculated and then the cost and £/£current values derived from it, so have just used those

There are a few alerts where a `one_year_saving_kwh` isn't suitable because they're about cost reduction and not energy saving specifically. E.g. a meter consolidation alert or an alert about the reaching the Agreed Supply Capacity limit.

The above changes have been tested through:

* the rspecs that confirm the `AlertAnalysisBase` class performs as expected
* using the test_alerts.rb script and running alerts for the alerts for a range of 20 schools to catch any runtime errors and confirm that variables are being set correctly
* testing via the application, e.g. does a school successfully regenerate and save the new variable as expected

