### PR TITLE
Create new Generic Tariff Manager

### DIFF
--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -45,7 +45,7 @@ module Dashboard
       set_meter_attributes(meter_attributes)
       @model_cache = AnalyseHeatingAndHotWater::ModelCache.new(self)
       @constituent_meters = [self]
-      logger.info "Creating new meter: type #{type} id: #{identifier} name: #{name} floor area: #{floor_area} pupils: #{number_of_pupils}"
+      logger.info "Created new meter: type #{type} id: #{identifier} name: #{name} floor area: #{floor_area} pupils: #{number_of_pupils}"
     end
 
     def mpxn

--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -188,7 +188,11 @@ module Dashboard
     end
 
     private def create_tariff_manager
-      MeterTariffManager.new(self)
+      use_new_energy_tariffs? ? GenericTariffManager.new(self) : MeterTariffManager.new(self)
+    end
+
+    def use_new_energy_tariffs?
+      ENV["FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS"] == 'true'
     end
 
     # Centrica

--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -184,7 +184,11 @@ module Dashboard
       @partial_meter_coverage ||= PartialMeterCoverage.new(attributes(:partial_meter_coverage))
       # Centrica attributes(:open_close_times)
       # @community_opening_times = SchoolOpenCloseTimes.new(@meter_collection, self)
-      @meter_tariffs = MeterTariffManager.new(self)
+      @meter_tariffs = create_tariff_manager
+    end
+
+    private def create_tariff_manager
+      MeterTariffManager.new(self)
     end
 
     # Centrica

--- a/app/models/tariffs/generic_accounting_tariff.rb
+++ b/app/models/tariffs/generic_accounting_tariff.rb
@@ -4,6 +4,15 @@ class GenericAccountingTariff < AccountingTariff
   def initialize(meter, tariff)
     super(meter, tariff)
     remove_climate_change_levy_from_standing_charges
+    default_missing_dates
+  end
+
+  def start_date
+    @tariff[:start_date]
+  end
+
+  def end_date
+    @tariff[:end_date]
   end
 
   #TODO should just check the :type of tariff
@@ -120,6 +129,11 @@ class GenericAccountingTariff < AccountingTariff
   end
 
   private
+
+  def default_missing_dates
+    @tariff[:start_date] = MIN_DEFAULT_START_DATE if !@tariff.key?(:start_date) || @tariff[:start_date].nil?
+    @tariff[:end_date] = MAX_DEFAULT_END_DATE if !@tariff.key?(:end_date) || @tariff[:end_date].nil?
+  end
 
   def defaulted_tariff?
     %i[site_settings school_group].include?(tariff[:tariff_holder])

--- a/app/models/tariffs/meter_tariff.rb
+++ b/app/models/tariffs/meter_tariff.rb
@@ -97,6 +97,19 @@ class MeterTariff
     "#{rate[:from]} to #{rate[:to]}".freeze
   end
 
+  #FIXME this and the following methods don't really make sense for
+  #MeterTariff, AccountingTariff, GenericAccountingTariff, EconomicTariff
+  #as there's only one @tariff that the instance wraps. In that context
+  #the tariff cannot change within a date range, or between periods, and
+  #the code doesn't check the actual tariff periods.
+  #
+  #EconomicTariffChangeOverTime overrides this method to return the
+  #list of tariffs it provides. In this context it makes sense to ask for
+  #the tariffs within a time period, as they may be several that apply
+  #between a given set of dates.
+  #
+  #These methods can be removed once we've introduced the new generic
+  #tariff manager as it will handle this functionality.
   def tariffs_by_date_range
     {
       MIN_DEFAULT_START_DATE..MAX_DEFAULT_END_DATE => @tariff[:rates]

--- a/app/models/tariffs/transmission_network_use_of_system_demand_changes.rb
+++ b/app/models/tariffs/transmission_network_use_of_system_demand_changes.rb
@@ -1,7 +1,7 @@
 # probably due to be replaced by a fixed charge per day from April 2023
 #
 class TNUOSCharges < MaxMonthlyDemandChargesBase
-  class MissingTNUoSDataForThisYear < StandardError; end 
+  class MissingTNUoSDataForThisYear < StandardError; end
 
   YEAR_18_19 = Date.new(2018, 4, 1)..Date.new(2019, 3, 31)
   YEAR_19_20 = Date.new(2019, 4, 1)..Date.new(2020, 3, 31)
@@ -48,7 +48,7 @@ class TNUOSCharges < MaxMonthlyDemandChargesBase
       { zone: 11, name: 'South East', rate_£_per_kw: 56.11085, nhh: 7.945653},
       { zone: 12, name: 'London', rate_£_per_kw: 59.175788, nhh: 6.291396},
       { zone: 13, name: 'Southern', rate_£_per_kw: 57.338781, nhh: 7.586023},
-      { zone: 14, name: 'South Western', rate_£_per_kw: 55.686678, nhh: 7.767486},      
+      { zone: 14, name: 'South Western', rate_£_per_kw: 55.686678, nhh: 7.767486},
     ],
     YEAR_20_21 => [
       { zone: 1, name: 'Northern Scotland', rate_£_per_kw: 21.126849, nhh: 2.742642},
@@ -64,7 +64,7 @@ class TNUOSCharges < MaxMonthlyDemandChargesBase
       { zone: 11, name: 'South East', rate_£_per_kw: 56.501849, nhh: 7.511337},
       { zone: 12, name: 'London', rate_£_per_kw: 59.267002, nhh: 5.828242},
       { zone: 13, name: 'Southern', rate_£_per_kw: 57.772417, nhh: 7.136303},
-      { zone: 14, name: 'South Western', rate_£_per_kw: 57.020402, nhh: 7.608806}, 
+      { zone: 14, name: 'South Western', rate_£_per_kw: 57.020402, nhh: 7.608806},
     ],
     YEAR_21_22 => [
       { zone: 1, name: 'Northern Scotland', rate_£_per_kw: 20.376396, nhh: 2.723726},
@@ -80,7 +80,7 @@ class TNUOSCharges < MaxMonthlyDemandChargesBase
       { zone: 11, name: 'South East', rate_£_per_kw: 56.772103, nhh: 7.73898},
       { zone: 12, name: 'London', rate_£_per_kw: 59.18635, nhh: 6.378699},
       { zone: 13, name: 'Southern', rate_£_per_kw: 58.865203, nhh: 7.574864},
-      { zone: 14, name: 'South Western', rate_£_per_kw: 61.676796, nhh: 8.488355},      
+      { zone: 14, name: 'South Western', rate_£_per_kw: 61.676796, nhh: 8.488355},
     ],
   }
   # guesswork, https://en.wikipedia.org/wiki/Meter_Point_Administration_Number map
@@ -93,7 +93,7 @@ class TNUOSCharges < MaxMonthlyDemandChargesBase
      6 => 13,
      7 => 11,
      8 => 14, # Midlands versus West midlands?
-     9 => 10, 
+     9 => 10,
     10 => 21,
     11 => 19,
     12 => 12,

--- a/app/services/aggregation_service.rb
+++ b/app/services/aggregation_service.rb
@@ -478,6 +478,10 @@ class AggregateDataService
   #So all meters in a school will inherit the same tariffs, so this will always
   #be returning true currently.
   def all_economic_tariffs_identical?(list_of_meters)
+    #TEMPORARY do something better here, e.g. compare whether meters have
+    #their own tariffs, rather than just sharing same school/group/system tariffs
+    return true if ENV["FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS"] == 'true'
+
     return true if list_of_meters.length == 1
 
     economic_tariffs = list_of_meters.map { |meter| meter.meter_tariffs.economic_tariff }

--- a/app/services/aggregation_service.rb
+++ b/app/services/aggregation_service.rb
@@ -478,12 +478,16 @@ class AggregateDataService
   #So all meters in a school will inherit the same tariffs, so this will always
   #be returning true currently.
   def all_economic_tariffs_identical?(list_of_meters)
-    #TEMPORARY do something better here, e.g. compare whether meters have
-    #their own tariffs, rather than just sharing same school/group/system tariffs
-    return true if ENV["FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS"] == 'true'
-
     return true if list_of_meters.length == 1
 
+    #Check whether any of the meters have their own tariffs, rather than
+    #just sharing the same school/group/system tariffs.
+    if ENV["FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS"] == 'true'
+      list_of_meters.any? {|meter| meter.meter_tariffs.meter_tariffs.any? }
+      return true
+    end
+
+    #relies on original MeterTariffManager
     economic_tariffs = list_of_meters.map { |meter| meter.meter_tariffs.economic_tariff }
     economic_tariffs.uniq { |t| [t.tariff, t.tariff]}.count == 1
   end

--- a/app/services/aggregation_service.rb
+++ b/app/services/aggregation_service.rb
@@ -483,8 +483,7 @@ class AggregateDataService
     #Check whether any of the meters have their own tariffs, rather than
     #just sharing the same school/group/system tariffs.
     if ENV["FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS"] == 'true'
-      list_of_meters.any? {|meter| meter.meter_tariffs.meter_tariffs.any? }
-      return true
+      return !list_of_meters.any? {|meter| meter.meter_tariffs.meter_tariffs.any? }
     end
 
     #relies on original MeterTariffManager

--- a/app/services/aggregation_service.rb
+++ b/app/services/aggregation_service.rb
@@ -446,8 +446,8 @@ class AggregateDataService
 
     calculate_carbon_emissions_for_meter(combined_meter, fuel_type)
 
-    has_differential_meter = any_component_meter_differential?(list_of_meters, fuel_type, combined_meter.amr_data.start_date, combined_meter.amr_data.end_date)
-    economic_tariffs_differ = !all_economic_tariffs_identical?(list_of_meters)
+    has_differential_meter = any_component_meter_differential?(list_of_meters, fuel_type, combined_meter.amr_data.start_date, combined_meter.amr_data.end_date) #true if any differential accounting, mostly false atm
+    economic_tariffs_differ = !all_economic_tariffs_identical?(list_of_meters) #always false
     has_time_variant_economic_tariffs = any_time_variant_economic_tariffs?(list_of_meters)
 
     log "Aggregation service time variant #{has_time_variant_economic_tariffs}"
@@ -461,7 +461,7 @@ class AggregateDataService
     combined_meter
   end
 
-  #Returns true if there are any differential tariffs for any meters in the provided list, within
+  #Returns true if there are any differential accounting tariffs for any meters in the provided list, within
   #the specified date range.
   def any_component_meter_differential?(list_of_meters, fuel_type, combined_meter_start_date, combined_meter_end_date)
     return false if fuel_type == :gas
@@ -473,6 +473,10 @@ class AggregateDataService
   end
 
   #Returns true if all economic tariffs for the list of meters are identical.
+  #
+  #Currently, economic tariffs and time varying tariffs are not set "below" School.
+  #So all meters in a school will inherit the same tariffs, so this will always
+  #be returning true currently.
   def all_economic_tariffs_identical?(list_of_meters)
     return true if list_of_meters.length == 1
 

--- a/app/services/tariffs/generic_tariff_manager.rb
+++ b/app/services/tariffs/generic_tariff_manager.rb
@@ -193,7 +193,7 @@ class GenericTariffManager
       when :site_settings
         @system_tariffs << tariff
       else
-        raise "Unknown tariff holder type"
+        raise "Unknown tariff holder type: #{attribute[:tariff_holder]}"
       end
     end
   end

--- a/app/services/tariffs/generic_tariff_manager.rb
+++ b/app/services/tariffs/generic_tariff_manager.rb
@@ -1,0 +1,117 @@
+class GenericTariffManager
+  include Logging
+
+  def initialize(meter)
+    @meter = meter
+    @meter_tariffs = []
+    @school_tariffs = []
+    @school_group_tariffs = []
+    @system_tariffs = []
+    @list_of_all_tariffs =[@meter_tariffs, @school_tariffs, @school_group_tariffs, @system_tariffs]
+    pre_process_tariff_attributes
+  end
+
+  def find_tariff_for_date(date)
+    found_tariffs = nil
+    @list_of_all_tariffs.each do |list|
+      found_tariffs = search_tariffs(list, date)
+      break if found_tariffs.any?
+    end
+    return nil unless found_tariffs.any?
+    sort_by_most_recent(found_tariffs).first
+  end
+
+  #TODO this should be moved elsewhere, similar to AccountingTariff
+  #TODO exceptions?
+  def economic_cost(date, kwh_x48)
+    tariff = find_tariff_for_date(date)
+    #TODO this is different to original?
+    return nil unless tariff
+    #TODO borrowed from generic accounting tariff
+    t = if tariff.flat_tariff?(date)
+        {
+          rates_x48: {
+            MeterTariff::FLAT_RATE => AMRData.fast_multiply_x48_x_scalar(kwh_x48, tariff.tariff[:rates][:flat_rate][:rate])
+          },
+          differential: false
+        }
+      else
+        {
+          rates_x48: tariff.tariff.rate_types.map { |type| tariff.weighted_costs(kwh_x48, type)}.inject(:merge),
+          differential: true
+        }
+      end
+
+    t.merge( { standing_charges: {}, system_wide: true, default: true } )
+  end
+
+  #TODO this will not return exactly same structure, e.g. no system/default values
+  def accounting_cost(date, kwh_x48)
+    tariff = find_tariff_for_date(date)
+    return nil if tariff.nil?
+    tariff.costs(date, kwh_x48)
+  end
+
+  def any_differential_tariff?(start_date, end_date)
+  end
+
+  def accounting_tariff_for_date(date)
+  end
+
+  def economic_tariffs_change_over_time?
+  end
+
+  def last_tariff_change_date(start_date = @meter.amr_data.start_date, end_date = @meter.amr_data.end_date)
+  end
+
+  def tariff_change_dates_in_period(start_date  = @meter.amr_data.start_date, end_date = @meter.amr_data.end_date)
+  end
+
+  def meter_tariffs_differ_within_date_range?(start_date, end_date)
+  end
+
+  def meter_tariffs_changes_between_periods?(period1, period2)
+  end
+
+  private
+
+  def search_tariffs(list, date)
+    list.select { |accounting_tariff| accounting_tariff.in_date_range?(date) }
+  end
+
+  #sort list of found tariffs with most recently created first,
+  #force nil timestamps to sort last
+  def sort_by_most_recent(found_tariffs)
+    found_tariffs.sort do |a,b|
+      a_created = a.tariff[:created_at]
+      b_created = b.tariff[:created_at]
+      a_created && b_created ? b_created <=> a_created : a_created ? -1 : 1
+    end
+  end
+
+  def tariff_attributes
+    @meter.attributes(:accounting_tariff_generic)
+  end
+
+  def pre_process_tariff_attributes
+    return if tariff_attributes.nil?
+    #sort the attributes into separate bins based on tariff_holder
+    #within each bin, sort by created_at, newest first
+    tariff_attributes.each do |attribute|
+      tariff = GenericAccountingTariff.new(@meter, attribute)
+      case attribute[:tariff_holder]
+      when :meter
+        @meter_tariffs << tariff
+      when :school
+        @school_tariffs << tariff
+      when :school_group
+        @school_group_tariffs << tariff
+      when :site_settings
+        @system_tariffs << tariff
+      else
+        raise "Unknown tariff holder type"
+      end
+    end
+  end
+
+end

--- a/app/services/tariffs/generic_tariff_manager.rb
+++ b/app/services/tariffs/generic_tariff_manager.rb
@@ -120,8 +120,6 @@ class GenericTariffManager
   def tariffs_change_between_periods?(period1, period2)
     period1_tariffs = find_all_tariffs_between_dates(period1.first, period1.last)
     period2_tariffs = find_all_tariffs_between_dates(period2.first, period2.last)
-    puts period1_tariffs.inspect
-    puts period2_tariffs.inspect
     period1_tariffs != period2_tariffs
   end
 

--- a/app/services/tariffs/generic_tariff_manager.rb
+++ b/app/services/tariffs/generic_tariff_manager.rb
@@ -90,7 +90,7 @@ class GenericTariffManager
   # Costs::EconomicTariffsChangeCaveatsService
   def tariff_change_dates_in_period(start_date  = @meter.amr_data.start_date, end_date = @meter.amr_data.end_date)
     list_of_tariffs = find_tariffs_between_dates(start_date, end_date)
-    return list_of_tariffs.map{ |t| t.end_date + 1 }
+    list_of_tariffs.map{ |t| t.end_date + 1 }
   end
 
   # Costs::EconomicTariffsChangeCaveatsService
@@ -146,7 +146,6 @@ class GenericTariffManager
     end
   end
 
-
   #All tariffs used within a specific date range, in reverse order
   def find_tariffs_between_dates(start_date, end_date)
     prev_tariff = nil
@@ -160,7 +159,6 @@ class GenericTariffManager
     end
     list_of_tariffs
   end
-
 
   #All tariffs used within date, regardlss of whether they have been
   #applied 1 or more times.

--- a/app/services/tariffs/generic_tariff_manager.rb
+++ b/app/services/tariffs/generic_tariff_manager.rb
@@ -25,35 +25,13 @@ class GenericTariffManager
     sort_by_most_recent(found_tariffs).first
   end
 
-  #TODO this should be moved elsewhere, similar to AccountingTariff
   #TODO exceptions?
   def economic_cost(date, kwh_x48)
-    tariff = find_tariff_for_date(date)
-    #TODO this is different to original?
-    return nil unless tariff
-    #TODO borrowed from generic accounting tariff
-    t = if tariff.flat_tariff?(date)
-        {
-          rates_x48: {
-            MeterTariff::FLAT_RATE => AMRData.fast_multiply_x48_x_scalar(kwh_x48, tariff.tariff[:rates][:flat_rate][:rate])
-          },
-          differential: false
-        }
-      else
-        {
-          rates_x48: tariff.tariff.rate_types.map { |type| tariff.weighted_costs(kwh_x48, type)}.inject(:merge),
-          differential: true
-        }
-      end
-
-    t.merge( { standing_charges: {}, system_wide: true, default: true } )
+    tariff = find_tariff_for_date(date)&.economic_costs(date, kwh_x48)
   end
 
-  #TODO this will not return exactly same structure, e.g. no system/default values
   def accounting_cost(date, kwh_x48)
-    tariff = find_tariff_for_date(date)
-    return nil if tariff.nil?
-    tariff.costs(date, kwh_x48)
+    tariff = find_tariff_for_date(date)&.costs(date, kwh_x48)
   end
 
   def any_differential_tariff?(start_date, end_date)

--- a/lib/dashboard/aggregation/amr_data.rb
+++ b/lib/dashboard/aggregation/amr_data.rb
@@ -36,7 +36,6 @@ class AMRData < HalfHourlyData
   def set_economic_tariff(meter)
     logger.info "Creating an economic costs in amr_meter #{meter.mpan_mprn} #{meter.fuel_type}"
     @economic_tariff = EconomicCostsParameterised.new(meter)
-    # @current_economic_tariff = @economic_tariff
   end
 
   def set_current_economic_tariff(meter)

--- a/lib/dashboard/aggregation/amr_data.rb
+++ b/lib/dashboard/aggregation/amr_data.rb
@@ -35,14 +35,14 @@ class AMRData < HalfHourlyData
 
   def set_economic_tariff(meter)
     logger.info "Creating an economic costs in amr_meter #{meter.mpan_mprn} #{meter.fuel_type}"
-    @economic_tariff = EconomicCostsParameterised.create_costs(meter)
+    @economic_tariff = EconomicCostsParameterised.new(meter)
     # @current_economic_tariff = @economic_tariff
   end
 
   def set_current_economic_tariff(meter)
     logger.info "Setting current economic tariff for meter #{meter.name}"
     if meter.meter_tariffs.economic_tariffs_change_over_time?
-      @current_economic_tariff = CurrentEconomicCostsParameterised.create_costs(meter)
+      @current_economic_tariff = CurrentEconomicCostsParameterised.new(meter)
     else
       # there no computational benefit in doing this,
       # given the tariff for amr_data.end_date is always re-looked up rather than cached
@@ -53,7 +53,7 @@ class AMRData < HalfHourlyData
 
   def set_accounting_tariff(meter)
     logger.info "Creating parameterised accounting costs in amr_meter #{meter.mpan_mprn} #{meter.fuel_type}"
-    @accounting_tariff = AccountingCostsParameterised.create_costs(meter)
+    @accounting_tariff = AccountingCostsParameterised.new(meter)
   end
 
   def set_economic_tariff_schedule(tariff)

--- a/lib/dashboard/aggregation/costs.rb
+++ b/lib/dashboard/aggregation/costs.rb
@@ -153,15 +153,6 @@ class CostsBase < HalfHourlyData
     cost_hh_£
   end
 
-  #Unused?
-  public def calculate_tariff(meter)
-    (amr_data.start_date..amr_data.end_date).each do |date|
-      one_day_cost = calculate_tariff_for_date(date, meter)
-      add(date, one_day_cost)
-    end
-    logger.info "Created #{costs_summary}"
-  end
-
   # Calculate the cost for a given date
   #
   # @param Date date the date to calculate. Used to lookup consumption and tariff data
@@ -174,14 +165,6 @@ class CostsBase < HalfHourlyData
     return nil if c.nil?
     one_day_cost = OneDaysCostData.new(c)
     one_day_cost
-  end
-
-  #Return total cost for a date and consumption values
-  #Unused?
-  public def calculate_x48_kwh_cost(date, kwh_x48)
-    c = costs(date, meter, kwh_x48)
-    raise EnergySparksUnexpectedStateException, "x48 cost for #{date}" if c.nil?
-    OneDaysCostData.new(c).one_day_total_cost
   end
 
   #Log summary of costs for a day

--- a/lib/dashboard/aggregation/costs_accounting_costs.rb
+++ b/lib/dashboard/aggregation/costs_accounting_costs.rb
@@ -59,20 +59,11 @@ class AccountingCostsParameterised < AccountingCosts
     end
   end
 
-  def self.create_costs(meter)
-    AccountingCostsParameterised.new(meter)
-  end
 end
 
 class AccountingCostsPreAggregated < AccountingCosts
   # always precalculated so don't calculate on the fly
   def one_days_cost_data(date)
     self[date]
-  end
-
-  def self.create_costs(meter)
-    costs = AccountingCostsPreAggregated.new(meter)
-    costs.calculate_tariff(amr_data, fuel_type, default_energy_purchaser)
-    costs
   end
 end

--- a/lib/dashboard/aggregation/costs_economic_costs.rb
+++ b/lib/dashboard/aggregation/costs_economic_costs.rb
@@ -60,10 +60,6 @@ end
 #
 # "parameterised representation of economic costs until after agggregation to reduce memory footprint"
 class EconomicCostsParameterised < EconomicCosts
-  def self.create_costs(meter)
-    self.new(meter)
-  end
-
   # Returns the costs for a specific date
   # @param Date date
   # @return OneDaysCostData
@@ -120,19 +116,7 @@ class EconomicCostsPreAggregated < EconomicCosts
     self[date]
   end
 
-  #Unused? There is no parameterised variable or method
-  def self.create_costs(meter)
-    costs = EconomicCostsPreAggregated.new(meter)
-    costs.calculate_tariff unless parameterised
-    costs
-  end
 end
 
 class CurrentEconomicCostsPreAggregated < EconomicCostsPreAggregated
-  #Unused? There is no parameterised variable or method
-  def self.create_costs(meter)
-    costs = CurrentEconomicCostsPreAggregated.new(meter)
-    costs.calculate_tariff unless parameterised
-    costs
-  end
 end

--- a/lib/dashboard/data_sources/metering/n3rgy/n3rgy_to_energy_sparks_tariffs.rb
+++ b/lib/dashboard/data_sources/metering/n3rgy/n3rgy_to_energy_sparks_tariffs.rb
@@ -34,6 +34,7 @@ class N3rgyToEnergySparksTariffs
       start_date:       overlap_dates.first,
       end_date:         overlap_dates.last,
       name:             'Tariff from DCC SMETS2 meter',
+      tariff_holder:    :meter
     }
     tariff.merge(convert_rates(kwh_rate, standing_charge.values.first))
   end

--- a/spec/app/models/tariffs/generic_accounting_tariff_spec.rb
+++ b/spec/app/models/tariffs/generic_accounting_tariff_spec.rb
@@ -1,0 +1,276 @@
+require 'spec_helper'
+
+describe GenericAccountingTariff do
+
+  let(:end_date)          { Date.today }
+  let(:start_date)        { Date.today - 30 }
+  let(:tariff_type)       { :flat }
+  let(:rates)             { create_flat_rate }
+  let(:kwh_data_x48)      { Array.new(48, 0.01) }
+
+  let(:tariff_attribute) { create_accounting_tariff_generic(start_date: start_date, end_date: end_date, type: tariff_type, rates: rates) }
+
+  let(:meter) { double(:meter) }
+
+  let(:accounting_tariff)      { GenericAccountingTariff.new(meter, tariff_attribute) }
+
+  before(:each) do
+    expect(meter).to receive(:mpxn).and_return(1512345678900)
+    expect(meter).to receive(:amr_data).and_return(nil)
+    expect(meter).to receive(:fuel_type).and_return(:electricity)
+  end
+
+  context '.initialize' do
+    context 'with overlapping times ranges' do
+      let(:rates) {
+        {
+          rate0: {
+            from: TimeOfDay.new(10,0),
+            to: TimeOfDay.new(23,30),
+            per: :kwh,
+            rate: 0.15
+          },
+          rate1: {
+            from: TimeOfDay.new(0,0),
+            to: TimeOfDay.new(10,30),
+            per: :kwh,
+            rate: 0.15
+          }
+        }
+      }
+      let(:tariff_attribute) { create_accounting_tariff_generic(type: :differential, rates: rates) }
+      it 'raises exception' do
+        expect{ accounting_tariff }.to raise_error(AccountingTariff::OverlappingTimeRanges)
+      end
+    end
+
+    context 'with incomplete time ranges' do
+      let(:rates) {
+        {
+          rate0: {
+            from: TimeOfDay.new(10,0),
+            to: TimeOfDay.new(23,30),
+            per: :kwh,
+            rate: 0.15
+          }
+        }
+      }
+
+      let(:tariff_attribute) { create_accounting_tariff_generic(type: :differential, rates: rates) }
+      it 'raises exception' do
+        expect{ accounting_tariff }.to raise_error(AccountingTariff::IncompleteTimeRanges)
+      end
+    end
+
+    context 'with times not on half hours' do
+      let(:rates) {
+        {
+          rate0: {
+            from: TimeOfDay.new(7,15),
+            to: TimeOfDay.new(23,30),
+            per: :kwh,
+            rate: 0.15
+          },
+          rate1: {
+            from: TimeOfDay.new(0,0),
+            to: TimeOfDay.new(7,00),
+            per: :kwh,
+            rate: 0.15
+          }
+        }
+      }
+      let(:tariff_attribute) { create_accounting_tariff_generic(type: :differential, rates: rates) }
+      it 'raises exception' do
+        expect{ accounting_tariff }.to raise_error(AccountingTariff::TimeRangesNotOn30MinuteBoundary)
+      end
+    end
+  end
+
+  context '.differential?' do
+    context 'with flat rate' do
+      it 'identifies the type of tariff' do
+        expect(accounting_tariff.differential?(nil)).to be false
+        expect(accounting_tariff.flat_tariff?(nil)).to be true
+      end
+    end
+    context 'with differential ' do
+      let(:tariff_attribute) { create_accounting_tariff_generic(rates: create_differential_rate) }
+      it 'identifies the type of tariff' do
+        expect(accounting_tariff.differential?(nil)).to be true
+        expect(accounting_tariff.flat_tariff?(nil)).to be false
+      end
+    end
+  end
+
+  context '.default?' do
+    let(:tariff_attribute) { create_accounting_tariff_generic(tariff_holder: :school) }
+    context 'when default is not not set' do
+      it 'treats school tariffs as not default' do
+        expect(accounting_tariff.default?).to be false
+      end
+    end
+    context 'when default explicitly set to true' do
+      let(:tariff_attribute) { create_accounting_tariff_generic(default: true) }
+      it 'returns true' do
+        expect(accounting_tariff.default?).to be true
+      end
+    end
+
+    context 'when tariff holder is a school group' do
+      let(:tariff_attribute) { create_accounting_tariff_generic(tariff_holder: :school_group) }
+
+      it 'returns true' do
+        expect(accounting_tariff.default?).to be true
+      end
+    end
+  end
+
+  context '.system_wide?' do
+    let(:tariff_attribute) { create_accounting_tariff_generic(tariff_holder: :school) }
+    context 'when not set' do
+      it 'returns false' do
+        expect(accounting_tariff.system_wide?).to be false
+      end
+    end
+    context 'when explicitly set to true' do
+      let(:tariff_attribute) { create_accounting_tariff_generic(system_wide: true) }
+      it 'returns true' do
+        expect(accounting_tariff.system_wide?).to be true
+      end
+    end
+
+    context 'when tariff holder is site settings' do
+      let(:tariff_attribute) { create_accounting_tariff_generic(tariff_holder: :site_settings) }
+
+      it 'returns true' do
+        expect(accounting_tariff.system_wide?).to be true
+      end
+    end
+  end
+
+  context '.costs' do
+    let(:accounting_cost)  { accounting_tariff.costs(end_date, kwh_data_x48) }
+
+    context 'with flat rate' do
+      it 'calculates the expected cost' do
+        expect(accounting_cost[:differential]).to eq false
+        expect(accounting_cost[:standing_charges]).to eq({})
+        expect(accounting_cost[:rates_x48]['flat_rate']).to eq Array.new(48, 0.01 * 0.15)
+      end
+
+      context 'with a standing charge when available' do
+        let(:rates) { create_flat_rate(rate: 0.15, standing_charge: 1.0) }
+        it 'includes the charge' do
+          expect(accounting_cost[:standing_charges]).to eq({standing_charge: 1.0})
+        end
+      end
+
+      context 'with a kwh based standing charge' do
+        let(:levy_rate) { 0.6 }
+        let(:other_charges) {
+          {
+            feed_in_tariff_levy: {
+              per: :kwh,
+              rate: levy_rate
+            }
+          }
+        }
+        let(:rates) { create_flat_rate(other_charges: other_charges) }
+        it 'includes the charge' do
+          expect(accounting_cost[:rates_x48]['Feed in tariff levy']).to eq Array.new(48, 0.01 * levy_rate)
+        end
+      end
+
+      context 'with climate change levy' do
+        let(:tariff_attribute) { create_accounting_tariff_generic(start_date: start_date, end_date: end_date,
+          type: tariff_type, climate_change_levy: true, rates: rates) }
+
+        it 'includes the charge' do
+          #value is from ClimateChangeLevy
+          expect(accounting_cost[:rates_x48][:climate_change_levy__2023_24]).to eq Array.new(48, 0.01 * 0.00775)
+        end
+      end
+
+      context 'with duos charges' do
+        let(:other_charges) {
+          {
+            duos_red: 0.025,
+            duos_amber: 0.015,
+            duos_green: 0.01
+          }
+        }
+        let(:rates) { create_flat_rate(other_charges: other_charges) }
+        it 'includes the charges' do
+          #check it calculates and we have non-zero values for each period
+          expect(accounting_cost[:rates_x48][:duos_green].sum).to_not be 0.0
+          expect(accounting_cost[:rates_x48][:duos_amber].sum).to_not be 0.0
+          expect(accounting_cost[:rates_x48][:duos_green].sum).to_not be 0.0
+        end
+      end
+
+      context 'with tnuous charge' do
+        let(:other_charges) {
+          {
+            tnuos: true
+          }
+        }
+        let(:rates) { create_flat_rate(other_charges: other_charges) }
+        #let(:start_date) {Date.new(2022,1,1)}
+        #let(:end_date)   {Date.new(2022,3,15)}
+
+        #TODO: this currently doesn't work as the tnuos config is out of date
+        xit 'includes the charge as a standing charge' do
+          puts accounting_cost.inspect
+        end
+      end
+
+      context 'with other standing charges' do
+        let(:other_charges) {
+          {
+            data_collection_dcda_agent_charge: {
+              per: :day,
+              rate: 0.5
+            }
+          }
+        }
+        let(:rates) { create_flat_rate(other_charges: other_charges) }
+        it 'adds them to standing charges' do
+          expect(accounting_cost[:standing_charges][:data_collection_dcda_agent_charge]).to eq(0.5)
+        end
+      end
+    end
+
+    context 'with differential rate' do
+      let(:tariff_type) { :differential }
+      let(:rates) { create_differential_rate(day_rate: 0.30, night_rate: 0.15, standing_charge: nil) }
+
+      it 'calculates the expected cost' do
+        expect(accounting_cost[:differential]).to eq true
+        expect(accounting_cost[:standing_charges]).to eq({})
+        expect(accounting_cost[:rates_x48]['07:00 to 23:30']).to eq Array.new(14, 0.0) + Array.new(34, 0.01 * 0.15)
+        expect(accounting_cost[:rates_x48]['00:00 to 06:30']).to eq Array.new(14, 0.01 * 0.30) + Array.new(34, 0.0)
+      end
+    end
+  end
+
+  context '.economic_costs' do
+    let(:economic_cost)  { accounting_tariff.economic_costs(end_date, kwh_data_x48) }
+
+    it 'calculates the expected cost' do
+      expect(economic_cost[:differential]).to eq false
+      expect(economic_cost[:standing_charges]).to eq({})
+      expect(economic_cost[:rates_x48]['flat_rate']).to eq Array.new(48, 0.01 * 0.15)
+    end
+    context 'with differential rate' do
+      let(:tariff_type) { :differential }
+      let(:rates) { create_differential_rate(day_rate: 0.30, night_rate: 0.15, standing_charge: nil) }
+
+      it 'calculates the expected cost' do
+        expect(economic_cost[:differential]).to eq true
+        expect(economic_cost[:standing_charges]).to eq({})
+        expect(economic_cost[:rates_x48]['07:00 to 23:30']).to eq Array.new(14, 0.0) + Array.new(34, 0.01 * 0.15)
+        expect(economic_cost[:rates_x48]['00:00 to 06:30']).to eq Array.new(14, 0.01 * 0.30) + Array.new(34, 0.0)
+      end
+    end
+  end
+end

--- a/spec/app/models/tariffs/meter_tariff_spec.rb
+++ b/spec/app/models/tariffs/meter_tariff_spec.rb
@@ -23,6 +23,7 @@ describe MeterTariff do
   context '.default?' do
     context 'with default key' do
       it 'identifies default' do
+        pry
         expect(meter_tariff.default?).to eq false
         tariff_attribute[:default] = true
         expect(meter_tariff.default?).to eq true

--- a/spec/app/models/tariffs/meter_tariff_spec.rb
+++ b/spec/app/models/tariffs/meter_tariff_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe MeterTariff do
+
+  let(:tariff_attribute) { create_accounting_tariff_generic(type: :differential, rates: create_old_differential_rate) }
+
+  let(:meter) { double(:meter) }
+
+  let(:meter_tariff)      { MeterTariff.new(meter, tariff_attribute) }
+
+  before(:each) do
+    expect(meter).to receive(:mpxn).and_return("123456789")
+    expect(meter).to receive(:amr_data).and_return(nil)
+    expect(meter).to receive(:fuel_type).and_return(:electricity)
+  end
+  context '.initialize' do
+    it 'assigns the attributes' do
+      expect(meter_tariff.tariff).to eq tariff_attribute
+      expect(meter_tariff.fuel_type).to eq :electricity
+    end
+  end
+
+  context '.default?' do
+    context 'with default key' do
+      it 'identifies default' do
+        expect(meter_tariff.default?).to eq false
+        tariff_attribute[:default] = true
+        expect(meter_tariff.default?).to eq true
+      end
+    end
+    context 'with tariff holder' do
+      it 'interprets default'
+    end
+  end
+
+  context '.dcc' do
+    it 'identifies dcc tariff' do
+      expect(meter_tariff.dcc?).to eq false
+      tariff_attribute[:source] = :dcc
+      expect(meter_tariff.dcc?).to eq true
+    end
+  end
+
+  context '.weighted_cost' do
+    let(:type)      { :nighttime_rate }
+    let(:kwh_x48)   { Array.new(48, 1.0) }
+    let(:cost)      { meter_tariff.weighted_cost(nil, kwh_x48, type) }
+    it 'calculates the cost' do
+      expect(cost).to eq Array.new(14, 0.0) + Array.new(34, 0.15)
+    end
+  end
+
+end

--- a/spec/app/models/tariffs/meter_tariff_spec.rb
+++ b/spec/app/models/tariffs/meter_tariff_spec.rb
@@ -28,9 +28,6 @@ describe MeterTariff do
         expect(meter_tariff.default?).to eq true
       end
     end
-    context 'with tariff holder' do
-      it 'interprets default'
-    end
   end
 
   context '.dcc' do

--- a/spec/app/models/tariffs/meter_tariff_spec.rb
+++ b/spec/app/models/tariffs/meter_tariff_spec.rb
@@ -23,7 +23,6 @@ describe MeterTariff do
   context '.default?' do
     context 'with default key' do
       it 'identifies default' do
-        pry
         expect(meter_tariff.default?).to eq false
         tariff_attribute[:default] = true
         expect(meter_tariff.default?).to eq true

--- a/spec/app/services/tariffs/generic_tariff_manager_spec.rb
+++ b/spec/app/services/tariffs/generic_tariff_manager_spec.rb
@@ -34,9 +34,6 @@ describe GenericTariffManager, type: :service do
   end
 
   context '#initialize' do
-    context 'with smart meter tariffs' do
-      it 'backdates the tariffs to the amr start date'
-    end
     context 'smart meter tariffs' do
       #amr data will be 1st - 31st Jan
       let(:amr_end_date)       { Date.new(2023,1,31) }

--- a/spec/app/services/tariffs/generic_tariff_manager_spec.rb
+++ b/spec/app/services/tariffs/generic_tariff_manager_spec.rb
@@ -37,6 +37,21 @@ describe GenericTariffManager, type: :service do
     context 'with smart meter tariffs' do
       it 'backdates the tariffs to the amr start date'
     end
+    context 'smart meter tariffs' do
+      #amr data will be 1st - 31st Jan
+      let(:amr_end_date)       { Date.new(2023,1,31) }
+
+      #set tariff to start after the meter data
+      let(:start_date)         { Date.new(2023, 1, 15) }
+      let(:end_date)           { Date.new(2050, 1, 1) }
+
+      let(:accounting_tariff)  { create_accounting_tariff_generic(start_date: start_date, end_date: end_date, source: :dcc, rates: rates, tariff_holder: :meter) }
+
+      let(:tariff) { service.meter_tariffs.first }
+      it 'backdates the tariffs to the amr start date' do
+        expect(tariff.tariff[:start_date]).to eq amr_end_date - 30
+      end
+    end
   end
 
   context '.find_tariff_for_date' do

--- a/spec/app/services/tariffs/generic_tariff_manager_spec.rb
+++ b/spec/app/services/tariffs/generic_tariff_manager_spec.rb
@@ -428,5 +428,75 @@ describe GenericTariffManager, type: :service do
 
   end
 
+  context '.tariffs_differ_within_date_range?' do
+    let(:t1_start_date)  { Date.new(2022,1,1) }
+    let(:t1_end_date)    { Date.new(2022,12,31) }
+
+    let(:tariff_1) { create_accounting_tariff_generic(start_date: t1_start_date, end_date: t1_end_date) }
+
+    let(:t2_start_date)  { Date.new(2023,1,1) }
+    let(:t2_end_date)    { Date.new(2023,12,31) }
+
+    let(:tariff_2) { create_accounting_tariff_generic(start_date: t2_start_date, end_date: t2_end_date) }
+
+    let(:meter_attributes) {
+      {:accounting_tariff_generic=> [tariff_1, tariff_2]}
+    }
+
+    let(:search_start_date)     { Date.new(2023, 4, 1)  }
+    let(:search_end_date)       { Date.new(2023, 4, 30) }
+
+    let(:changed) { service.tariffs_differ_within_date_range?(search_start_date, search_end_date) }
+
+    context 'when there has been no change' do
+      it 'returns false' do
+        expect(changed).to eq false
+      end
+    end
+
+    context 'when there has been a change' do
+      let(:search_start_date)     { Date.new(2022, 12, 1)  }
+      let(:search_end_date)       { Date.new(2023, 2, 1) }
+
+      it 'returns true' do
+        expect(changed).to eq true
+      end
+    end
+
+  end
+
+  context '.tariffs_change_between_periods?' do
+    let(:t1_start_date)  { Date.new(2022,1,1) }
+    let(:t1_end_date)    { Date.new(2022,12,31) }
+
+    let(:tariff_1) { create_accounting_tariff_generic(start_date: t1_start_date, end_date: t1_end_date) }
+
+    let(:t2_start_date)  { Date.new(2023,1,1) }
+    let(:t2_end_date)    { Date.new(2023,12,31) }
+
+    let(:tariff_2) { create_accounting_tariff_generic(start_date: t2_start_date, end_date: t2_end_date) }
+
+    let(:meter_attributes) {
+      {:accounting_tariff_generic=> [tariff_1, tariff_2]}
+    }
+
+    let(:first_period)    { Date.new(2023, 2, 1)..Date.new(2023, 3, 1)}
+    let(:second_period)   { Date.new(2023, 3, 1)..Date.new(2023, 4, 1)}
+    let(:changed) { service.tariffs_change_between_periods?(first_period, second_period) }
+
+    context 'with no change' do
+      it 'returns false' do
+        expect(changed).to eq false
+      end
+    end
+
+    context 'with a change' do
+      let(:first_period)    { Date.new(2022, 2, 1)..Date.new(2022, 3, 1)}
+      it 'returns false' do
+        expect(changed).to eq true
+      end
+    end
+
+  end
   it 'fulfils the contract of the old tariff manager'
 end

--- a/spec/app/services/tariffs/generic_tariff_manager_spec.rb
+++ b/spec/app/services/tariffs/generic_tariff_manager_spec.rb
@@ -195,7 +195,7 @@ describe GenericTariffManager, type: :service do
     end
   end
 
-  context '.any_differential_tariff' do
+  context '.any_differential_tariff?' do
     context 'with flat rate' do
       it 'returns false' do
         expect(service.any_differential_tariff?(start_date, end_date)).to be false
@@ -498,5 +498,87 @@ describe GenericTariffManager, type: :service do
     end
 
   end
+
+  context '.meter_tariffs_differ_within_date_range?' do
+    let(:t1_start_date)  { Date.new(2022,1,1) }
+    let(:t1_end_date)    { Date.new(2022,12,31) }
+
+    let(:tariff_1) { create_accounting_tariff_generic(start_date: t1_start_date, end_date: t1_end_date) }
+
+    let(:t2_start_date)  { Date.new(2023,1,1) }
+    let(:t2_end_date)    { Date.new(2023,12,31) }
+
+    let(:tariff_2) { create_accounting_tariff_generic(start_date: t2_start_date, end_date: t2_end_date) }
+
+    let(:meter_attributes) {
+      {:accounting_tariff_generic=> [tariff_1, tariff_2]}
+    }
+
+    let(:search_start_date)     { Date.new(2023, 4, 1)  }
+    let(:search_end_date)       { Date.new(2023, 4, 30) }
+
+    let(:changed) { service.meter_tariffs_differ_within_date_range?(search_start_date, search_end_date) }
+
+    before(:each) do
+      allow_any_instance_of(Dashboard::Meter).to receive(:meter_tariffs) do
+        service
+      end
+    end
+
+    context 'when there has been no change' do
+      it 'returns false' do
+        expect(changed).to eq false
+      end
+    end
+
+    context 'when there has been a change' do
+      let(:search_start_date)     { Date.new(2022, 12, 1)  }
+      let(:search_end_date)       { Date.new(2023, 2, 1) }
+
+      it 'returns true' do
+        expect(changed).to eq true
+      end
+    end
+  end
+
+  context '.meter_tariffs_changes_between_periods?' do
+    let(:t1_start_date)  { Date.new(2022,1,1) }
+    let(:t1_end_date)    { Date.new(2022,12,31) }
+
+    let(:tariff_1) { create_accounting_tariff_generic(start_date: t1_start_date, end_date: t1_end_date) }
+
+    let(:t2_start_date)  { Date.new(2023,1,1) }
+    let(:t2_end_date)    { Date.new(2023,12,31) }
+
+    let(:tariff_2) { create_accounting_tariff_generic(start_date: t2_start_date, end_date: t2_end_date) }
+
+    let(:meter_attributes) {
+      {:accounting_tariff_generic=> [tariff_1, tariff_2]}
+    }
+
+    let(:first_period)    { Date.new(2023, 2, 1)..Date.new(2023, 3, 1)}
+    let(:second_period)   { Date.new(2023, 3, 1)..Date.new(2023, 4, 1)}
+    let(:changed) { service.meter_tariffs_changes_between_periods?(first_period, second_period) }
+
+    before(:each) do
+      allow_any_instance_of(Dashboard::Meter).to receive(:meter_tariffs) do
+        service
+      end
+    end
+
+    context 'with no change' do
+      it 'returns false' do
+        expect(changed).to eq false
+      end
+    end
+
+    context 'with a change' do
+      let(:first_period)    { Date.new(2022, 2, 1)..Date.new(2022, 3, 1)}
+      it 'returns false' do
+        expect(changed).to eq true
+      end
+    end
+  end
+
   it 'fulfils the contract of the old tariff manager'
 end

--- a/spec/app/services/tariffs/generic_tariff_manager_spec.rb
+++ b/spec/app/services/tariffs/generic_tariff_manager_spec.rb
@@ -1,0 +1,179 @@
+require 'spec_helper'
+
+describe GenericTariffManager, type: :service do
+
+  let(:end_date)    { Date.today }
+  let(:start_date)  { Date.today - 30 }
+
+  let(:rates)       { create_flat_rate }
+
+  let(:accounting_tariff) { create_accounting_tariff_generic(start_date: start_date, end_date: end_date, rates: rates, tariff_holder: :site_settings) }
+
+  let(:meter_attributes) {
+    {:accounting_tariff_generic=> [accounting_tariff]}
+  }
+
+  let(:kwh_data_x48)       { Array.new(48, 0.01) }
+  let(:amr_end_date)       { end_date }
+
+  let(:meter) { build(:meter,
+      type: :electricity,
+      meter_attributes: meter_attributes,
+      amr_data: build(:amr_data, :with_days, day_count: 31, end_date: amr_end_date, kwh_data_x48: kwh_data_x48)
+    )
+  }
+
+  let(:service)    { GenericTariffManager.new(meter) }
+
+  #TEMPORARY, need to add code to switch in different implementation
+  #Stub the creation of the tariff manager called via the Meter constructor
+  before(:each) do
+    allow_any_instance_of(Dashboard::Meter).to receive(:create_tariff_manager) do
+      nil
+    end
+  end
+
+  context '#initialize' do
+    context 'with smart meter tariffs' do
+      it 'backdates the tariffs to the amr start date'
+    end
+  end
+
+  context '.find_tariff_for_date' do
+    let(:search_date)     { end_date }
+    let(:found_tariff)    { service.find_tariff_for_date(search_date) }
+
+    context 'with no tariff' do
+      let(:meter_attributes)  { {} }
+      it 'returns nil' do
+        expect(found_tariff).to be_nil
+      end
+    end
+
+    context 'with date outside range' do
+      let(:search_date)       { Date.today - 365 }
+      it 'returns nil' do
+        expect(found_tariff).to be_nil
+      end
+    end
+
+    context 'with only system settings tariff' do
+      it 'returns the tariff' do
+        expect(found_tariff).to_not be_nil
+        expect(found_tariff.tariff).to eq accounting_tariff
+      end
+    end
+
+    context 'with a school group tariff' do
+      let(:tariff_holder) { :school_group }
+      it 'returns the tariff' do
+        expect(found_tariff).to_not be_nil
+        expect(found_tariff.tariff).to eq accounting_tariff
+      end
+    end
+    context 'with a school tariff' do
+      let(:tariff_holder) { :school }
+      it 'returns the tariff' do
+        expect(found_tariff).to_not be_nil
+        expect(found_tariff.tariff).to eq accounting_tariff
+      end
+    end
+    context 'with a meter tariff' do
+      let(:tariff_holder) { :meter }
+      it 'returns the tariff' do
+        expect(found_tariff).to_not be_nil
+        expect(found_tariff.tariff).to eq accounting_tariff
+      end
+    end
+    context 'with a full hierarchy of tariffs' do
+      let(:site)            { create_accounting_tariff_generic(tariff_holder: :site_settings) }
+      let(:school_group)    { create_accounting_tariff_generic(tariff_holder: :school_group) }
+      let(:school)          { create_accounting_tariff_generic(tariff_holder: :school) }
+      let(:meter_tariff)    { create_accounting_tariff_generic(tariff_holder: :meter) }
+
+      let(:meter_attributes) {
+        {:accounting_tariff_generic=> [site, school_group, school, meter_tariff]}
+      }
+
+      it 'returns the applicable meter tariff first' do
+        expect(found_tariff).to_not be_nil
+        expect(found_tariff.tariff).to eq meter_tariff
+      end
+    end
+
+    context 'with a hierarchy of overlapping tariffs' do
+      let(:search_date)  { Date.new(2023, 1, 15) }
+
+      let(:school_group) { create_accounting_tariff_generic(tariff_holder: :school_group,
+        start_date: Date.new(2022, 1,1), end_date: Date.new(2024, 1, 1)) }
+
+      let(:school)       { create_accounting_tariff_generic(tariff_holder: :school,
+        start_date: Date.new(2023, 1, 1), end_date: Date.new(2023, 4, 1)) }
+
+      let(:meter_tariff) { create_accounting_tariff_generic(tariff_holder: :meter,
+        start_date: Date.new(2022, 6, 1), end_date: Date.new(2023, 1, 5)) }
+
+      let(:meter_attributes) {
+        {:accounting_tariff_generic=> [school_group, school, meter_tariff]}
+      }
+
+      it 'falls back to the school tariff when the meter tariff doesnt apply' do
+        expect(found_tariff).to_not be_nil
+        expect(found_tariff.tariff).to eq school
+      end
+    end
+
+    context 'with overlapping tariffs at the same level' do
+      let(:older) { create_accounting_tariff_generic(created_at: DateTime.now - 30, tariff_holder: :school) }
+      let(:newer) { create_accounting_tariff_generic(tariff_holder: :school) }
+
+      let(:meter_attributes) {
+        {:accounting_tariff_generic=> [older, newer]}
+      }
+
+      it 'returns the most recently created' do
+        expect(found_tariff.tariff).to eq newer
+      end
+
+      context 'and one has a missing timestamp' do
+        let(:older) { create_accounting_tariff_generic(created_at: nil, tariff_holder: :school) }
+        it 'returns the most recently created' do
+          expect(found_tariff.tariff).to eq newer
+        end
+      end
+    end
+  end
+
+  context '.economic_cost' do
+    let(:rates)           { create_flat_rate(rate: 0.15, standing_charge: nil) }
+    let(:economic_cost)   { service.economic_cost(amr_end_date, kwh_data_x48) }
+
+    it 'calculates the expected cost' do
+      expect(economic_cost[:differential]).to eq false
+      expect(economic_cost[:standing_charges]).to eq({})
+      expect(economic_cost[:rates_x48]['flat_rate']).to eq Array.new(48, 0.01 * 0.15)
+    end
+
+  end
+
+  context '.accounting_cost' do
+    let(:rates)           { create_flat_rate(rate: 0.15, standing_charge: nil) }
+
+    let(:accounting_cost) { service.accounting_cost(amr_end_date, kwh_data_x48)}
+
+    it 'calculates the expected cost' do
+      expect(accounting_cost[:differential]).to eq false
+      expect(accounting_cost[:standing_charges]).to eq({})
+      expect(accounting_cost[:rates_x48]['flat_rate']).to eq Array.new(48, 0.01 * 0.15)
+    end
+
+    context 'with a standing charge when available' do
+      let(:rates)           { create_flat_rate(rate: 0.15, standing_charge: 1.0) }
+      it 'includes the charge' do
+        expect(accounting_cost[:standing_charges]).to eq({standing_charge: 1.0})
+      end
+    end
+  end
+
+  it 'fulfils the contract of the old tariff manager'
+end

--- a/spec/lib/dashboard/data_sources/n3rgy/n3rgy_to_energy_sparks_tariffs_spec.rb
+++ b/spec/lib/dashboard/data_sources/n3rgy/n3rgy_to_energy_sparks_tariffs_spec.rb
@@ -39,6 +39,7 @@ describe N3rgyToEnergySparksTariffs do
             start_date: day,
             end_date: day,
             name: 'Tariff from DCC SMETS2 meter',
+            tariff_holder: :meter,
             rates: {
               flat_rate: {
                 per:    :kwh,
@@ -78,6 +79,7 @@ describe N3rgyToEnergySparksTariffs do
             start_date: day,
             end_date: day,
             name: 'Tariff from DCC SMETS2 meter',
+            tariff_holder: :meter,
             rates: {
               rate0: {
                 from: TimeOfDay30mins.new(0, 0),
@@ -126,6 +128,7 @@ describe N3rgyToEnergySparksTariffs do
             start_date: day,
             end_date: day,
             name: 'Tariff from DCC SMETS2 meter',
+            tariff_holder: :meter,
             rates: {
               rate0: {
                 from: TimeOfDay30mins.new(0, 0),
@@ -173,6 +176,7 @@ describe N3rgyToEnergySparksTariffs do
             start_date: day,
             end_date: day,
             name: 'Tariff from DCC SMETS2 meter',
+            tariff_holder: :meter,
             rates: {
               rate0: {
                 from: TimeOfDay30mins.new(0, 0),

--- a/spec/lib/dashboard/utilities/datetime_helper_spec.rb
+++ b/spec/lib/dashboard/utilities/datetime_helper_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+describe DateTimeHelper do
+
+  describe '#weighted_x48_vector_multiple_ranges' do
+
+    context 'with single range' do
+      let(:range) { [TimeOfDay.new(8,50)..TimeOfDay.new(15,20)] }
+      it 'returns expected values' do
+        vector = DateTimeHelper.weighted_x48_vector_multiple_ranges(range)
+        expect(vector[0..16]).to eq Array.new(17,0.0)
+        expect(vector[17]).to eq 0.6666666666666666
+        expect(vector[18..29]).to eq Array.new(12,1.0)
+        expect(vector[30]).to eq 0.6666666666666666
+        expect(vector[31..48]).to eq Array.new(17,0.0)
+      end
+    end
+
+    context 'with multiple ranges' do
+      let(:range) { [TimeOfDay.new(15,21)..TimeOfDay.new(19,30), TimeOfDay.new(7,0)..TimeOfDay.new(8,49)] }
+      it 'returns expected values' do
+        vector = DateTimeHelper.weighted_x48_vector_multiple_ranges(range)
+        expect(vector[0..13]).to eq Array.new(14,0.0)
+        #14 == 7am
+        #16 == 8am
+        expect(vector[14..16]).to eq Array.new(3, 1.0)
+        #17 == 8.30am, 19 / 30 minutes (% time through hh slot)
+        expect(vector[17]).to eq 0.6333333333333333
+        #19 == 9.00am
+        expect(vector[18..29]).to eq Array.new(12,0.0)
+        #30 == 15.00, 21 / 30 minutes (% time through hh slot)
+        expect(vector[30]).to eq 0.7
+        expect(vector[31..38]).to eq Array.new(8,1.0)
+        expect(vector[39..48]).to eq Array.new(9,0.0)
+      end
+    end
+
+  end
+
+  describe '#weighted_x48_vector_single_range' do
+    let(:range) { TimeOfDay.new(0,0)..TimeOfDay.new(1,0) }
+
+    it 'returns expected weights' do
+      expect(DateTimeHelper.weighted_x48_vector_single_range(range)).to eq([1.0, 1.0] + Array.new(46, 0.0))
+    end
+
+    context 'with mid day' do
+      let(:range) { TimeOfDay.new(8,0)..TimeOfDay.new(10,0) }
+
+      it 'returns expected weights' do
+        expect(DateTimeHelper.weighted_x48_vector_single_range(range)).to eq( Array.new(16, 0.0) + Array.new(4, 1.0) + Array.new(28, 0.0) )
+      end
+    end
+
+    context 'with full day' do
+      let(:range) { TimeOfDay.new(0,0)..TimeOfDay.new(24,00) }
+
+      it 'returns expected weights' do
+        expect(DateTimeHelper.weighted_x48_vector_single_range(range)).to eq(Array.new(48, 1.0))
+      end
+    end
+  end
+
+  describe '#weighted_x48_vector_fast_inclusive' do
+    let(:range)  { TimeOfDay.new(0,0)..TimeOfDay.new(1,0) }
+    let(:weight) { 1.0 }
+    it 'returns expected weights' do
+      expect(DateTimeHelper.weighted_x48_vector_fast_inclusive(range, weight)).to eq([1.0, 1.0, 1.0] + Array.new(45, 0.0))
+    end
+
+    context 'with mid day' do
+      let(:range) { TimeOfDay.new(8,0)..TimeOfDay.new(10,0) }
+
+      it 'returns expected weights' do
+        expect(DateTimeHelper.weighted_x48_vector_fast_inclusive(range, weight)).to eq( Array.new(16, 0.0) + Array.new(5, 1.0) + Array.new(27, 0.0) )
+      end
+    end
+
+    context 'with range ending 23:30' do
+      let(:range) { TimeOfDay.new(0,0)..TimeOfDay.new(23,30) }
+
+      it 'returns expected weights' do
+        expect(DateTimeHelper.weighted_x48_vector_fast_inclusive(range, weight)).to eq(Array.new(48, 1.0))
+      end
+    end
+
+    context 'with overnight range' do
+      let(:range) { TimeOfDay.new(23,0)..TimeOfDay.new(1,0) }
+
+      it 'returns expected weights' do
+        expect(DateTimeHelper.weighted_x48_vector_fast_inclusive(range, weight)).to eq(Array.new(3,1.0) + Array.new(43, 0.0) + Array.new(2, 1.0))
+      end
+    end
+
+  end
+end

--- a/spec/support/tariff_helpers.rb
+++ b/spec/support/tariff_helpers.rb
@@ -1,0 +1,57 @@
+module EnergySparksAnalyticsDataHelpers
+
+  def create_flat_rate(rate: 0.15, standing_charge: nil)
+    rates = {
+      flat_rate: {
+        per: :kwh,
+        rate: rate
+      }
+    }
+    if standing_charge
+      rates[:standing_charge] = {
+        per: :day,
+        rate: standing_charge
+      }
+    end
+    rates
+  end
+
+  def create_differential_rate(day_rate: 0.30, night_rate: 0.15, standing_charge: nil)
+    rates = {
+      rate0: {
+        from: TimeOfDay.new(7,0),
+        to: TimeOfDay.new(0,0),
+        per: :kwh,
+        rate: night_rate
+      },
+      rate1: {
+        from: TimeOfDay.new(0,0),
+        to: TimeOfDay.new(6,30),
+        per: :kwh,
+        rate: day_rate
+      }
+    }
+    if standing_charge
+      rates[:standing_charge] = {
+        per: :day,
+        rate: standing_charge
+      }
+    end
+    rates
+  end
+
+  def create_accounting_tariff_generic(start_date: Date.yesterday, end_date: Date.today, name: "Tariff #{rand}", source: :manually_entered, tariff_holder: :site_settings, type: :flat, vat: "0%", created_at: DateTime.now, rates: create_flat_rate)
+    {
+      start_date: start_date,
+      end_date: end_date,
+      name: name,
+      source: source,
+      type: type,
+      tariff_holder: tariff_holder,
+      created_at: created_at,
+      vat: vat,
+      rates: rates
+    }
+  end
+
+end


### PR DESCRIPTION
This PR creates a new tariff manager implementation (`GenericTariffManager`) which is intended to be a drop-in replacement for the current implementation (`MeterTariffManager`).

The new version works solely from `accounting_tariff_generic` meter attributes, as supplied by the new `EnergyTariff` model in the application. This type of meter attribute structure will cover all types of tariff from now on.

The new implementation does not distinguish between economic and accounting tariffs. Instead it just calculates economic costs from the full accounting tariffs, by ignoring the standard charges and other costs.

It also provides more flexibility in creating and managing tariffs by supporting a full hierarchy of tariffs from system, school group, school and meter. These tariffs are sorted into different buckets (via the `tariff_holder` attribute) and are then searched in order to find the applicable tariff for a given day. This ensures that overrides at each level are processed correctly.

It relaxes requirements around overlapping/contiguous tariffs to give flexibility when editing and be more tolerant of errors.

This version does not support weekend/weekday tariffs at present. We don't have any of those currently, so handling of those needs some rework across the system.

Switching to use the new tariff manage is done via the `FEATURE_FLAG_USE_NEW_ENERGY_TARIFF` environment variable.

Due to the removal of economic tariffs, there isn't a direct equivalent of some code, e.g. checking whether tariffs change over time. Sensible defaults have been implemented pending further refactoring of the tariff code.

The PR adds some additional tests around some classes and also removes some redundant / unused code.

In future PRs we can simplify things further:

* simplify the MeterTariff class hierarchy, to just a single AccountingTariff class with subclasses for more esoteric tariffs (e.g. weekend/weekday)
* remove the older MeterTariffManager implementation
* reorganise the classes into more consistent modules

In addition to the provided specs, the changes have been manually tested against https://github.com/Energy-Sparks/energy-sparks/pull/2948 which ensures that the EnergyTariffs are provided to the application in the right structure and all of the older accounting and economic tariffs are ignored when aggregating a school. All schools have been aggregated without errors (except for existing errors in the manually setup meter attributes). Tariff calculations for charts and advice pages also work correctly.