### PR TITLE
Tidy up solar_pv_profit_loss

### DIFF
--- a/lib/dashboard/charting_and_reports/old_advice/solar_pv_profit_loss.rb
+++ b/lib/dashboard/charting_and_reports/old_advice/solar_pv_profit_loss.rb
@@ -1,12 +1,6 @@
 class SolarPVProfitLoss
-  DAYS_IN_YEAR = 365
-  SOLAR_FIT = 0.12
-
-  def initialize(meter_collection, mains_electricity_rate_£_per_kWh = 0.15, fit_£_per_kwh = 0.20, export_£_per_kwh = 0.05)
+  def initialize(meter_collection)
     @meter_collection = meter_collection
-    @mains_electricity_rate_£_per_kWh = mains_electricity_rate_£_per_kWh
-    @fit_£_per_kwh = fit_£_per_kwh
-    @export_£_per_kwh = export_£_per_kwh
   end
 
   def annual_electricity_including_onsite_solar_pv_consumption_kwh
@@ -17,16 +11,8 @@ class SolarPVProfitLoss
     last_years_kwh(sub_meter(:self_consume))[:kwh]
   end
 
-  def period_available_description
-    last_years_kwh(sub_meter(:self_consume))[:period_description]
-  end
-
   def annual_exported_solar_pv_kwh
     last_years_kwh(sub_meter(:export))[:kwh]
-  end
-
-  def sub_meter(meter_type)
-    @meter_collection.aggregated_electricity_meters.sub_meters[meter_type]
   end
 
   def annual_solar_pv_kwh
@@ -89,91 +75,4 @@ class SolarPVProfitLoss
     end
   end
 
-  private def value_from_profit_loss_tables_deprecated(row_type, data_type)
-    data = profit_loss_multiple_years.values[0][:data].detect { |row| row[:name].include?(row_type) }
-    data[data_type]
-  end
-
-  private def profit_loss_multiple_years_deprecated
-    @profit_loss_multiple_years_deprecated ||= calculate_profit_loss_multiple_years_deprecated
-  end
-
-  private def calculate_profit_loss_multiple_years_deprecated
-    results_by_year = {}
-    end_date = @meter_collection.aggregated_electricity_meters.amr_data.end_date
-    start_date = [end_date - 365, @meter_collection.aggregated_electricity_meters.amr_data.start_date].max
-    return nil if end_date - start_date < 365
-    while start_date >= @meter_collection.aggregated_electricity_meters.amr_data.start_date
-      results_by_year[formatted_date_range(start_date, end_date)] = annual_profit_loss_deprecated(start_date, end_date)
-      start_date -= DAYS_IN_YEAR
-      end_date -= DAYS_IN_YEAR
-    end
-    results_by_year
-  end
-
-  private def formatted_date_range(start_date, end_date)
-    start_date.strftime('%d %b %Y') + ' to ' + end_date.strftime('%d %b %Y')
-  end
-
-  private def annual_profit_loss_deprecated(start_date, end_date)
-    profit_loss = []
-
-    meters = [@meter_collection.aggregated_electricity_meters] + @meter_collection.aggregated_electricity_meters.sub_meters.values
-
-    total_pv_kwh = 0.0
-
-    meters.each do |meter|
-      next if meter.name == SolarPVPanels::ELECTRIC_CONSUMED_FROM_MAINS_METER_NAME
-      next unless SolarPVPanels::SUBMETER_TYPES.include?(meter.name) # no storage heaters
-
-      kwh = meter.amr_data.kwh_date_range(start_date, end_date, :kwh).magnitude
-
-      profit_loss.push(
-        {
-          name: meter.name,
-          kwh:  kwh,
-          rate: rate_deprecated(meter, start_date, end_date),
-          £:    kwh * rate_deprecated(meter.name)
-        }
-      )
-      pv_meters = [SolarPVPanels::SOLAR_PV_ONSITE_ELECTRIC_CONSUMPTION_METER_NAME, SolarPVPanels::SOLAR_PV_EXPORTED_ELECTRIC_METER_NAME]
-      total_pv_kwh += kwh if pv_meters.include?(meter.name)
-    end
-
-    profit_loss.push(
-      {
-        name: 'Solar feed-in-tariff',
-        kwh:  total_pv_kwh,
-        rate: SOLAR_FIT,
-        £:    total_pv_kwh * SOLAR_FIT
-      }
-    )
-
-    total_kwh = profit_loss.detect { |row| row[:name] == @meter_collection.aggregated_electricity_meters.name }[:kwh]
-    total =
-      {
-        name: 'Total',
-        kwh:   total_kwh - total_pv_kwh,
-        rate: nil,
-        £:    profit_loss.map { |row| row[:£] }.sum # Statsample bug means you can't use sum direct, so map and then sum
-      }
-
-    {
-      data:   profit_loss,
-      total:  total
-    }
-  end
-
-  private def rate_deprecated(meter_name)
-    case meter_name
-    when SolarPVPanels::SOLAR_PV_ONSITE_ELECTRIC_CONSUMPTION_METER_NAME
-      BenchmarkMetrics.pricing.electricity_price  # deprecated
-    when SolarPVPanels::SOLAR_PV_EXPORTED_ELECTRIC_METER_NAME
-      BenchmarkMetrics.pricing.solar_export_price  # deprecated
-    when SolarPVPanels::ELECTRIC_CONSUMED_FROM_MAINS_METER_NAME
-      BenchmarkMetrics.pricing.electricity_price  # deprecated
-    else
-      -1.0 * BenchmarkMetrics.pricing.electricity_price  # deprecated
-    end
-  end
 end


### PR DESCRIPTION
Reviewing how we use (or not) solar pv and solar export pv tariffs I noticed that there was some deprecated code in the `SolarPVProfitLoss` class, so this PR just removes that:

- removes constructor arguments not used in class
- removes constants not used anywhere
- remove private methods with a `_deprecated` suffix to their name, plus any methods that only they call
- remove duplicate method declaration, leaving private method

 