### PR TITLE
Update rating calculation in peak kw alert

### DIFF
--- a/lib/dashboard/alerts/electricity/alert_peak_kw_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/alert_peak_kw_versus_benchmark.rb
@@ -74,7 +74,7 @@ class AlertElectricityPeakKWVersusBenchmark < AlertElectricityOnlyBase
     @average_school_day_last_year_kw_per_pupil = @average_school_day_last_year_kw / pupil_count
     @average_school_day_last_year_kw_per_floor_area = @average_school_day_last_year_kw / floor_area(asof_date - 365, asof_date)
 
-    benchmark_kw_m2 = BenchmarkMetrics.benchmark_peak_kw(pupil_count, school_type)
+    benchmark_kw = BenchmarkMetrics.benchmark_peak_kw(pupil_count, school_type)
     @exemplar_kw = BenchmarkMetrics.exemplar_peak_kw(pupil_count, school_type)
 
     potential_saving = consumption_above_exemplar_peak(asof_date, @exemplar_kw)
@@ -83,7 +83,10 @@ class AlertElectricityPeakKWVersusBenchmark < AlertElectricityOnlyBase
     @one_year_saving_versus_exemplar_£    = potential_saving[:£]
     @one_year_saving_versus_exemplar_co2  = potential_saving[:co2]
 
-    @rating = calculate_rating_from_range(benchmark_kw_m2, 0.02, @average_school_day_last_year_kw_per_floor_area)
+    # rating: benchmark value = 4.0, exemplar = 10.0
+    percent_from_benchmark_to_exemplar = (@average_school_day_last_year_kw - benchmark_kw) / (@exemplar_kw - benchmark_kw)
+    uncapped_rating = percent_from_benchmark_to_exemplar * (10.0 - 4.0) + 4.0
+    @rating = [[uncapped_rating, 10.0].min, 0.0].max.round(2)
 
     assign_commmon_saving_variables(
       one_year_saving_kwh: @one_year_saving_versus_exemplar_kwh,

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -7,15 +7,16 @@ require_rel '../../test_support'
 #   logger.level = :debug
 # end
 
-asof_date = Date.new(2023, 6, 4)
+asof_date = Date.new(2023, 7, 19)
 # schools = ['t*']
-schools = ['derby*']
+schools = ['n*']
 
 overrides = {
   schools:  schools,
   cache_school: false,
   alerts:   { alerts: nil, control: { asof_date: asof_date} },
   alerts:   { alerts: [
+    AlertElectricityPeakKWVersusBenchmark
 #    AlertThermostaticControl
 #    AlertEnergyAnnualVersusBenchmark,
 #    AlertSchoolWeekComparisonGas,
@@ -23,7 +24,7 @@ overrides = {
 #    AlertElectricityBaseloadVersusBenchmark,
 #    AlertHeatingComingOnTooEarly,
 #    AlertPreviousYearHolidayComparisonElectricity,
-    AlertSolarPVBenefitEstimator,
+#    AlertSolarPVBenefitEstimator,
 #    AlertElectricityAnnualVersusBenchmark,
 #    AlertElectricityLongTermTrend,
 #    AlertGasAnnualVersusBenchmark,


### PR DESCRIPTION
The recent changes to how we calculate the benchmark and exemplar values for the peak kw alert have broken the ratings calculation. The wrong and inconsistent variables are being used.

This PR fixes the rating calculation, to apply the same logic as used in the baseload and annual consumption alerts: generate a rating based on comparing the school's peak kw usage vs that expected of a benchmark and exemplar school with the same number of pupils.

The rating is offset so that a peak kw usage equal to the benchmark gives a rating of 4.0. An exemplar school will score 10.0. A school needing to take action (> benchmark usage) will get a rating of 0.0.

Ratings have been manually checked for a range of schools. 