### PR TITLE
Remove duplicate solar scenarios

### DIFF
--- a/app/services/solar_photovoltaics/potential_benefits_estimator_service.rb
+++ b/app/services/solar_photovoltaics/potential_benefits_estimator_service.rb
@@ -72,7 +72,7 @@ module SolarPhotovoltaics
 
     def kwp_scenario_including_optimum(optimum_kwp)
       optimum = round_optimum_kwp(optimum_kwp)
-      kwp_scenario_ranges.push(optimum).sort.uniq {|s| s.to_f }
+      kwp_scenario_ranges.push(optimum).sort.uniq(&:to_f)
     end
 
     def round_optimum_kwp(kwp)

--- a/app/services/solar_photovoltaics/potential_benefits_estimator_service.rb
+++ b/app/services/solar_photovoltaics/potential_benefits_estimator_service.rb
@@ -72,7 +72,7 @@ module SolarPhotovoltaics
 
     def kwp_scenario_including_optimum(optimum_kwp)
       optimum = round_optimum_kwp(optimum_kwp)
-      kwp_scenario_ranges.push(optimum).sort.uniq
+      kwp_scenario_ranges.push(optimum).sort.uniq {|s| s.to_f }
     end
 
     def round_optimum_kwp(kwp)

--- a/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator.rb
+++ b/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator.rb
@@ -94,7 +94,7 @@ class AlertSolarPVBenefitEstimator < AlertElectricityOnlyBase
 
   def kwp_scenario_including_optimum(optimum_kwp)
     optimum = round_optimum_kwp(optimum_kwp)
-    kwp_scenario_ranges.push(optimum).sort.uniq
+    kwp_scenario_ranges.push(optimum).sort.uniq {|s| s.to_f }
   end
 
   def max_possible_kwp


### PR DESCRIPTION
After rounding the optimum kwp value for a potential solar installation we can end up with a duplicate scenario.

E.g. the normal scenarios end up as 1, 2, 4, 8, 16, 32, 64, 128

If the optimum ends up being rounded to 8.0 or 16.0 then we end up with a duplicate. The existing `.sort.uniq` on the scenarios assumed they were all of the same types, but the defaults are integer values and the optimum a float. 

PR makes a small change to the alert and the service to fix this to remove the duplicates that are appearing for a few schools.