### PR TITLE
Fix N3rgyData readings X48 formatting

### DIFF
--- a/lib/dashboard/data_sources/metering/n3rgy/n3rgy_data.rb
+++ b/lib/dashboard/data_sources/metering/n3rgy/n3rgy_data.rb
@@ -99,8 +99,6 @@ module MeterReadingsFeeds
       DateTime.strptime(end_date, '%Y%m%d%H%M')
     end
 
-    # private
-
     def consumption_data(mpxn, fuel_type, start_date, end_date)
       readings = []
       (start_date..end_date).each_slice(90) do |date_range_max_90days|
@@ -143,6 +141,8 @@ module MeterReadingsFeeds
         prices:           prices
       }
     end
+
+    private
 
     def deduplicate_standing_charges(ary)
       N3rgyDataDeduplicator.deduplicate_standing_charges(ary)

--- a/lib/dashboard/data_sources/metering/n3rgy/n3rgy_data.rb
+++ b/lib/dashboard/data_sources/metering/n3rgy/n3rgy_data.rb
@@ -99,7 +99,7 @@ module MeterReadingsFeeds
       DateTime.strptime(end_date, '%Y%m%d%H%M')
     end
 
-    private
+    # private
 
     def consumption_data(mpxn, fuel_type, start_date, end_date)
       readings = []

--- a/lib/dashboard/data_sources/metering/n3rgy/n3rgy_data.rb
+++ b/lib/dashboard/data_sources/metering/n3rgy/n3rgy_data.rb
@@ -38,7 +38,7 @@ module MeterReadingsFeeds
       tariff_details = tariff_data(mpxn, fuel_type, start_date, end_date)
       charges_by_date = tariff_details[:standing_charges].to_h
       prices_by_date = tariff_details[:prices].to_h
-      tariff_readings = X48Formatter.convert_dt_to_v_to_date_to_v_x48(start_date, end_date, prices_by_date)
+      tariff_readings = X48Formatter.convert_dt_to_v_to_date_to_v_x48(start_date.to_date, end_date.to_date, prices_by_date)
       {
         kwh_tariffs:      deduplicate_prices(tariff_readings[:readings]),
         standing_charges: charges_by_date,

--- a/lib/dashboard/data_sources/metering/n3rgy/n3rgy_data.rb
+++ b/lib/dashboard/data_sources/metering/n3rgy/n3rgy_data.rb
@@ -23,7 +23,7 @@ module MeterReadingsFeeds
       else
         readings_by_date = consumption_data(mpxn, fuel_type, start_date, end_date)
       end
-      meter_readings = X48Formatter.convert_dt_to_v_to_date_to_v_x48(start_date, end_date, readings_by_date, true, nil)
+      meter_readings = X48Formatter.convert_dt_to_v_to_date_to_v_x48(start_date.to_date, end_date.to_date, readings_by_date, true, nil)
       { fuel_type =>
           {
             mpan_mprn:        mpxn,

--- a/lib/dashboard/utilities/x48_formatter.rb
+++ b/lib/dashboard/utilities/x48_formatter.rb
@@ -1,6 +1,8 @@
 class X48Formatter
 
   def self.convert_dt_to_v_to_date_to_v_x48(start_date, end_date, dt_to_kwh, offset = false, default_datatype = nil)
+    fail unless start_date.is_a?(Date) && end_date.is_a?(Date)
+
     missing_readings = []
     readings = Hash.new { |h, k| h[k] = Array.new(48, default_datatype) }
     (start_date..end_date).each do |date|


### PR DESCRIPTION
This PR fixes a small bug to ensure the `X48Formatter` is always passed a `start_date` and `end_date` in Date format (as opposed to a DateTime) by the `readings` and `tariffs` methods in the class `MeterReadingsFeeds::N3rgyData`

This is required as line 6 of `X48Formatter` creates a range `(start_date..end_date)` which is then iterated over and converts `date` to a `DateTime` (line 7 https://github.com/Energy-Sparks/energy-sparks_analytics/blob/master/lib/dashboard/utilities/x48_formatter.rb#L7) which is in turn iterated over to find the half hourly readings from the `dt_to_kwh` hash (passed as `readings_by_date` in `MeterReadingsFeeds::N3rgyData`).  

Currently, if a `DateTime` is passed the "conversion"  to `DateTime` at line 7 (which isn't a conversion as it's already a `DateTime`) assigns a `DateTime` to `dt` that has a time starting at whatever time the `DateTime` of the `start_date` is (e.g. `23:15`) and does all half hourly offsets and lookups starting from that time.

To explain with an example, here's a simplified version of the `convert_dt_to_v_to_date_to_v_x48` method with the reading lookups and recording code removed (the original method is here https://github.com/Energy-Sparks/energy-sparks_analytics/blob/master/lib/dashboard/utilities/x48_formatter.rb#L3)
```
def convert_dt_to_v_to_date_to_v_x48(start_date, end_date)
  (start_date..end_date).each do |date|
    dt = date.to_datetime
    (0..47).each do |idx|
      puts dt.inspect
      dt = dt + Rational(30*60, 86400)
    end
  end
end
```

passing two dates in `Date` format iterates over the full range of half hourly readings for both dates as expected (from `00:00` to `23:30`) e.g.

```
irb(main):125:0> convert_dt_to_v_to_date_to_v_x48(Date.today-1, Date.today)
Thu, 29 Jun 2023 00:00:00 +0000
Thu, 29 Jun 2023 00:30:00 +0000
Thu, 29 Jun 2023 01:00:00 +0000
Thu, 29 Jun 2023 01:30:00 +0000
Thu, 29 Jun 2023 02:00:00 +0000
Thu, 29 Jun 2023 02:30:00 +0000
Thu, 29 Jun 2023 03:00:00 +0000
Thu, 29 Jun 2023 03:30:00 +0000
Thu, 29 Jun 2023 04:00:00 +0000
Thu, 29 Jun 2023 04:30:00 +0000
Thu, 29 Jun 2023 05:00:00 +0000
Thu, 29 Jun 2023 05:30:00 +0000
Thu, 29 Jun 2023 06:00:00 +0000
Thu, 29 Jun 2023 06:30:00 +0000
Thu, 29 Jun 2023 07:00:00 +0000
Thu, 29 Jun 2023 07:30:00 +0000
Thu, 29 Jun 2023 08:00:00 +0000
Thu, 29 Jun 2023 08:30:00 +0000
Thu, 29 Jun 2023 09:00:00 +0000
Thu, 29 Jun 2023 09:30:00 +0000
Thu, 29 Jun 2023 10:00:00 +0000
Thu, 29 Jun 2023 10:30:00 +0000
Thu, 29 Jun 2023 11:00:00 +0000
Thu, 29 Jun 2023 11:30:00 +0000
Thu, 29 Jun 2023 12:00:00 +0000
Thu, 29 Jun 2023 12:30:00 +0000
Thu, 29 Jun 2023 13:00:00 +0000
Thu, 29 Jun 2023 13:30:00 +0000
Thu, 29 Jun 2023 14:00:00 +0000
Thu, 29 Jun 2023 14:30:00 +0000
Thu, 29 Jun 2023 15:00:00 +0000
Thu, 29 Jun 2023 15:30:00 +0000
Thu, 29 Jun 2023 16:00:00 +0000
Thu, 29 Jun 2023 16:30:00 +0000
Thu, 29 Jun 2023 17:00:00 +0000
Thu, 29 Jun 2023 17:30:00 +0000
Thu, 29 Jun 2023 18:00:00 +0000
Thu, 29 Jun 2023 18:30:00 +0000
Thu, 29 Jun 2023 19:00:00 +0000
Thu, 29 Jun 2023 19:30:00 +0000
Thu, 29 Jun 2023 20:00:00 +0000
Thu, 29 Jun 2023 20:30:00 +0000
Thu, 29 Jun 2023 21:00:00 +0000
Thu, 29 Jun 2023 21:30:00 +0000
Thu, 29 Jun 2023 22:00:00 +0000
Thu, 29 Jun 2023 22:30:00 +0000
Thu, 29 Jun 2023 23:00:00 +0000
Thu, 29 Jun 2023 23:30:00 +0000
Fri, 30 Jun 2023 00:00:00 +0000
Fri, 30 Jun 2023 00:30:00 +0000
Fri, 30 Jun 2023 01:00:00 +0000
Fri, 30 Jun 2023 01:30:00 +0000
Fri, 30 Jun 2023 02:00:00 +0000
Fri, 30 Jun 2023 02:30:00 +0000
Fri, 30 Jun 2023 03:00:00 +0000
Fri, 30 Jun 2023 03:30:00 +0000
Fri, 30 Jun 2023 04:00:00 +0000
Fri, 30 Jun 2023 04:30:00 +0000
Fri, 30 Jun 2023 05:00:00 +0000
Fri, 30 Jun 2023 05:30:00 +0000
Fri, 30 Jun 2023 06:00:00 +0000
Fri, 30 Jun 2023 06:30:00 +0000
Fri, 30 Jun 2023 07:00:00 +0000
Fri, 30 Jun 2023 07:30:00 +0000
Fri, 30 Jun 2023 08:00:00 +0000
Fri, 30 Jun 2023 08:30:00 +0000
Fri, 30 Jun 2023 09:00:00 +0000
Fri, 30 Jun 2023 09:30:00 +0000
Fri, 30 Jun 2023 10:00:00 +0000
Fri, 30 Jun 2023 10:30:00 +0000
Fri, 30 Jun 2023 11:00:00 +0000
Fri, 30 Jun 2023 11:30:00 +0000
Fri, 30 Jun 2023 12:00:00 +0000
Fri, 30 Jun 2023 12:30:00 +0000
Fri, 30 Jun 2023 13:00:00 +0000
Fri, 30 Jun 2023 13:30:00 +0000
Fri, 30 Jun 2023 14:00:00 +0000
Fri, 30 Jun 2023 14:30:00 +0000
Fri, 30 Jun 2023 15:00:00 +0000
Fri, 30 Jun 2023 15:30:00 +0000
Fri, 30 Jun 2023 16:00:00 +0000
Fri, 30 Jun 2023 16:30:00 +0000
Fri, 30 Jun 2023 17:00:00 +0000
Fri, 30 Jun 2023 17:30:00 +0000
Fri, 30 Jun 2023 18:00:00 +0000
Fri, 30 Jun 2023 18:30:00 +0000
Fri, 30 Jun 2023 19:00:00 +0000
Fri, 30 Jun 2023 19:30:00 +0000
Fri, 30 Jun 2023 20:00:00 +0000
Fri, 30 Jun 2023 20:30:00 +0000
Fri, 30 Jun 2023 21:00:00 +0000
Fri, 30 Jun 2023 21:30:00 +0000
Fri, 30 Jun 2023 22:00:00 +0000
Fri, 30 Jun 2023 22:30:00 +0000
Fri, 30 Jun 2023 23:00:00 +0000
Fri, 30 Jun 2023 23:30:00 +0000
=> Thu, 29 Jun 2023..Fri, 30 Jun 2023
```

However passing the `start_date` as a `DateTime` means the method starts at the time of the `start_date` and does all half hourly offsets from there - which also throws out where the data should be recorded in the `X48` array as it's done by index (see below)
```
irb(main):134:0> convert_dt_to_v_to_date_to_v_x48(DateTime.new(2023,06,29,12,30), DateTime.new(2023,06,29,12,30))
Thu, 29 Jun 2023 12:30:00 +0000
Thu, 29 Jun 2023 13:00:00 +0000
Thu, 29 Jun 2023 13:30:00 +0000
Thu, 29 Jun 2023 14:00:00 +0000
Thu, 29 Jun 2023 14:30:00 +0000
Thu, 29 Jun 2023 15:00:00 +0000
Thu, 29 Jun 2023 15:30:00 +0000
Thu, 29 Jun 2023 16:00:00 +0000
Thu, 29 Jun 2023 16:30:00 +0000
Thu, 29 Jun 2023 17:00:00 +0000
Thu, 29 Jun 2023 17:30:00 +0000
Thu, 29 Jun 2023 18:00:00 +0000
Thu, 29 Jun 2023 18:30:00 +0000
Thu, 29 Jun 2023 19:00:00 +0000
Thu, 29 Jun 2023 19:30:00 +0000
Thu, 29 Jun 2023 20:00:00 +0000
Thu, 29 Jun 2023 20:30:00 +0000
Thu, 29 Jun 2023 21:00:00 +0000
Thu, 29 Jun 2023 21:30:00 +0000
Thu, 29 Jun 2023 22:00:00 +0000
Thu, 29 Jun 2023 22:30:00 +0000
Thu, 29 Jun 2023 23:00:00 +0000
Thu, 29 Jun 2023 23:30:00 +0000
Fri, 30 Jun 2023 00:00:00 +0000
Fri, 30 Jun 2023 00:30:00 +0000
Fri, 30 Jun 2023 01:00:00 +0000
Fri, 30 Jun 2023 01:30:00 +0000
Fri, 30 Jun 2023 02:00:00 +0000
Fri, 30 Jun 2023 02:30:00 +0000
Fri, 30 Jun 2023 03:00:00 +0000
Fri, 30 Jun 2023 03:30:00 +0000
Fri, 30 Jun 2023 04:00:00 +0000
Fri, 30 Jun 2023 04:30:00 +0000
Fri, 30 Jun 2023 05:00:00 +0000
Fri, 30 Jun 2023 05:30:00 +0000
Fri, 30 Jun 2023 06:00:00 +0000
Fri, 30 Jun 2023 06:30:00 +0000
Fri, 30 Jun 2023 07:00:00 +0000
Fri, 30 Jun 2023 07:30:00 +0000
Fri, 30 Jun 2023 08:00:00 +0000
Fri, 30 Jun 2023 08:30:00 +0000
Fri, 30 Jun 2023 09:00:00 +0000
Fri, 30 Jun 2023 09:30:00 +0000
Fri, 30 Jun 2023 10:00:00 +0000
Fri, 30 Jun 2023 10:30:00 +0000
Fri, 30 Jun 2023 11:00:00 +0000
Fri, 30 Jun 2023 11:30:00 +0000
Fri, 30 Jun 2023 12:00:00 +0000
```



Testing this end to end 

```
def readings_current_date_range(meter)
  if meter.amr_data_feed_readings.any?
    first = meter.amr_data_feed_readings.minimum(:reading_date)
    last = meter.amr_data_feed_readings.maximum(:reading_date)
    (DateTime.parse(first + 'T00:00')..DateTime.parse(last + 'T23:30'))
  end
end

meter = Meter.find(684)
n3rgy_api_factory = Amr::N3rgyApiFactory.new
n3rgy_api = n3rgy_api_factory.data_api(meter)
config = AmrDataFeedConfig.n3rgy_api.first
current_dates = readings_current_date_range(meter)
=> Fri, 17 Sep 2021 00:00:00 +0000..Tue, 27 Jun 2023 23:30:00 +0000
available_dates = n3rgy_api.readings_available_date_range(meter.mpan_mprn, meter.fuel_type)
=> Fri, 17 Sep 2021 11:30:00 +0000..Fri, 30 Jun 2023 03:30:00 +0000
start_date = Amr::N3rgyDownloaderDates.start_date(available_dates, current_dates)
=> Tue, 27 Jun 2023 23:30:00 +0000
end_date = Amr::N3rgyDownloaderDates.end_date(available_dates)
=> Fri, 30 Jun 2023 03:30:00 +0000
```
Note: all readings requests below were made on the 30th June.

Here's the returned consumption data for reference
```
irb(main):026:0> pp n3rgy_api.consumption_data(meter.mpan_mprn, meter.meter_type, start_date, end_date);nil
{Tue, 27 Jun 2023 00:00:00 +0000=>0.016,
 Tue, 27 Jun 2023 00:30:00 +0000=>0.011,
 Tue, 27 Jun 2023 01:00:00 +0000=>0.008,
 Tue, 27 Jun 2023 01:30:00 +0000=>0.014,
 Tue, 27 Jun 2023 02:00:00 +0000=>0.014,
 Tue, 27 Jun 2023 02:30:00 +0000=>0.007,
 Tue, 27 Jun 2023 03:00:00 +0000=>0.012,
 Tue, 27 Jun 2023 03:30:00 +0000=>0.015,
 Tue, 27 Jun 2023 04:00:00 +0000=>0.008,
 Tue, 27 Jun 2023 04:30:00 +0000=>0.011,
 Tue, 27 Jun 2023 05:00:00 +0000=>0.016,
 Tue, 27 Jun 2023 05:30:00 +0000=>0.01,
 Tue, 27 Jun 2023 06:00:00 +0000=>0.012,
 Tue, 27 Jun 2023 06:30:00 +0000=>0.016,
 Tue, 27 Jun 2023 07:00:00 +0000=>0.009,
 Tue, 27 Jun 2023 07:30:00 +0000=>0.013,
 Tue, 27 Jun 2023 08:00:00 +0000=>0.016,
 Tue, 27 Jun 2023 08:30:00 +0000=>0.011,
 Tue, 27 Jun 2023 09:00:00 +0000=>0.019,
 Tue, 27 Jun 2023 09:30:00 +0000=>0.017,
 Tue, 27 Jun 2023 10:00:00 +0000=>0.014,
 Tue, 27 Jun 2023 10:30:00 +0000=>0.018,
 Tue, 27 Jun 2023 11:00:00 +0000=>0.011,
 Tue, 27 Jun 2023 11:30:00 +0000=>0.019,
 Tue, 27 Jun 2023 12:00:00 +0000=>0.02,
 Tue, 27 Jun 2023 12:30:00 +0000=>0.02,
 Tue, 27 Jun 2023 13:00:00 +0000=>0.013,
 Tue, 27 Jun 2023 13:30:00 +0000=>0.019,
 Tue, 27 Jun 2023 14:00:00 +0000=>0.02,
 Tue, 27 Jun 2023 14:30:00 +0000=>0.019,
 Tue, 27 Jun 2023 15:00:00 +0000=>0.019,
 Tue, 27 Jun 2023 15:30:00 +0000=>0.019,
 Tue, 27 Jun 2023 16:00:00 +0000=>0.019,
 Tue, 27 Jun 2023 16:30:00 +0000=>0.019,
 Tue, 27 Jun 2023 17:00:00 +0000=>0.02,
 Tue, 27 Jun 2023 17:30:00 +0000=>0.062,
 Tue, 27 Jun 2023 18:00:00 +0000=>0.12,
 Tue, 27 Jun 2023 18:30:00 +0000=>0.111,
 Tue, 27 Jun 2023 19:00:00 +0000=>0.119,
 Tue, 27 Jun 2023 19:30:00 +0000=>0.113,
 Tue, 27 Jun 2023 20:00:00 +0000=>0.122,
 Tue, 27 Jun 2023 20:30:00 +0000=>0.123,
 Tue, 27 Jun 2023 21:00:00 +0000=>0.124,
 Tue, 27 Jun 2023 21:30:00 +0000=>0.121,
 Tue, 27 Jun 2023 22:00:00 +0000=>0.12,
 Tue, 27 Jun 2023 22:30:00 +0000=>0.123,
 Tue, 27 Jun 2023 23:00:00 +0000=>0.12,
 Tue, 27 Jun 2023 23:30:00 +0000=>0.065,
 Wed, 28 Jun 2023 00:00:00 +0000=>0.018,
 Wed, 28 Jun 2023 00:30:00 +0000=>0.012,
 Wed, 28 Jun 2023 01:00:00 +0000=>0.018,
 Wed, 28 Jun 2023 01:30:00 +0000=>0.013,
 Wed, 28 Jun 2023 02:00:00 +0000=>0.006,
 Wed, 28 Jun 2023 02:30:00 +0000=>0.014,
 Wed, 28 Jun 2023 03:00:00 +0000=>0.013,
 Wed, 28 Jun 2023 03:30:00 +0000=>0.013,
 Wed, 28 Jun 2023 04:00:00 +0000=>0.014,
 Wed, 28 Jun 2023 04:30:00 +0000=>0.01,
 Wed, 28 Jun 2023 05:00:00 +0000=>0.01,
 Wed, 28 Jun 2023 05:30:00 +0000=>0.02,
 Wed, 28 Jun 2023 06:00:00 +0000=>0.009,
 Wed, 28 Jun 2023 06:30:00 +0000=>0.015,
 Wed, 28 Jun 2023 07:00:00 +0000=>0.015,
 Wed, 28 Jun 2023 07:30:00 +0000=>0.009,
 Wed, 28 Jun 2023 08:00:00 +0000=>0.014,
 Wed, 28 Jun 2023 08:30:00 +0000=>0.015,
 Wed, 28 Jun 2023 09:00:00 +0000=>0.015,
 Wed, 28 Jun 2023 09:30:00 +0000=>0.016,
 Wed, 28 Jun 2023 10:00:00 +0000=>0.011,
 Wed, 28 Jun 2023 10:30:00 +0000=>0.02,
 Wed, 28 Jun 2023 11:00:00 +0000=>0.019,
 Wed, 28 Jun 2023 11:30:00 +0000=>0.011,
 Wed, 28 Jun 2023 12:00:00 +0000=>0.02,
 Wed, 28 Jun 2023 12:30:00 +0000=>0.01,
 Wed, 28 Jun 2023 13:00:00 +0000=>0.02,
 Wed, 28 Jun 2023 13:30:00 +0000=>0.013,
 Wed, 28 Jun 2023 14:00:00 +0000=>0.02,
 Wed, 28 Jun 2023 14:30:00 +0000=>0.01,
 Wed, 28 Jun 2023 15:00:00 +0000=>0.02,
 Wed, 28 Jun 2023 15:30:00 +0000=>0.013,
 Wed, 28 Jun 2023 16:00:00 +0000=>0.016,
 Wed, 28 Jun 2023 16:30:00 +0000=>0.01,
 Wed, 28 Jun 2023 17:00:00 +0000=>0.015,
 Wed, 28 Jun 2023 17:30:00 +0000=>0.065,
 Wed, 28 Jun 2023 18:00:00 +0000=>0.109,
 Wed, 28 Jun 2023 18:30:00 +0000=>0.112,
 Wed, 28 Jun 2023 19:00:00 +0000=>0.116,
 Wed, 28 Jun 2023 19:30:00 +0000=>0.11,
 Wed, 28 Jun 2023 20:00:00 +0000=>0.119,
 Wed, 28 Jun 2023 20:30:00 +0000=>0.121,
 Wed, 28 Jun 2023 21:00:00 +0000=>0.118,
 Wed, 28 Jun 2023 21:30:00 +0000=>0.112,
 Wed, 28 Jun 2023 22:00:00 +0000=>0.117,
 Wed, 28 Jun 2023 22:30:00 +0000=>0.116,
 Wed, 28 Jun 2023 23:00:00 +0000=>0.113,
 Wed, 28 Jun 2023 23:30:00 +0000=>0.059,
 Thu, 29 Jun 2023 00:00:00 +0000=>0.014,
 Thu, 29 Jun 2023 00:30:00 +0000=>0.014,
 Thu, 29 Jun 2023 01:00:00 +0000=>0.008,
 Thu, 29 Jun 2023 01:30:00 +0000=>0.012,
 Thu, 29 Jun 2023 02:00:00 +0000=>0.014,
 Thu, 29 Jun 2023 02:30:00 +0000=>0.011,
 Thu, 29 Jun 2023 03:00:00 +0000=>0.008,
 Thu, 29 Jun 2023 03:30:00 +0000=>0.015,
 Thu, 29 Jun 2023 04:00:00 +0000=>0.013,
 Thu, 29 Jun 2023 04:30:00 +0000=>0.009,
 Thu, 29 Jun 2023 05:00:00 +0000=>0.019,
 Thu, 29 Jun 2023 05:30:00 +0000=>0.006,
 Thu, 29 Jun 2023 06:00:00 +0000=>0.013,
 Thu, 29 Jun 2023 06:30:00 +0000=>0.014,
 Thu, 29 Jun 2023 07:00:00 +0000=>0.008,
 Thu, 29 Jun 2023 07:30:00 +0000=>0.014,
 Thu, 29 Jun 2023 08:00:00 +0000=>0.013,
 Thu, 29 Jun 2023 08:30:00 +0000=>0.008,
 Thu, 29 Jun 2023 09:00:00 +0000=>0.019,
 Thu, 29 Jun 2023 09:30:00 +0000=>0.008,
 Thu, 29 Jun 2023 10:00:00 +0000=>0.046,
 Thu, 29 Jun 2023 10:30:00 +0000=>0.052,
 Thu, 29 Jun 2023 11:00:00 +0000=>0.017,
 Thu, 29 Jun 2023 11:30:00 +0000=>0.011,
 Thu, 29 Jun 2023 12:00:00 +0000=>0.012,
 Thu, 29 Jun 2023 12:30:00 +0000=>0.014,
 Thu, 29 Jun 2023 13:00:00 +0000=>0.015,
 Thu, 29 Jun 2023 13:30:00 +0000=>0.013,
 Thu, 29 Jun 2023 14:00:00 +0000=>0.012,
 Thu, 29 Jun 2023 14:30:00 +0000=>0.014,
 Thu, 29 Jun 2023 15:00:00 +0000=>0.017,
 Thu, 29 Jun 2023 15:30:00 +0000=>0.011,
 Thu, 29 Jun 2023 16:00:00 +0000=>0.014,
 Thu, 29 Jun 2023 16:30:00 +0000=>0.016,
 Thu, 29 Jun 2023 17:00:00 +0000=>0.013,
 Thu, 29 Jun 2023 17:30:00 +0000=>0.066,
 Thu, 29 Jun 2023 18:00:00 +0000=>0.116,
 Thu, 29 Jun 2023 18:30:00 +0000=>0.113,
 Thu, 29 Jun 2023 19:00:00 +0000=>0.109,
 Thu, 29 Jun 2023 19:30:00 +0000=>0.116,
 Thu, 29 Jun 2023 20:00:00 +0000=>0.108,
 Thu, 29 Jun 2023 20:30:00 +0000=>0.105,
 Thu, 29 Jun 2023 21:00:00 +0000=>0.116,
 Thu, 29 Jun 2023 21:30:00 +0000=>0.122,
 Thu, 29 Jun 2023 22:00:00 +0000=>0.119,
 Thu, 29 Jun 2023 22:30:00 +0000=>0.12,
 Thu, 29 Jun 2023 23:00:00 +0000=>0.111,
 Thu, 29 Jun 2023 23:30:00 +0000=>0.059,
 Fri, 30 Jun 2023 00:00:00 +0000=>0.016}
```

Without the fix in this PR we have a day lag (missing data for 29th June) and readings data recorded in the wrong place in the `X48` array due to the indexing (`idx` in `(0..47).each do |idx|`): 
```
irb(main):017:0> pp n3rgy_api.readings(meter.mpan_mprn, meter.meter_type, start_date, end_date)
{"electricity"=>
  {:mpan_mprn=>[REMOVED],
   :readings=>
    {Tue, 27 Jun 2023=>
      #<OneDayAMRReading:0x0000000117960498
       @date=Tue, 27 Jun 2023,
       @kwh_data_x48=[0.018,0.012,0.018,0.013,0.006,0.014,0.013,0.013,0.014,0.01,0.01,0.02,0.009,0.015,0.015,0.009,0.014,0.015,0.015,0.016,0.011,0.02,0.019,0.011,0.02,0.01,0.02,0.013,0.02,0.01,0.02,0.013,0.016,0.01,0.015,0.065,0.109,0.112,0.116,0.11,0.119,0.121,0.118,0.112,0.117,0.116,0.113,0.059],
       @meter_id="[REMOVED]",
       @one_day_kwh=1.8840000000000006,
       @substitute_date=nil,
       @type="ORIG",
       @upload_datetime=Fri, 30 Jun 2023 10:20:24 +0100>,
     Wed, 28 Jun 2023=>
      #<OneDayAMRReading:0x0000000117960268
       @date=Wed, 28 Jun 2023,
       @kwh_data_x48=[0.014,0.014,0.008,0.012,0.014,0.011,0.008,0.015,0.013,0.009,0.019,0.006,0.013,0.014,0.008,0.014,0.013,0.008,0.019,0.008,0.046,0.052,0.017,0.011,0.012,0.014,0.015,0.013,0.012,0.014,0.017,0.011,0.014,0.016,0.013,0.066,0.116,0.113,0.109,0.116,0.108,0.105,0.116,0.122,0.119,0.12,0.111,0.059],
       @meter_id="[REMOVED]",
       @one_day_kwh=1.8970000000000002,
       @substitute_date=nil,
       @type="ORIG",
       @upload_datetime=Fri, 30 Jun 2023 10:20:24 +0100>},
   :missing_readings=>
    [Fri, 30 Jun 2023 00:00:00 +0000,
     Fri, 30 Jun 2023 00:30:00 +0000,
     Fri, 30 Jun 2023 01:00:00 +0000,
     Fri, 30 Jun 2023 01:30:00 +0000,
     Fri, 30 Jun 2023 02:00:00 +0000,
     Fri, 30 Jun 2023 02:30:00 +0000,
     Fri, 30 Jun 2023 03:00:00 +0000,
     Fri, 30 Jun 2023 03:30:00 +0000,
     Fri, 30 Jun 2023 04:00:00 +0000,
     Fri, 30 Jun 2023 04:30:00 +0000,
     Fri, 30 Jun 2023 05:00:00 +0000,
     Fri, 30 Jun 2023 05:30:00 +0000,
     Fri, 30 Jun 2023 06:00:00 +0000,
     Fri, 30 Jun 2023 06:30:00 +0000,
     Fri, 30 Jun 2023 07:00:00 +0000,
     Fri, 30 Jun 2023 07:30:00 +0000,
     Fri, 30 Jun 2023 08:00:00 +0000,
     Fri, 30 Jun 2023 08:30:00 +0000,
     Fri, 30 Jun 2023 09:00:00 +0000,
     Fri, 30 Jun 2023 09:30:00 +0000,
     Fri, 30 Jun 2023 10:00:00 +0000,
     Fri, 30 Jun 2023 10:30:00 +0000,
     Fri, 30 Jun 2023 11:00:00 +0000,
     Fri, 30 Jun 2023 11:30:00 +0000,
     Fri, 30 Jun 2023 12:00:00 +0000,
     Fri, 30 Jun 2023 12:30:00 +0000,
     Fri, 30 Jun 2023 13:00:00 +0000,
     Fri, 30 Jun 2023 13:30:00 +0000,
     Fri, 30 Jun 2023 14:00:00 +0000,
     Fri, 30 Jun 2023 14:30:00 +0000,
     Fri, 30 Jun 2023 15:00:00 +0000,
     Fri, 30 Jun 2023 15:30:00 +0000,
     Fri, 30 Jun 2023 16:00:00 +0000,
     Fri, 30 Jun 2023 16:30:00 +0000,
     Fri, 30 Jun 2023 17:00:00 +0000,
     Fri, 30 Jun 2023 17:30:00 +0000,
     Fri, 30 Jun 2023 18:00:00 +0000,
     Fri, 30 Jun 2023 18:30:00 +0000,
     Fri, 30 Jun 2023 19:00:00 +0000,
     Fri, 30 Jun 2023 19:30:00 +0000,
     Fri, 30 Jun 2023 20:00:00 +0000,
     Fri, 30 Jun 2023 20:30:00 +0000,
     Fri, 30 Jun 2023 21:00:00 +0000,
     Fri, 30 Jun 2023 21:30:00 +0000,
     Fri, 30 Jun 2023 22:00:00 +0000,
     Fri, 30 Jun 2023 22:30:00 +0000,
     Fri, 30 Jun 2023 23:00:00 +0000,
     Fri, 30 Jun 2023 23:30:00 +0000]}}
```

With the fix in this pr included the readings data is recorded for all dates (27, 28, & 29 June)

```
irb(main):021:0> pp n3rgy_api.readings(meter.mpan_mprn, meter.meter_type, start_date, end_date)
{"electricity"=>
  {:mpan_mprn=>[REMOVED],
   :readings=>
    {Tue, 27 Jun 2023=>
      #<OneDayAMRReading:0x0000000108696208
       @date=Tue, 27 Jun 2023,
       @kwh_data_x48=[nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,0.065,0.018],
       @meter_id="[REMOVED]",
       @one_day_kwh=nil,
       @substitute_date=nil,
       @type="ORIG",
       @upload_datetime=Fri, 30 Jun 2023 10:13:11 +0100>,
     Wed, 28 Jun 2023=>
      #<OneDayAMRReading:0x0000000108696078
       @date=Wed, 28 Jun 2023,
       @kwh_data_x48=[0.012,0.018,0.013,0.006,0.014,0.013,0.013,0.014,0.01,0.01,0.02,0.009,0.015,0.015,0.009,0.014,0.015,0.015,0.016,0.011,0.02,0.019,0.011,0.02,0.01,0.02,0.013,0.02,0.01,0.02,0.013,0.016,0.01,0.015,0.065,0.109,0.112,0.116,0.11,0.119,0.121,0.118,0.112,0.117,0.116,0.113,0.059,0.014],
       @meter_id="[REMOVED]",
       @one_day_kwh=1.8800000000000003,
       @substitute_date=nil,
       @type="ORIG",
       @upload_datetime=Fri, 30 Jun 2023 10:13:11 +0100>,
     Thu, 29 Jun 2023=>
      #<OneDayAMRReading:0x0000000108695f60
       @date=Thu, 29 Jun 2023,
       @kwh_data_x48=[0.014,0.008,0.012,0.014,0.011,0.008,0.015,0.013,0.009,0.019,0.006,0.013,0.014,0.008,0.014,0.013,0.008,0.019,0.008,0.046,0.052,0.017,0.011,0.012,0.014,0.015,0.013,0.012,0.014,0.017,0.011,0.014,0.016,0.013,0.066,0.116,0.113,0.109,0.116,0.108,0.105,0.116,0.122,0.119,0.12,0.111,0.059,nil],
       @meter_id="[REMOVED]",
       @one_day_kwh=nil,
       @substitute_date=nil,
       @type="ORIG",
       @upload_datetime=Fri, 30 Jun 2023 10:13:11 +0100>},
   :missing_readings=>
    [Tue, 27 Jun 2023 00:30:00 +0000,
     Tue, 27 Jun 2023 01:00:00 +0000,
     Tue, 27 Jun 2023 01:30:00 +0000,
     Tue, 27 Jun 2023 02:00:00 +0000,
     Tue, 27 Jun 2023 02:30:00 +0000,
     Tue, 27 Jun 2023 03:00:00 +0000,
     Tue, 27 Jun 2023 03:30:00 +0000,
     Tue, 27 Jun 2023 04:00:00 +0000,
     Tue, 27 Jun 2023 04:30:00 +0000,
     Tue, 27 Jun 2023 05:00:00 +0000,
     Tue, 27 Jun 2023 05:30:00 +0000,
     Tue, 27 Jun 2023 06:00:00 +0000,
     Tue, 27 Jun 2023 06:30:00 +0000,
     Tue, 27 Jun 2023 07:00:00 +0000,
     Tue, 27 Jun 2023 07:30:00 +0000,
     Tue, 27 Jun 2023 08:00:00 +0000,
     Tue, 27 Jun 2023 08:30:00 +0000,
     Tue, 27 Jun 2023 09:00:00 +0000,
     Tue, 27 Jun 2023 09:30:00 +0000,
     Tue, 27 Jun 2023 10:00:00 +0000,
     Tue, 27 Jun 2023 10:30:00 +0000,
     Tue, 27 Jun 2023 11:00:00 +0000,
     Tue, 27 Jun 2023 11:30:00 +0000,
     Tue, 27 Jun 2023 12:00:00 +0000,
     Tue, 27 Jun 2023 12:30:00 +0000,
     Tue, 27 Jun 2023 13:00:00 +0000,
     Tue, 27 Jun 2023 13:30:00 +0000,
     Tue, 27 Jun 2023 14:00:00 +0000,
     Tue, 27 Jun 2023 14:30:00 +0000,
     Tue, 27 Jun 2023 15:00:00 +0000,
     Tue, 27 Jun 2023 15:30:00 +0000,
     Tue, 27 Jun 2023 16:00:00 +0000,
     Tue, 27 Jun 2023 16:30:00 +0000,
     Tue, 27 Jun 2023 17:00:00 +0000,
     Tue, 27 Jun 2023 17:30:00 +0000,
     Tue, 27 Jun 2023 18:00:00 +0000,
     Tue, 27 Jun 2023 18:30:00 +0000,
     Tue, 27 Jun 2023 19:00:00 +0000,
     Tue, 27 Jun 2023 19:30:00 +0000,
     Tue, 27 Jun 2023 20:00:00 +0000,
     Tue, 27 Jun 2023 20:30:00 +0000,
     Tue, 27 Jun 2023 21:00:00 +0000,
     Tue, 27 Jun 2023 21:30:00 +0000,
     Tue, 27 Jun 2023 22:00:00 +0000,
     Tue, 27 Jun 2023 22:30:00 +0000,
     Tue, 27 Jun 2023 23:00:00 +0000,
     Fri, 30 Jun 2023 00:00:00 +0000,
     Fri, 30 Jun 2023 00:30:00 +0000,
     Fri, 30 Jun 2023 01:00:00 +0000,
     Fri, 30 Jun 2023 01:30:00 +0000,
     Fri, 30 Jun 2023 02:00:00 +0000,
     Fri, 30 Jun 2023 02:30:00 +0000,
     Fri, 30 Jun 2023 03:00:00 +0000,
     Fri, 30 Jun 2023 03:30:00 +0000,
     Fri, 30 Jun 2023 04:00:00 +0000,
     Fri, 30 Jun 2023 04:30:00 +0000,
     Fri, 30 Jun 2023 05:00:00 +0000,
     Fri, 30 Jun 2023 05:30:00 +0000,
     Fri, 30 Jun 2023 06:00:00 +0000,
     Fri, 30 Jun 2023 06:30:00 +0000,
     Fri, 30 Jun 2023 07:00:00 +0000,
     Fri, 30 Jun 2023 07:30:00 +0000,
     Fri, 30 Jun 2023 08:00:00 +0000,
     Fri, 30 Jun 2023 08:30:00 +0000,
     Fri, 30 Jun 2023 09:00:00 +0000,
     Fri, 30 Jun 2023 09:30:00 +0000,
     Fri, 30 Jun 2023 10:00:00 +0000,
     Fri, 30 Jun 2023 10:30:00 +0000,
     Fri, 30 Jun 2023 11:00:00 +0000,
     Fri, 30 Jun 2023 11:30:00 +0000,
     Fri, 30 Jun 2023 12:00:00 +0000,
     Fri, 30 Jun 2023 12:30:00 +0000,
     Fri, 30 Jun 2023 13:00:00 +0000,
     Fri, 30 Jun 2023 13:30:00 +0000,
     Fri, 30 Jun 2023 14:00:00 +0000,
     Fri, 30 Jun 2023 14:30:00 +0000,
     Fri, 30 Jun 2023 15:00:00 +0000,
     Fri, 30 Jun 2023 15:30:00 +0000,
     Fri, 30 Jun 2023 16:00:00 +0000,
     Fri, 30 Jun 2023 16:30:00 +0000,
     Fri, 30 Jun 2023 17:00:00 +0000,
     Fri, 30 Jun 2023 17:30:00 +0000,
     Fri, 30 Jun 2023 18:00:00 +0000,
     Fri, 30 Jun 2023 18:30:00 +0000,
     Fri, 30 Jun 2023 19:00:00 +0000,
     Fri, 30 Jun 2023 19:30:00 +0000,
     Fri, 30 Jun 2023 20:00:00 +0000,
     Fri, 30 Jun 2023 20:30:00 +0000,
     Fri, 30 Jun 2023 21:00:00 +0000,
     Fri, 30 Jun 2023 21:30:00 +0000,
     Fri, 30 Jun 2023 22:00:00 +0000,
     Fri, 30 Jun 2023 22:30:00 +0000,
     Fri, 30 Jun 2023 23:00:00 +0000,
     Fri, 30 Jun 2023 23:30:00 +0000,
     Sat, 01 Jul 2023 00:00:00 +0000]}}
```

However, there are now nil values for `Tue, 27 Jun 2023` so there's an additional application PR here to ensure the `start_date` always starts at `00:00` https://github.com/Energy-Sparks/energy-sparks/pull/2879/files

Running with that application fix returns:

```
irb(main):016:0> pp n3rgy_api.readings(meter.mpan_mprn, meter.meter_type, start_date, end_date)
{"electricity"=>
  {:mpan_mprn=>[REMOVED],
   :readings=>
    {Tue, 27 Jun 2023=>
      #<OneDayAMRReading:0x0000000121beef48
       @date=Tue, 27 Jun 2023,
       @kwh_data_x48=[0.011,0.008,0.014,0.014,0.007,0.012,0.015,0.008,0.011,0.016,0.01,0.012,0.016,0.009,0.013,0.016,0.011,0.019,0.017,0.014,0.018,0.011,0.019,0.02,0.02,0.013,0.019,0.02,0.019,0.019,0.019,0.019,0.019,0.02,0.062,0.12,0.111,0.119,0.113,0.122,0.123,0.124,0.121,0.12,0.123,0.12,0.065,0.018],
       @meter_id="[REMOVED]",
       @one_day_kwh=1.969,
       @substitute_date=nil,
       @type="ORIG",
       @upload_datetime=Fri, 30 Jun 2023 11:03:50 +0100>,
     Wed, 28 Jun 2023=>
      #<OneDayAMRReading:0x0000000121bec9c8
       @date=Wed, 28 Jun 2023,
       @kwh_data_x48=[0.012,0.018,0.013,0.006,0.014,0.013,0.013,0.014,0.01,0.01,0.02,0.009,0.015,0.015,0.009,0.014,0.015,0.015,0.016,0.011,0.02,0.019,0.011,0.02,0.01,0.02,0.013,0.02,0.01,0.02,0.013,0.016,0.01,0.015,0.065,0.109,0.112,0.116,0.11,0.119,0.121,0.118,0.112,0.117,0.116,0.113,0.059,0.014],
       @meter_id="[REMOVED]",
       @one_day_kwh=1.8800000000000003,
       @substitute_date=nil,
       @type="ORIG",
       @upload_datetime=Fri, 30 Jun 2023 11:03:50 +0100>,
     Thu, 29 Jun 2023=>
      #<OneDayAMRReading:0x0000000121bec8b0
       @date=Thu, 29 Jun 2023,
       @kwh_data_x48=[0.014,0.008,0.012,0.014,0.011,0.008,0.015,0.013,0.009,0.019,0.006,0.013,0.014,0.008,0.014,0.013,0.008,0.019,0.008,0.046,0.052,0.017,0.011,0.012,0.014,0.015,0.013,0.012,0.014,0.017,0.011,0.014,0.016,0.013,0.066,0.116,0.113,0.109,0.116,0.108,0.105,0.116,0.122,0.119,0.12,0.111,0.059,0.016],
       @meter_id="[REMOVED]",
       @one_day_kwh=1.899,
       @substitute_date=nil,
       @type="ORIG",
       @upload_datetime=Fri, 30 Jun 2023 11:03:50 +0100>},
   :missing_readings=>
    [Fri, 30 Jun 2023 00:30:00 +0000,
     Fri, 30 Jun 2023 01:00:00 +0000,
     Fri, 30 Jun 2023 01:30:00 +0000,
     Fri, 30 Jun 2023 02:00:00 +0000,
     Fri, 30 Jun 2023 02:30:00 +0000,
     Fri, 30 Jun 2023 03:00:00 +0000,
     Fri, 30 Jun 2023 03:30:00 +0000,
     Fri, 30 Jun 2023 04:00:00 +0000,
     Fri, 30 Jun 2023 04:30:00 +0000,
     Fri, 30 Jun 2023 05:00:00 +0000,
     Fri, 30 Jun 2023 05:30:00 +0000,
     Fri, 30 Jun 2023 06:00:00 +0000,
     Fri, 30 Jun 2023 06:30:00 +0000,
     Fri, 30 Jun 2023 07:00:00 +0000,
     Fri, 30 Jun 2023 07:30:00 +0000,
     Fri, 30 Jun 2023 08:00:00 +0000,
     Fri, 30 Jun 2023 08:30:00 +0000,
     Fri, 30 Jun 2023 09:00:00 +0000,
     Fri, 30 Jun 2023 09:30:00 +0000,
     Fri, 30 Jun 2023 10:00:00 +0000,
     Fri, 30 Jun 2023 10:30:00 +0000,
     Fri, 30 Jun 2023 11:00:00 +0000,
     Fri, 30 Jun 2023 11:30:00 +0000,
     Fri, 30 Jun 2023 12:00:00 +0000,
     Fri, 30 Jun 2023 12:30:00 +0000,
     Fri, 30 Jun 2023 13:00:00 +0000,
     Fri, 30 Jun 2023 13:30:00 +0000,
     Fri, 30 Jun 2023 14:00:00 +0000,
     Fri, 30 Jun 2023 14:30:00 +0000,
     Fri, 30 Jun 2023 15:00:00 +0000,
     Fri, 30 Jun 2023 15:30:00 +0000,
     Fri, 30 Jun 2023 16:00:00 +0000,
     Fri, 30 Jun 2023 16:30:00 +0000,
     Fri, 30 Jun 2023 17:00:00 +0000,
     Fri, 30 Jun 2023 17:30:00 +0000,
     Fri, 30 Jun 2023 18:00:00 +0000,
     Fri, 30 Jun 2023 18:30:00 +0000,
     Fri, 30 Jun 2023 19:00:00 +0000,
     Fri, 30 Jun 2023 19:30:00 +0000,
     Fri, 30 Jun 2023 20:00:00 +0000,
     Fri, 30 Jun 2023 20:30:00 +0000,
     Fri, 30 Jun 2023 21:00:00 +0000,
     Fri, 30 Jun 2023 21:30:00 +0000,
     Fri, 30 Jun 2023 22:00:00 +0000,
     Fri, 30 Jun 2023 22:30:00 +0000,
     Fri, 30 Jun 2023 23:00:00 +0000,
     Fri, 30 Jun 2023 23:30:00 +0000,
     Sat, 01 Jul 2023 00:00:00 +0000]}}
```

To confirm the data is now correctly formatted we can compare the readings returned by `n3rgy_api.readings` against that of `n3rgy_api.consumption_data`:
```
Tue, 27 Jun 2023
formatted readings returned by `n3rgy_api.readings`:                     [0.011,0.008,0.014,0.014,0.007,0.012,0.015,0.008,0.011,0.016,0.01,0.012,0.016,0.009,0.013,0.016,0.011,0.019,0.017,0.014,0.018,0.011,0.019,0.02,0.02,0.013,0.019,0.02,0.019,0.019,0.019,0.019,0.019,0.02,0.062,0.12,0.111,0.119,0.113,0.122,0.123,0.124,0.121,0.12,0.123,0.12,0.065,0.018],
readings returned by `n3rgy_api.consumption_data` put in an array: [0.016,0.011,0.008,0.014,0.014,0.007,0.012,0.015,0.008,0.011,0.016,0.01,0.012,0.016,0.009,0.013,0.016,0.011,0.019,0.017,0.014,0.018,0.011,0.019,0.02,0.02,0.013,0.019,0.02,0.019,0.019,0.019,0.019,0.019,0.02,0.062,0.12,0.111,0.119,0.113,0.122,0.123,0.124,0.121,0.12,0.123,0.12,0.065]
```
```
Wed, 28 Jun 2023
formatted readings returned by `n3rgy_api.readings`:                     [0.012,0.018,0.013,0.006,0.014,0.013,0.013,0.014,0.01,0.01,0.02,0.009,0.015,0.015,0.009,0.014,0.015,0.015,0.016,0.011,0.02,0.019,0.011,0.02,0.01,0.02,0.013,0.02,0.01,0.02,0.013,0.016,0.01,0.015,0.065,0.109,0.112,0.116,0.11,0.119,0.121,0.118,0.112,0.117,0.116,0.113,0.059,0.014],
readings returned by `n3rgy_api.consumption_data` put in an array: [0.018,0.012,0.018,0.013,0.006,0.014,0.013,0.013,0.014,0.01,0.01,0.02,0.009,0.015,0.015,0.009,0.014,0.015,0.015,0.016,0.011,0.02,0.019,0.011,0.02,0.01,0.02,0.013,0.02,0.01,0.02,0.013,0.016,0.01,0.015,0.065,0.109,0.112,0.116,0.11,0.119,0.121,0.118,0.112,0.117,0.116,0.113,0.059]
```
```
Thu, 29 Jun 2023
formatted readings returned by `n3rgy_api.readings`:                     [0.014,0.008,0.012,0.014,0.011,0.008,0.015,0.013,0.009,0.019,0.006,0.013,0.014,0.008,0.014,0.013,0.008,0.019,0.008,0.046,0.052,0.017,0.011,0.012,0.014,0.015,0.013,0.012,0.014,0.017,0.011,0.014,0.016,0.013,0.066,0.116,0.113,0.109,0.116,0.108,0.105,0.116,0.122,0.119,0.12,0.111,0.059,0.016],
readings returned by `n3rgy_api.consumption_data` put in an array: [0.014,0.014,0.008,0.012,0.014,0.011,0.008,0.015,0.013,0.009,0.019,0.006,0.013,0.014,0.008,0.014,0.013,0.008,0.019,0.008,0.046,0.052,0.017,0.011,0.012,0.014,0.015,0.013,0.012,0.014,0.017,0.011,0.014,0.016,0.013,0.066,0.116,0.113,0.109,0.116,0.108,0.105,0.116,0.122,0.119,0.12,0.111,0.059]
```

The above assumes that the data for '00:00' for a given day is being correctly appended to the previous days values. For example: 
* the `0.018` value for `Wed, 28 Jun 2023 00:00:00 +0000` is appended to the end of the `X48` array for `Tue, 27 Jun`
* the `0.014` value for `Thu, 29 Jun 2023 00:00:00 +0000` is appended to the end of the `X48` array for `Wed, 28 Jun`