### PR TITLE
Avoid infinite loop in rescaling of amr data

### DIFF
--- a/lib/dashboard/corrections/rescaler.rb
+++ b/lib/dashboard/corrections/rescaler.rb
@@ -1,0 +1,39 @@
+module Corrections
+  class Rescaler
+
+    def initialize(amr_data, mpan_mprn)
+      @amr_data = amr_data
+      @mpan_mprn = mpan_mprn
+    end
+
+    def perform(start_date:, end_date:, scale:)
+      # case where another correction has changed data prior to configured correction
+      rescale_start_date = rescale_start_date(start_date)
+      rescale_end_date = rescale_end_date(end_date)
+      (rescale_start_date..rescale_end_date).each do |date|
+        if @amr_data.date_exists?(date) && @amr_data.substitution_type(date) != 'S31M'
+          new_data_x48 = []
+          (0..47).each do |halfhour_index|
+            new_data_x48.push(@amr_data.kwh(date, halfhour_index) * scale)
+          end
+          scaled_data = OneDayAMRReading.new(@mpan_mprn, date, 'S31M', nil, DateTime.now, new_data_x48)
+          @amr_data.add(date, scaled_data)
+        end
+      end
+      @amr_data
+    end
+
+    private
+
+    def rescale_start_date(start_date)
+      return @amr_data.start_date if (start_date.nil? || @amr_data.start_date > start_date)
+      start_date
+    end
+
+    def rescale_end_date(end_date)
+      # ensure that we dont loop forever if an end date isn't provided
+      return @amr_data.end_date if (end_date.nil? || @amr_data.end_date < end_date)
+      end_date
+    end
+  end
+end

--- a/spec/lib/dashboard/corrections/rescaler_spec.rb
+++ b/spec/lib/dashboard/corrections/rescaler_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe Corrections::Rescaler, type: :service do
+
+  let(:mpan_mprn)    { "1" }
+  let(:kwh_data_x48) { Array.new(48, 0.1) }
+  let(:amr_data_end_date)  { Date.new(2023,1,31) }
+  let(:amr_data)     { build(:amr_data, :with_days, day_count: 31, end_date: amr_data_end_date, kwh_data_x48: kwh_data_x48) }
+
+  let(:start_date)   { Date.new(2023,1,1) }
+  let(:end_date)     { Date.new(2023,1,10) }
+  let(:scale)        { 10.0 }
+
+  let(:service)      { Corrections::Rescaler.new(amr_data, mpan_mprn) }
+
+  let(:results)      { service.perform(start_date: start_date, end_date: end_date, scale: scale) }
+  it 'rescales the data' do
+    (start_date..end_date).each do |date|
+      expect(results.days_kwh_x48(date)).to eq Array.new(48, 1.0)
+    end
+    first_date_outside_correction_range = end_date + 1
+    expect(results.days_kwh_x48(first_date_outside_correction_range)).to eq Array.new(48, 0.1)
+    expect(results.end_date).to eq amr_data_end_date
+  end
+
+  it 'annotates the corrected data' do
+    expect(results.days_amr_data(start_date)).to_not be_nil
+    expect(results.meter_id(start_date)).to eq mpan_mprn
+    expect(results.substitution_type(start_date)).to eq 'S31M'
+    expect(results.substitution_date(start_date)).to eq nil
+  end
+
+  describe 'with earlier correction start date' do
+    let(:start_date)   { Date.new(2023,1,1) }
+
+    it 'uses amr data start date' do
+      (start_date..end_date).each do |date|
+        expect(results.days_kwh_x48(date)).to eq Array.new(48, 1.0)
+      end
+      expect(results.start_date).to eq Date.new(2023,1,1)
+    end
+  end
+
+  describe 'with nil correction start date' do
+    let(:start_date)   { nil }
+
+    it 'uses amr data start date' do
+      expect(results.start_date).to eq Date.new(2023,1,1)
+      (results.start_date..end_date).each do |date|
+        expect(results.days_kwh_x48(date)).to eq Array.new(48, 1.0)
+      end
+    end
+  end
+
+  describe 'with later correction end date' do
+    let(:end_date)   { Date.new(2023,3,1) }
+
+    it 'uses amr data end date' do
+      (start_date..amr_data_end_date).each do |date|
+        expect(results.days_kwh_x48(date)).to eq Array.new(48, 1.0)
+      end
+      expect(results.end_date).to eq Date.new(2023,1,31)
+    end
+  end
+
+  describe 'with nil correction end date' do
+    let(:end_date)   { nil }
+
+    it 'uses amr data end date' do
+      (start_date..amr_data_end_date).each do |date|
+        expect(results.days_kwh_x48(date)).to eq Array.new(48, 1.0)
+      end
+      expect(results.end_date).to eq Date.new(2023,1,31)
+    end
+  end
+
+end


### PR DESCRIPTION
A bug in the front end means that it's possible to create "rescale" meter attribute that has no start or end date. In the latter case it causes the validation process to loop forever.

This PR makes the correction logic in the analytics more robust, ensuring that the scaling is only done over the available date range. The front-end bug will also get fixed.

The code for the scaling has been broken out into a simple `Rescaler` service, as it makes it easier to test and reduces amount of code in the validation service. This service is then used by the `ValidateAMRData` class. 

My plan, over time, is to migrate more of that correction and validation code into independent, separately testable services.