### PR TITLE
Fix bug with periods not on half-hourly boundaries

### DIFF
--- a/lib/dashboard/utilities/datetime_helper.rb
+++ b/lib/dashboard/utilities/datetime_helper.rb
@@ -120,8 +120,8 @@ module DateTimeHelper
     result = []
     (0..47).each do |halfhour_index|
       value = 0.0
-      if  halfhour_index == start_halfhour_index
-        value =  start_excess_minutes_percent > 0.0 ? start_excess_minutes_percent : 1.0
+      if halfhour_index == start_halfhour_index
+        value =  start_excess_minutes_percent > 0.0 ? (1.0 - start_excess_minutes_percent) : 1.0
       elsif halfhour_index > start_halfhour_index && halfhour_index < end_halfhour_index
         value = 1.0
       elsif halfhour_index == end_halfhour_index

--- a/spec/app/classes/usage/annual_usage_category_breakdown_spec.rb
+++ b/spec/app/classes/usage/annual_usage_category_breakdown_spec.rb
@@ -23,9 +23,9 @@ describe Usage::AnnualUsageCategoryBreakdown, type: :service do
   context '#potential_savings' do
     it 'returns a combined usage metric of potential kwh, co2, and percent savings compared to an exemplar school' do
       exemplar_comparison = service.potential_savings(versus: :exemplar_school)
-      expect(exemplar_comparison.kwh).to round_to_two_digits(61631.57) # 61631.56666666665
-      expect(exemplar_comparison.percent).to round_to_two_digits(0.13) # 0.13186088498947934
-      expect(exemplar_comparison.£).to round_to_two_digits(9370.09) # 9370.089737063214
+      expect(exemplar_comparison.kwh).to round_to_two_digits(66464.97)
+      expect(exemplar_comparison.percent).to round_to_two_digits(0.14)
+      expect(exemplar_comparison.£).to round_to_two_digits(10104.93)
     end
   end
 end

--- a/spec/app/services/usage/annual_usage_breakdown_service_spec.rb
+++ b/spec/app/services/usage/annual_usage_breakdown_service_spec.rb
@@ -29,25 +29,26 @@ describe Usage::AnnualUsageBreakdownService, type: :service do
     it 'returns a usage category breakdown with calculated combined usage metrics for holiday, school open days etc for electricity' do
       usage_breakdown_benchmark_service = Usage::AnnualUsageBreakdownService.new(meter_collection: meter_collection, fuel_type: :electricity)
       day_type_breakdown = usage_breakdown_benchmark_service.usage_breakdown
+
       expect(day_type_breakdown.holiday.kwh).to round_to_two_digits(71847.1) # 71847.09999999999
       expect(day_type_breakdown.holiday.co2).to round_to_two_digits(12476.78) # 12476.783800000008
       expect(day_type_breakdown.holiday.percent).to round_to_two_digits(0.15) # 0.15371704310498283
       expect(day_type_breakdown.holiday.£).to round_to_two_digits(10813.95) # 10813.954999999998
 
-      expect(day_type_breakdown.school_day_closed.kwh).to round_to_two_digits(181388.27) # 181388.2666666666
-      expect(day_type_breakdown.school_day_closed.co2).to round_to_two_digits(35745.40) # 35745.40483333333
-      expect(day_type_breakdown.school_day_closed.percent).to round_to_two_digits(0.39) # 0.3880806324254996
-      expect(day_type_breakdown.school_day_closed.£).to round_to_two_digits(27184.38) # 27184.38200000001
+      expect(day_type_breakdown.school_day_closed.kwh).to round_to_two_digits(186221.67)
+      expect(day_type_breakdown.school_day_closed.co2).to round_to_two_digits(36732.62)
+      expect(day_type_breakdown.school_day_closed.percent).to round_to_two_digits(0.4)
+      expect(day_type_breakdown.school_day_closed.£).to round_to_two_digits(27935.39)
 
-      expect(day_type_breakdown.school_day_open.kwh).to round_to_two_digits(172067.63) # 172067.6333333333
-      expect(day_type_breakdown.school_day_open.co2).to round_to_two_digits(33246.98) # 33246.97816666668
-      expect(day_type_breakdown.school_day_open.percent).to round_to_two_digits(0.37) # 0.36813911501052066
-      expect(day_type_breakdown.school_day_open.£).to round_to_two_digits(26756.20) # 26756.202000000005
+      expect(day_type_breakdown.school_day_open.kwh).to round_to_two_digits(167234.23)
+      expect(day_type_breakdown.school_day_open.co2).to round_to_two_digits(32259.76)
+      expect(day_type_breakdown.school_day_open.percent).to round_to_two_digits(0.36)
+      expect(day_type_breakdown.school_day_open.£).to round_to_two_digits(26005.19)
 
-      expect(day_type_breakdown.out_of_hours.kwh).to round_to_two_digits(295330.77) # 295330.7666666666
-      expect(day_type_breakdown.out_of_hours.co2).to round_to_two_digits(55245.66) # 55245.66103333332
-      expect(day_type_breakdown.out_of_hours.percent).to round_to_two_digits(0.63) # 0.6318608849894793
-      expect(day_type_breakdown.out_of_hours.£).to round_to_two_digits(44304.22) # 44304.217000000004
+      expect(day_type_breakdown.out_of_hours.kwh).to round_to_two_digits(300164.17)
+      expect(day_type_breakdown.out_of_hours.co2).to round_to_two_digits(56232.88)
+      expect(day_type_breakdown.out_of_hours.percent).to round_to_two_digits(0.64)
+      expect(day_type_breakdown.out_of_hours.£).to round_to_two_digits(45055.23)
 
       expect(day_type_breakdown.weekend.kwh).to round_to_two_digits(42095.40) # 42095.39999999999
       expect(day_type_breakdown.weekend.co2).to round_to_two_digits(7023.47) # 7023.472399999997
@@ -63,13 +64,13 @@ describe Usage::AnnualUsageBreakdownService, type: :service do
       expect(day_type_breakdown.total.co2).to round_to_two_digits(88_492.64) # 88492.6392
 
       exemplar_comparison = day_type_breakdown.potential_savings(versus: :exemplar_school)
-      expect(exemplar_comparison.co2).to eq(nil) #11667.048848999002
-      expect(exemplar_comparison.kwh).to round_to_two_digits(61631.57) # 61631.56666666665
-      expect(exemplar_comparison.percent).to round_to_two_digits(0.13) # 0.13186088498947934
-      expect(exemplar_comparison.£).to round_to_two_digits(9370.09) # 9370.089737063214
+      expect(exemplar_comparison.co2).to eq(nil)
+      expect(exemplar_comparison.kwh).to round_to_two_digits(66464.97)
+      expect(exemplar_comparison.percent).to round_to_two_digits(0.14)
+      expect(exemplar_comparison.£).to round_to_two_digits(10104.93)
 
       comparison = day_type_breakdown.potential_savings(versus: :benchmark_school)
-      expect(comparison.percent).to round_to_two_digits(0.03)
+      expect(comparison.percent).to round_to_two_digits(0.04)
     end
 
     it 'returns a usage category breakdown with calculated combined usage metrics for holiday, school open days etc for storage heater' do

--- a/spec/lib/dashboard/utilities/datetime_helper_spec.rb
+++ b/spec/lib/dashboard/utilities/datetime_helper_spec.rb
@@ -1,0 +1,144 @@
+require 'spec_helper'
+
+describe DateTimeHelper do
+
+  describe '#weighted_x48_vector_multiple_ranges' do
+
+    context 'with single range' do
+      let(:range) { [TimeOfDay.new(8,50)..TimeOfDay.new(15,20)] }
+      it 'returns expected values' do
+        vector = DateTimeHelper.weighted_x48_vector_multiple_ranges(range)
+        expect(vector[0..16]).to eq Array.new(17,0.0)
+        #8.50 means only final 10 minutes, 1/3rd of half hour
+        expect(vector[17]).to eq 0.3333333333333333
+        expect(vector[18..29]).to eq Array.new(12,1.0)
+        #15,20 means first 20 minutes, so 2/3rd of half hour
+        expect(vector[30]).to eq 0.6666666666666666
+        expect(vector[31..48]).to eq Array.new(17,0.0)
+      end
+    end
+
+    context 'with multiple ranges' do
+      let(:range) { [TimeOfDay.new(15,21)..TimeOfDay.new(19,30), TimeOfDay.new(7,0)..TimeOfDay.new(8,49)] }
+      it 'returns expected values' do
+        vector = DateTimeHelper.weighted_x48_vector_multiple_ranges(range)
+        expect(vector[0..13]).to eq Array.new(14,0.0)
+        #14 == 7am
+        #16 == 8am
+        expect(vector[14..16]).to eq Array.new(3, 1.0)
+        #17 == 8.30am, 19 / 30 minutes (% time through hh slot)
+        expect(vector[17]).to eq 0.6333333333333333
+        #19 == 9.00am
+        expect(vector[18..29]).to eq Array.new(12,0.0)
+        #30 == 15.00, 21 / 30 minutes (% time through hh slot)
+        expect(vector[30]).to eq 0.7
+        expect(vector[31..38]).to eq Array.new(8,1.0)
+        expect(vector[39..48]).to eq Array.new(9,0.0)
+      end
+    end
+
+  end
+
+  describe '#weighted_x48_vector_single_range' do
+    let(:range) { TimeOfDay.new(0,0)..TimeOfDay.new(1,0) }
+    let(:weights) { DateTimeHelper.weighted_x48_vector_single_range(range) }
+
+    it 'returns expected weights' do
+      expect(weights[0..1]).to eq [1.0, 1.0]
+      expect(weights[2..47]).to eq Array.new(46, 0.0)
+    end
+
+    context 'with ranges on 15 min boundary' do
+      let(:range)   { TimeOfDay.new(8,15)..TimeOfDay.new(10,15) }
+
+      it 'returns expected weights' do
+        expect(weights[0..15]).to eq Array.new(16, 0.0)
+        #half of the 8-8.30am period
+        expect(weights[16]).to eq 0.5
+        expect(weights[17..19]).to eq Array.new(3, 1.0)
+        #half of the 10-10.30am period
+        expect(weights[20]).to eq 0.5
+        expect(weights[21..47]).to eq Array.new(27, 0.0)
+      end
+    end
+
+    context 'with ranges at 10 mins and 20 mins' do
+      let(:range) { TimeOfDay.new(8,10)..TimeOfDay.new(10,20) }
+      it 'returns expected weights' do
+        expect(weights[0..15]).to eq Array.new(16, 0.0)
+        #two third of the 8-8.3.0am period
+        expect(weights[16].round(2)).to eq 0.67
+        expect(weights[17..19]).to eq Array.new(3, 1.0)
+        #and two thirds of the 10-10.30am period
+        expect(weights[20].round(2)).to eq 0.67
+        expect(weights[21..47]).to eq Array.new(27, 0.0)
+      end
+    end
+
+    context 'with ranges at 50 mins and 20 mins' do
+      let(:range) { TimeOfDay.new(8,50)..TimeOfDay.new(10,20) }
+      it 'returns expected weights' do
+                puts weights.inspect
+        expect(weights[0..16]).to eq Array.new(17, 0.0)
+        #one third of the 8-8.3.0am period
+        expect(weights[17].round(2)).to eq 0.33
+        expect(weights[18..19]).to eq Array.new(2, 1.0)
+        #and two thirds of the 10-10.30am period
+        expect(weights[20].round(2)).to eq 0.67
+        expect(weights[21..47]).to eq Array.new(27, 0.0)
+      end
+    end
+
+
+    context 'with morning period' do
+      let(:range) { TimeOfDay.new(8,0)..TimeOfDay.new(10,0) }
+
+      it 'returns expected weights' do
+        expect(weights[0..15]).to eq Array.new(16, 0.0)
+        expect(weights[16..19]).to eq Array.new(4, 1.0)
+        expect(weights[20..47]).to eq Array.new(28, 0.0)
+      end
+    end
+
+    context 'with full day' do
+      let(:range) { TimeOfDay.new(0,0)..TimeOfDay.new(24,00) }
+
+      it 'returns expected weights' do
+        expect(DateTimeHelper.weighted_x48_vector_single_range(range)).to eq(Array.new(48, 1.0))
+      end
+    end
+  end
+
+  describe '#weighted_x48_vector_fast_inclusive' do
+    let(:range)  { TimeOfDay.new(0,0)..TimeOfDay.new(1,0) }
+    let(:weight) { 1.0 }
+    it 'returns expected weights' do
+      expect(DateTimeHelper.weighted_x48_vector_fast_inclusive(range, weight)).to eq([1.0, 1.0, 1.0] + Array.new(45, 0.0))
+    end
+
+    context 'with mid day' do
+      let(:range) { TimeOfDay.new(8,0)..TimeOfDay.new(10,0) }
+
+      it 'returns expected weights' do
+        expect(DateTimeHelper.weighted_x48_vector_fast_inclusive(range, weight)).to eq( Array.new(16, 0.0) + Array.new(5, 1.0) + Array.new(27, 0.0) )
+      end
+    end
+
+    context 'with range ending 23:30' do
+      let(:range) { TimeOfDay.new(0,0)..TimeOfDay.new(23,30) }
+
+      it 'returns expected weights' do
+        expect(DateTimeHelper.weighted_x48_vector_fast_inclusive(range, weight)).to eq(Array.new(48, 1.0))
+      end
+    end
+
+    context 'with overnight range' do
+      let(:range) { TimeOfDay.new(23,0)..TimeOfDay.new(1,0) }
+
+      it 'returns expected weights' do
+        expect(DateTimeHelper.weighted_x48_vector_fast_inclusive(range, weight)).to eq(Array.new(3,1.0) + Array.new(43, 0.0) + Array.new(2, 1.0))
+      end
+    end
+
+  end
+end

--- a/spec/lib/dashboard/utilities/datetime_helper_spec.rb
+++ b/spec/lib/dashboard/utilities/datetime_helper_spec.rb
@@ -10,10 +10,10 @@ describe DateTimeHelper do
         vector = DateTimeHelper.weighted_x48_vector_multiple_ranges(range)
         expect(vector[0..16]).to eq Array.new(17,0.0)
         #8.50 means only final 10 minutes, 1/3rd of half hour
-        expect(vector[17]).to eq 0.3333333333333333
+        expect(vector[17].round(2)).to eq 0.33
         expect(vector[18..29]).to eq Array.new(12,1.0)
         #15,20 means first 20 minutes, so 2/3rd of half hour
-        expect(vector[30]).to eq 0.6666666666666666
+        expect(vector[30].round(2)).to eq 0.67
         expect(vector[31..48]).to eq Array.new(17,0.0)
       end
     end
@@ -31,7 +31,7 @@ describe DateTimeHelper do
         #19 == 9.00am
         expect(vector[18..29]).to eq Array.new(12,0.0)
         #30 == 15.00, 21 / 30 minutes (% time through hh slot)
-        expect(vector[30]).to eq 0.7
+        expect(vector[30].round(2)).to eq 0.3
         expect(vector[31..38]).to eq Array.new(8,1.0)
         expect(vector[39..48]).to eq Array.new(9,0.0)
       end
@@ -78,7 +78,6 @@ describe DateTimeHelper do
     context 'with ranges at 50 mins and 20 mins' do
       let(:range) { TimeOfDay.new(8,50)..TimeOfDay.new(10,20) }
       it 'returns expected weights' do
-                puts weights.inspect
         expect(weights[0..16]).to eq Array.new(17, 0.0)
         #one third of the 8-8.3.0am period
         expect(weights[17].round(2)).to eq 0.33
@@ -89,6 +88,18 @@ describe DateTimeHelper do
       end
     end
 
+    context 'with ranges at 20 mins and 50 mins' do
+      let(:range) { TimeOfDay.new(8,20)..TimeOfDay.new(10,50) }
+      it 'returns expected weights' do
+        expect(weights[0..15]).to eq Array.new(16, 0.0)
+        #one thirds of the 8-8.3.0am period
+        expect(weights[16].round(2)).to eq 0.33
+        expect(weights[17..20]).to eq Array.new(4, 1.0)
+        #and two thirds of the 10-10.30am period
+        expect(weights[21].round(2)).to eq 0.67
+        expect(weights[22..47]).to eq Array.new(26, 0.0)
+      end
+    end
 
     context 'with morning period' do
       let(:range) { TimeOfDay.new(8,0)..TimeOfDay.new(10,0) }


### PR DESCRIPTION
Fixes an issue with periods that aren't on exact half-hourly boundaries.

For the start of the half-hourly period, the code was returning the time within the period, rather than the time remaining.

This potentially impacts all calculations that involve school opening hours: our system defaults are 8.50am to 15:20. The bug would have caused the 8.50am range to have been treated as 20 rather than 10 minutes within the 8.30-9.00am range. See updates to usage breakdown service for indication of impacts.

Potentially also impacts community use times, depending on data provided by schools.