### PR TITLE
Removed unused tariff code

### DIFF
--- a/app/models/meter_attributes.rb
+++ b/app/models/meter_attributes.rb
@@ -823,22 +823,6 @@ class MeterAttributes
     structure MeterAttributes.generic_accounting_tariff
   end
 
-  class AccountingGenericTariffOverride < MeterAttributeTypes::AttributeBase
-    id :accounting_tariff_generic_override
-    aggregate_over :accounting_tariff_generic_override
-    name 'Accounting tariff override (generic + DCC)'
-
-    structure MeterAttributes.generic_accounting_tariff
-  end
-
-  class AccountingGenericTariffMerge < MeterAttributeTypes::AttributeBase
-    id :accounting_tariff_generic_merge
-    aggregate_over :accounting_tariff_generic_merge
-    name 'Accounting tariff merge (generic + DCC)'
-
-    structure MeterAttributes.generic_accounting_tariff
-  end
-
   def self.all
     constants.inject({}) do |collection, constant_name|
       constant = const_get(constant_name)

--- a/app/models/meter_attributes.rb
+++ b/app/models/meter_attributes.rb
@@ -520,21 +520,6 @@ class MeterAttributes
     )
   end
 
-  class EconomicTariffDifferentialType < MeterAttributeTypes::AttributeBase
-    id  :economic_tariff_differential_accounting_tariff
-    key :economic_tariff_differential_accounting_tariff
-
-    name 'Differential tariff'
-
-    structure MeterAttributeTypes::Hash.define(
-      structure: {
-        start_date:      MeterAttributeTypes::Date.define(required: true),
-        end_date:        MeterAttributeTypes::Date.define,
-        differential:    MeterAttributeTypes::Boolean.define(required: true),
-      }
-    )
-  end
-
   def self.default_tariff_rates
     {
       standing_charge: MeterAttributeTypes::Hash.define(

--- a/app/models/tariffs/meter_tariff_manager.rb
+++ b/app/models/tariffs/meter_tariff_manager.rb
@@ -66,7 +66,7 @@ class MeterTariffManager
   #Calculate the accounting cost for a given date and one days worth
   # of half-hourly consumption
   #
-  # Returns a hash which can be used to a OneDaysCostData object
+  # Returns a hash which can be used to create a OneDaysCostData object
   # TODO: could just create that directly?
   def accounting_cost(date, kwh_x48)
     tariff = accounting_tariff_for_date(date)
@@ -85,6 +85,7 @@ class MeterTariffManager
   end
 
   #Determine whether there's a differential tariff for a specific date
+  #Only used in this class, could be private
   def differential_tariff_on_date?(date)
     override = differential_override(date)
     if override.nil?

--- a/app/models/tariffs/meter_tariff_manager.rb
+++ b/app/models/tariffs/meter_tariff_manager.rb
@@ -137,13 +137,8 @@ class MeterTariffManager
 
   #Determine whether there's a differential tariff for a specific date
   def differential_tariff_on_date?(date)
-    override = differential_override(date)
-    if override.nil?
-      accounting_tariff = accounting_tariff_for_date(date)
-      !accounting_tariff.nil? && accounting_tariff.differential?(date)
-    else
-      override
-    end
+    accounting_tariff = accounting_tariff_for_date(date)
+    !accounting_tariff.nil? && accounting_tariff.differential?(date)
   end
 
   # Find all the tariffs for the underlying meters for a specific date range
@@ -209,12 +204,6 @@ class MeterTariffManager
     tariffs[0]
   end
 
-  def differential_override(date)
-    return nil if @differential_tariff_override.empty?
-
-    @differential_tariff_override.any? { |dr, tf| date >= dr.first && date <= dr.last && tf }
-  end
-
   #Create the collections of models that represent the different categories of tariff for this
   #meter
   def pre_process_tariff_attributes(meter)
@@ -249,18 +238,6 @@ class MeterTariffManager
     unless economic_tariff_classes.include?(@economic_tariff.class)
       raise EnergySparksUnexpectedStateException, "Economic tariff must one of #{economic_tariff_classes.join(' ')} got #{@economic_tariff.class.name}"
     end
-  end
-
-  def process_economic_tariff_override(differential_overrides)
-    return {} if differential_overrides.nil?
-
-    differential_overrides.map do |override|
-      end_date = override[:end_date] || Date.new(2050, 1, 1)
-      [
-        override[:start_date]..end_date,
-        override[:differential]
-      ]
-    end.to_h
   end
 
   #Loop over the accounting tariffs to select those are that marked as default (or not)

--- a/spec/app/models/tariffs/meter_tariff_manager_spec.rb
+++ b/spec/app/models/tariffs/meter_tariff_manager_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper'
+
+describe MeterTariffManager do
+
+  let(:economic_tariff) {
+    {
+     :name=>"Economic standard electricity tariff (inc day-night)",
+     :rates=>
+      {
+        :rate=> {:per=>:kwh, :rate=>0.15},
+        :daytime_rate=>{:per=>:kwh, :rate=>0.16, :from=>TimeOfDay.new(6,30), :to=>TimeOfDay.new(24,00)},
+        :nighttime_rate=>{:per=>:kwh, :rate=>0.12, :from=>TimeOfDay.new(0,0), :to=>TimeOfDay.new(6,30)}
+      }
+    }
+  }
+
+  let(:default) { false }
+  let(:source)  { :manually_entered }
+  let(:start_date) { Date.new(2000, 1, 1) }
+  let(:end_date)  { Date.new(2050, 1, 1) }
+
+  let(:accounting_tariff) {
+    {
+      :start_date=> start_date,
+      :end_date=> end_date,
+      :name=>"Electricity Accounting Tariff",
+      :default=> default,
+      :source => source,
+      :system_wide=>false,
+      :rates=> {
+        :rate=>{:per=>:kwh, :rate=>0.15},
+        :standing_charge=>{:per=>:day, :rate=>1.0}
+      }
+    }
+  }
+
+  let(:meter_attributes) {
+    {:economic_tariff=> economic_tariff, :accounting_tariffs=> [accounting_tariff]}
+  }
+
+  let(:kwh_data_x48)       { Array.new(48, 0.01) }
+  let(:amr_end_date)       { Date.new(2023,1,31) }
+  let(:meter) { build(:meter,
+      type: :electricity,
+      meter_attributes: meter_attributes,
+      amr_data: build(:amr_data, :with_days, day_count: 31, end_date: amr_end_date, kwh_data_x48: kwh_data_x48)
+    )
+  }
+
+  let(:meter_tariff_manager)    { MeterTariffManager.new(meter) }
+
+  context 'pre-processing' do
+    context 'the accounting tariffs' do
+      let(:tariff) { meter_tariff_manager.accounting_tariffs.first }
+      it 'creates an AccountingTariff' do
+        expect(tariff).to_not be_nil
+        expect(tariff.fuel_type).to eq :electricity
+        expect(tariff.tariff).to eq accounting_tariff
+        expect(tariff.differential?(Date.today)).to eq false
+      end
+      context 'and its a default accounting tariff' do
+        let(:default) { true }
+        let(:tariff) { meter_tariff_manager.accounting_tariffs.first }
+        it 'creates an AccountingTariff' do
+          expect(tariff).to be_nil
+        end
+      end
+    end
+    context 'the economic tariffs' do
+      let(:tariff) { meter_tariff_manager.economic_tariff }
+      it 'creates an EconomicTariff' do
+        expect(tariff).to_not be_nil
+        expect(tariff.fuel_type).to eq :electricity
+        expect(tariff.tariff).to eq economic_tariff
+      end
+    end
+    context 'smart meter tariffs' do
+      let(:source)  { :dcc }
+      #set tariff to start after the meter data
+      let(:start_date)  { Date.new(2023, 1, 15) }
+      let(:tariff) { meter_tariff_manager.accounting_tariffs.first }
+      it 'backdates the tariffs to the amr start date' do
+        expect(tariff.tariff[:start_date]).to eq amr_end_date - 30
+      end
+    end
+  end
+
+  context '.economic_cost' do
+    let(:economic_cost) { meter_tariff_manager.economic_cost(amr_end_date, kwh_data_x48)}
+    it 'calculates the expected cost' do
+      expect(economic_cost[:differential]).to eq false
+      expect(economic_cost[:standing_charges]).to eq({})
+      expect(economic_cost[:rates_x48]['flat_rate']).to eq Array.new(48, 0.01 * 0.15)
+    end
+  end
+
+  context '.accounting_cost' do
+    let(:accounting_cost) { meter_tariff_manager.accounting_cost(amr_end_date, kwh_data_x48)}
+
+    it 'calculates the expected cost' do
+      expect(accounting_cost[:differential]).to eq false
+      expect(accounting_cost[:standing_charges]).to eq({standing_charge: 1.0})
+      expect(accounting_cost[:rates_x48]['flat_rate']).to eq Array.new(48, 0.01 * 0.15)
+    end
+
+    context 'and there are multiple tariffs' do
+      let(:start_date) { Date.new(2000, 1, 1) }
+      let(:end_date)  { Date.new(2023, 1, 1) }
+
+      let(:accounting_tariff2) {
+        {
+          :start_date=> Date.new(2023, 1, 2),
+          :end_date=> Date.new(2023, 1, 31),
+          :name=>"Current Electricity Accounting Tariff",
+          :default=> default,
+          :source => source,
+          :system_wide=>false,
+          :rates=> {
+            :rate=>{:per=>:kwh, :rate=>0.30},
+            :standing_charge=>{:per=>:day, :rate=>1.5}
+          }
+        }
+      }
+
+      let(:meter_attributes) {
+        {:economic_tariff=> economic_tariff, :accounting_tariffs=> [accounting_tariff, accounting_tariff2]}
+      }
+
+      it 'selects the right tariff and calculates the expected cost' do
+        expect(accounting_cost[:differential]).to eq false
+        expect(accounting_cost[:standing_charges]).to eq({standing_charge: 1.5})
+        expect(accounting_cost[:rates_x48]['flat_rate']).to eq Array.new(48, 0.01 * 0.30)
+      end
+
+    end
+  end
+
+end


### PR DESCRIPTION
The `MeterTariffManager` includes support for some functionality which is currently unused, this includes:

* ability to specify an "override" accounting tariff that will be used instead of any other tariffs for the meter, e.g. to force DCC tariffs to be ignored
* ability to specific a "merge" tariff that is intended to allow standing charges to be added to other tariffs. (this code is unfinished and contains errors)
* ability to specify an override that will force use of a differential tariff when calculating economic costs for a specific date range

We don't use this currently in the application: there are no attributes configured for any meters in the system.

With the planned rework of the tariff code these will either be unnecessary or will be supported in other ways:

* users can specific tariffs for schools and meters to override those set of a group or system
* tariffs will have a status flag so incorrect / invalid tariffs can be disabled
* DCC tariffs will be editable so that standing charges can be added in
* there will no longer be a distinction between economic and accounting tariffs, there will just be accounting tariffs. So no need to specify an override

This PR:

* Adds rspec tests around all of the core `MeterTariffManager` functionality to support this refactoring and as well as future changes
* Removes all of the code that processes the above meter attributes, along with their definitions
* Tidies up the class to remove some unused methods and to mark a couple of methods that are only used internally as `private`

