### PR TITLE
Remove unneeded scan of AMR data

### DIFF
--- a/app/services/aggregation_service.rb
+++ b/app/services/aggregation_service.rb
@@ -70,9 +70,6 @@ class AggregateDataService
   def aggregate_heat_and_electricity_meters
     log 'Aggregate Meters'
     bm = Benchmark.realtime do
-      #adjust meter start/end dates if needed
-      set_long_gap_boundary_on_all_meters
-
       #aggregate heat meters
       aggregate_heat_meters
 
@@ -144,25 +141,6 @@ class AggregateDataService
     ].compact.each do |meter|
       oc_breakdown = AMRDataCommunityOpenCloseBreakdown.new(meter, @meter_collection.open_close_times)
       meter.amr_data.open_close_breakdown = oc_breakdown
-    end
-  end
-
-  #2023 (LD): this looks to be unnecessary. Do some further tests and remove
-  #
-  #set_long_gap_boundary will try and adjust the amr data start/end to the
-  #date of an LGAP, FIXS, FIXE reading if it can find one
-  #
-  #But in the validation step, setting these readings will result in the AMR data before
-  #or after the data to be removed from the AmrData object. The application removes any
-  #validated data that isn't part of this range.
-  #
-  # So there's never any data provided outside of these dates and we're doing an
-  # unnecessary scan of all meter data in case we find one of these readings. But
-  # they will already be the start or end of provided meter data range
-  def set_long_gap_boundary_on_all_meters
-    @meter_collection.all_meters.each do |meter|
-      log "Considering setting long gap boundaries on #{meter.mpan_mprn}?"
-      meter.amr_data.set_long_gap_boundary
     end
   end
 

--- a/lib/dashboard/aggregation/amr_data.rb
+++ b/lib/dashboard/aggregation/amr_data.rb
@@ -607,27 +607,6 @@ class AMRData < HalfHourlyData
     data
   end
 
-  # long gaps are demarked by a single LGAP meter reading - the last day of the gap
-  # data held in the database doesn't store the date as part of its meta data so its
-  # set here by calling this function after all meter readings are loaded
-  def set_long_gap_boundary
-    override_start_date = nil
-    override_end_date = nil
-    (start_date..end_date).each do |date|
-      one_days_data = self[date]
-      override_start_date = date if !one_days_data.nil? && (one_days_data.type == 'LGAP' || one_days_data.type == 'FIXS')
-      override_end_date = date if !one_days_data.nil? && one_days_data.type == 'FIXE'
-    end
-    unless override_start_date.nil?
-      logger.info "Overriding start_date of amr data from #{self.start_date} to #{override_start_date}"
-      set_start_date(override_start_date)
-    end
-    unless override_end_date.nil?
-      logger.info "Overriding end_date of amr data from #{self.end_date} to #{override_end_date}"
-      set_end_date(override_end_date) unless override_end_date.nil?
-    end
-  end
-
   def summarise_bad_data
     date, one_days_data = self.first
     logger.info '=' * 80

--- a/lib/dashboard/aggregation/validate_amr_data.rb
+++ b/lib/dashboard/aggregation/validate_amr_data.rb
@@ -326,6 +326,8 @@ class ValidateAMRData
     check_date_exists(fix_start_date, :readings_start_date)
     logger.debug "Fixing start date to #{fix_start_date} for #{@meter_id}"
     substitute_data_x48 = @amr_data.one_days_data_x48(fix_start_date)
+    #Setting start date will truncate earlier data. Application will end up
+    #storing the FIXS reading as the earliest reading. Prior data will be deleted
     @amr_data.add(fix_start_date, OneDayAMRReading.new(meter_id, fix_start_date, 'FIXS', nil, DateTime.now, substitute_data_x48))
     @amr_data.set_start_date(fix_start_date)
   end
@@ -343,6 +345,8 @@ class ValidateAMRData
     check_date_exists(fix_end_date, :readings_end_date)
     logger.debug "Fixing end date to #{fix_end_date}"
     substitute_data_x48 = @amr_data.one_days_data_x48(fix_end_date)
+    #Setting end date will truncate earlier data. Application will end up
+    #storing the FIXE reading as the latest reading. Later data will be deleted
     @amr_data.add(fix_end_date, OneDayAMRReading.new(meter_id, fix_end_date, 'FIXE', nil, DateTime.now, substitute_data_x48))
     @amr_data.set_end_date(fix_end_date)
   end
@@ -880,6 +884,8 @@ class ValidateAMRData
       end
       if gap_count > @max_days_missing_data && !in_meter_correction_period?(date)
         min_date = first_bad_date + 1
+        #Setting start date will truncate earlier data. Application will end up
+        #storing the LGAP reading as the earliest reading. Prior data will be deleted
         @amr_data.set_start_date(min_date)
         msg =  'Ignoring all data before ' + min_date.strftime(FSTRDEF)
         msg += ' as gap of more than ' + @max_days_missing_data.to_s + ' days '


### PR DESCRIPTION
When we validate data there are some status markers added to the validated readings:

- LGAP which means the first reading after a long gap of missing readings. 
- FIXS which indicates we've forced the system to only look at a fixed start date
- FIXE the above, but for end date

Whenever those are set the validation code also calls `set_start_date` or `set_end_date` on the `AmrData` class. This ends up removing all of the readings before or after that. When this is passed back to the application for storage we just end up storing that range of data.

There has been a check in the aggregation service for sometime that looks for the LGAP, FIXS and FIXE markers and then calls `set_start_date` and `set_end_date` again. This is based on the assumption that the application is storing data before and after those dates and so the dates have to be re-applied based on the markers.

That's not actually the case though. The application only stores the validated data returned by the analytics. Anything outside of the range that might have existed is removed.

So the `set_long_gap_boundary_on_all_meters` check is doing an unnecessary scan of all AMR data across all the meters for a school. It does find the LGAP/FIXS/FIXE markers but just ends up setting the same data. 

This PR removes that code as its redundant. I've added some comments about the application behaviour to the validation service where it sets the markers.