### PR TITLE
Add tariff holder and created_at to generic tariff attribute

### DIFF
--- a/app/models/meter_attribute_types.rb
+++ b/app/models/meter_attribute_types.rb
@@ -189,6 +189,13 @@ module MeterAttributeTypes
     end
   end
 
+  class DateTime < AttributeType
+    self.type = :date_time
+    def _parse(input)
+      ::DateTime.parse(input)
+    end
+  end
+
   class Hash < AttributeType
     self.type = :hash
 

--- a/app/models/meter_attributes.rb
+++ b/app/models/meter_attributes.rb
@@ -760,7 +760,7 @@ class MeterAttributes
       structure: {
         start_date: MeterAttributeTypes::Date.define,
         end_date:   MeterAttributeTypes::Date.define,
-        source:   MeterAttributeTypes::Symbol.define(required: false, allowed_values: [:dcc, :manually_entered]),
+        source:     MeterAttributeTypes::Symbol.define(required: false, allowed_values: [:dcc, :manually_entered]),
         name:       MeterAttributeTypes::String.define,
         type:       MeterAttributeTypes::Symbol.define(required: true, allowed_values: %i[flat differential differential_tiered]),
         sub_type:   MeterAttributeTypes::Symbol.define(required: false, allowed_values: [:weekday_weekend]),
@@ -795,7 +795,9 @@ class MeterAttributes
           }.merge(MeterAttributes.default_tariff_rates)
         ),
         asc_limit_kw:           MeterAttributeTypes::Float.define,
-        climate_change_levy:    MeterAttributeTypes::Boolean.define
+        climate_change_levy:    MeterAttributeTypes::Boolean.define,
+        tariff_holder:   MeterAttributeTypes::Symbol.define(required: false, allowed_values: [:meter, :school, :school_group, :site_settings]),
+        created_at:      MeterAttributeTypes::DateTime.define(required: false)
       }
     )
   end


### PR DESCRIPTION
To better distinguish between different tariff holders, I've updated the meter attribute structure to indicate:

- the tariff holder for a specific tariff (meter, if its tied to a specific meter, or school, school group, site settings to match hierarchy)
- a created_at attribute to support disambiguation between potentially overlapping tariffs

