### PR TITLE
Add AnnualUsageBreakdownService.annual_out_of_hours_kwh

### DIFF
--- a/app/services/usage/annual_usage_breakdown_service.rb
+++ b/app/services/usage/annual_usage_breakdown_service.rb
@@ -11,6 +11,12 @@ module Usage
       @fuel_type = fuel_type
     end
 
+    def annual_out_of_hours_kwh
+      build_usage_category_usage_metrics!
+      calculate_kwh!
+      { out_of_hours: @out_of_hours.kwh, total_annual: total_annual_kwh }
+    end
+
     # Calculates a breakdown of the annual usage over the last twelve months
     # Broken down by usage during school day open, closed, weekends and holidays
     #
@@ -50,11 +56,11 @@ module Usage
       calculate_pounds_sterling!
       calculate_co2!
 
-      assign_and_return_usage_category_breakdown
+      build_usage_category_breakdown
     end
 
-    def assign_and_return_usage_category_breakdown
-      Usage::AnnualUsageCategoryBreakdown.new(
+    def build_usage_category_breakdown
+      @usage_category_breakdown ||= Usage::AnnualUsageCategoryBreakdown.new(
         holiday: @holiday,
         school_day_closed: @school_day_closed,
         school_day_open: @school_day_open,

--- a/spec/app/services/usage/annual_usage_breakdown_service_spec.rb
+++ b/spec/app/services/usage/annual_usage_breakdown_service_spec.rb
@@ -4,7 +4,6 @@ describe Usage::AnnualUsageBreakdownService, type: :service do
   Object.const_set('Rails', true) # Otherwise the test fails at line 118 (RecordTestTimes) in ChartManager
 
   let(:meter_collection)                     { @acme_academy }
-  let(:meter_collection_with_storage_heater) { @beta_academy }
 
   before(:all) do
     @acme_academy = load_unvalidated_meter_collection(school: 'acme-academy')
@@ -25,96 +24,139 @@ describe Usage::AnnualUsageBreakdownService, type: :service do
     end
   end
 
+  context '#annual_out_of_hours_kwh' do
+    let(:usage_breakdown_benchmark_service) { Usage::AnnualUsageBreakdownService.new(meter_collection: meter_collection, fuel_type: :electricity) }
+    let(:usage)                { usage_breakdown_benchmark_service.annual_out_of_hours_kwh }
+    it 'returns the expected data' do
+      expect(usage[:out_of_hours]).to round_to_two_digits(300164.17)
+      expect(usage[:total_annual]).to round_to_two_digits(467_398.40) # 467398.3999999999
+    end
+  end
+
   context '#usage_breakdown' do
-    it 'returns a usage category breakdown with calculated combined usage metrics for holiday, school open days etc for electricity' do
-      usage_breakdown_benchmark_service = Usage::AnnualUsageBreakdownService.new(meter_collection: meter_collection, fuel_type: :electricity)
-      day_type_breakdown = usage_breakdown_benchmark_service.usage_breakdown
+    let(:usage_breakdown_benchmark_service) { Usage::AnnualUsageBreakdownService.new(meter_collection: meter_collection, fuel_type: fuel_type) }
+    let(:day_type_breakdown) { usage_breakdown_benchmark_service.usage_breakdown }
 
-      expect(day_type_breakdown.holiday.kwh).to round_to_two_digits(71847.1) # 71847.09999999999
-      expect(day_type_breakdown.holiday.co2).to round_to_two_digits(12476.78) # 12476.783800000008
-      expect(day_type_breakdown.holiday.percent).to round_to_two_digits(0.15) # 0.15371704310498283
-      expect(day_type_breakdown.holiday.£).to round_to_two_digits(10813.95) # 10813.954999999998
+    context 'for electricity' do
+      let(:fuel_type) { :electricity }
 
-      expect(day_type_breakdown.school_day_closed.kwh).to round_to_two_digits(186221.67)
-      expect(day_type_breakdown.school_day_closed.co2).to round_to_two_digits(36732.62)
-      expect(day_type_breakdown.school_day_closed.percent).to round_to_two_digits(0.4)
-      expect(day_type_breakdown.school_day_closed.£).to round_to_two_digits(27935.39)
+      it 'returns the holiday usage analysis' do
+        expect(day_type_breakdown.holiday.kwh).to round_to_two_digits(71847.1) # 71847.09999999999
+        expect(day_type_breakdown.holiday.co2).to round_to_two_digits(12476.78) # 12476.783800000008
+        expect(day_type_breakdown.holiday.percent).to round_to_two_digits(0.15) # 0.15371704310498283
+        expect(day_type_breakdown.holiday.£).to round_to_two_digits(10813.95) # 10813.954999999998
+      end
 
-      expect(day_type_breakdown.school_day_open.kwh).to round_to_two_digits(167234.23)
-      expect(day_type_breakdown.school_day_open.co2).to round_to_two_digits(32259.76)
-      expect(day_type_breakdown.school_day_open.percent).to round_to_two_digits(0.36)
-      expect(day_type_breakdown.school_day_open.£).to round_to_two_digits(26005.19)
+      it 'returns the school day closed usage analysis' do
+        expect(day_type_breakdown.school_day_closed.kwh).to round_to_two_digits(186221.67)
+        expect(day_type_breakdown.school_day_closed.co2).to round_to_two_digits(36732.62)
+        expect(day_type_breakdown.school_day_closed.percent).to round_to_two_digits(0.4)
+        expect(day_type_breakdown.school_day_closed.£).to round_to_two_digits(27935.39)
+      end
 
-      expect(day_type_breakdown.out_of_hours.kwh).to round_to_two_digits(300164.17)
-      expect(day_type_breakdown.out_of_hours.co2).to round_to_two_digits(56232.88)
-      expect(day_type_breakdown.out_of_hours.percent).to round_to_two_digits(0.64)
-      expect(day_type_breakdown.out_of_hours.£).to round_to_two_digits(45055.23)
+      it 'returns the school day open usage analysis' do
+        expect(day_type_breakdown.school_day_open.kwh).to round_to_two_digits(167234.23)
+        expect(day_type_breakdown.school_day_open.co2).to round_to_two_digits(32259.76)
+        expect(day_type_breakdown.school_day_open.percent).to round_to_two_digits(0.36)
+        expect(day_type_breakdown.school_day_open.£).to round_to_two_digits(26005.19)
+      end
 
-      expect(day_type_breakdown.weekend.kwh).to round_to_two_digits(42095.40) # 42095.39999999999
-      expect(day_type_breakdown.weekend.co2).to round_to_two_digits(7023.47) # 7023.472399999997
-      expect(day_type_breakdown.weekend.percent).to round_to_two_digits(0.09) # 0.09006320945899686
-      expect(day_type_breakdown.weekend.£).to round_to_two_digits(6305.88) # 6305.880000000001
+      it 'returns the out of hours usage analysis' do
+        expect(day_type_breakdown.out_of_hours.kwh).to round_to_two_digits(300164.17)
+        expect(day_type_breakdown.out_of_hours.co2).to round_to_two_digits(56232.88)
+        expect(day_type_breakdown.out_of_hours.percent).to round_to_two_digits(0.64)
+        expect(day_type_breakdown.out_of_hours.£).to round_to_two_digits(45055.23)
+      end
 
-      expect(day_type_breakdown.community.kwh).to round_to_two_digits(0) # 0
-      expect(day_type_breakdown.community.co2).to round_to_two_digits(0) # 0
-      expect(day_type_breakdown.community.percent).to round_to_two_digits(0) # 0
-      expect(day_type_breakdown.community.£).to round_to_two_digits(0) # 0
+      it 'returns the weekend usage analysis' do
+        expect(day_type_breakdown.weekend.kwh).to round_to_two_digits(42095.40) # 42095.39999999999
+        expect(day_type_breakdown.weekend.co2).to round_to_two_digits(7023.47) # 7023.472399999997
+        expect(day_type_breakdown.weekend.percent).to round_to_two_digits(0.09) # 0.09006320945899686
+        expect(day_type_breakdown.weekend.£).to round_to_two_digits(6305.88) # 6305.880000000001
+      end
 
-      expect(day_type_breakdown.total.kwh).to round_to_two_digits(467_398.40) # 467398.3999999999
-      expect(day_type_breakdown.total.co2).to round_to_two_digits(88_492.64) # 88492.6392
+      it 'returns the community use analysis' do
+        expect(day_type_breakdown.community.kwh).to round_to_two_digits(0) # 0
+        expect(day_type_breakdown.community.co2).to round_to_two_digits(0) # 0
+        expect(day_type_breakdown.community.percent).to round_to_two_digits(0) # 0
+        expect(day_type_breakdown.community.£).to round_to_two_digits(0) # 0
+      end
 
-      exemplar_comparison = day_type_breakdown.potential_savings(versus: :exemplar_school)
-      expect(exemplar_comparison.co2).to eq(nil)
-      expect(exemplar_comparison.kwh).to round_to_two_digits(66464.97)
-      expect(exemplar_comparison.percent).to round_to_two_digits(0.14)
-      expect(exemplar_comparison.£).to round_to_two_digits(10104.93)
+      it 'returns the totals' do
+        expect(day_type_breakdown.total.kwh).to round_to_two_digits(467_398.40) # 467398.3999999999
+        expect(day_type_breakdown.total.co2).to round_to_two_digits(88_492.64) # 88492.6392
+      end
 
-      comparison = day_type_breakdown.potential_savings(versus: :benchmark_school)
-      expect(comparison.percent).to round_to_two_digits(0.04)
+      it 'includes a comparison' do
+        exemplar_comparison = day_type_breakdown.potential_savings(versus: :exemplar_school)
+        expect(exemplar_comparison.co2).to eq(nil)
+        expect(exemplar_comparison.kwh).to round_to_two_digits(66464.97)
+        expect(exemplar_comparison.percent).to round_to_two_digits(0.14)
+        expect(exemplar_comparison.£).to round_to_two_digits(10104.93)
+
+        comparison = day_type_breakdown.potential_savings(versus: :benchmark_school)
+        expect(comparison.percent).to round_to_two_digits(0.04)
+      end
     end
 
-    it 'returns a usage category breakdown with calculated combined usage metrics for holiday, school open days etc for storage heater' do
-      usage_breakdown_benchmark_service = Usage::AnnualUsageBreakdownService.new(meter_collection: meter_collection_with_storage_heater, fuel_type: :storage_heater)
-      day_type_breakdown = usage_breakdown_benchmark_service.usage_breakdown
+    context 'for storage heater' do
+      let(:fuel_type) { :storage_heater }
+      let(:meter_collection) { @beta_academy }
 
-      expect(day_type_breakdown.holiday.kwh).to round_to_two_digits(21359.91) # 21359.912500000002
-      expect(day_type_breakdown.holiday.co2).to round_to_two_digits(2940.11) # 12476.78
-      expect(day_type_breakdown.holiday.percent).to round_to_two_digits(0.16) # 0.15371704310498283
-      expect(day_type_breakdown.holiday.£).to round_to_two_digits(3203.99) # 3203.986874999999
+      it 'returns the holiday usage analysis' do
+        expect(day_type_breakdown.holiday.kwh).to round_to_two_digits(21359.91) # 21359.912500000002
+        expect(day_type_breakdown.holiday.co2).to round_to_two_digits(2940.11) # 12476.78
+        expect(day_type_breakdown.holiday.percent).to round_to_two_digits(0.16) # 0.15371704310498283
+        expect(day_type_breakdown.holiday.£).to round_to_two_digits(3203.99) # 3203.986874999999
+      end
 
-      expect(day_type_breakdown.school_day_closed.kwh).to round_to_two_digits(88657.96) # 88657.96250000004
-      expect(day_type_breakdown.school_day_closed.co2).to round_to_two_digits(14412.63) # 14412.626000000004
-      expect(day_type_breakdown.school_day_closed.percent).to round_to_two_digits(0.66) # 0.6604774659312422
-      expect(day_type_breakdown.school_day_closed.£).to round_to_two_digits(13298.69) # 13298.694374999997
+      it 'returns the school day closed usage analysis' do
+        expect(day_type_breakdown.school_day_closed.kwh).to round_to_two_digits(88657.96) # 88657.96250000004
+        expect(day_type_breakdown.school_day_closed.co2).to round_to_two_digits(14412.63) # 14412.626000000004
+        expect(day_type_breakdown.school_day_closed.percent).to round_to_two_digits(0.66) # 0.6604774659312422
+        expect(day_type_breakdown.school_day_closed.£).to round_to_two_digits(13298.69) # 13298.694374999997
+      end
 
-      expect(day_type_breakdown.school_day_open.kwh).to round_to_two_digits(0.00) # 0.00
-      expect(day_type_breakdown.school_day_open.co2).to round_to_two_digits(0.00) # 0.00
-      expect(day_type_breakdown.school_day_open.percent).to round_to_two_digits(0.00) # 0.00
-      expect(day_type_breakdown.school_day_open.£).to round_to_two_digits(0.00) # 0.00
+      it 'returns the school day open usage analysis' do
+        expect(day_type_breakdown.school_day_open.kwh).to round_to_two_digits(0.00) # 0.00
+        expect(day_type_breakdown.school_day_open.co2).to round_to_two_digits(0.00) # 0.00
+        expect(day_type_breakdown.school_day_open.percent).to round_to_two_digits(0.00) # 0.00
+        expect(day_type_breakdown.school_day_open.£).to round_to_two_digits(0.00) # 0.00
+      end
 
-      expect(day_type_breakdown.out_of_hours.kwh).to round_to_two_digits(134233.14) # 134233.13750000004
-      expect(day_type_breakdown.out_of_hours.co2).to round_to_two_digits(20762.91) # 20762.907862500004
-      expect(day_type_breakdown.out_of_hours.percent).to round_to_two_digits(1.0) # 1.0
-      expect(day_type_breakdown.out_of_hours.£).to round_to_two_digits(20134.97) # 20134.970624999994
+      it 'returns the out of hours usage analysis' do
+        expect(day_type_breakdown.out_of_hours.kwh).to round_to_two_digits(134233.14) # 134233.13750000004
+        expect(day_type_breakdown.out_of_hours.co2).to round_to_two_digits(20762.91) # 20762.907862500004
+        expect(day_type_breakdown.out_of_hours.percent).to round_to_two_digits(1.0) # 1.0
+        expect(day_type_breakdown.out_of_hours.£).to round_to_two_digits(20134.97) # 20134.970624999994
+      end
 
-      expect(day_type_breakdown.weekend.kwh).to round_to_two_digits(24215.26) # 24215.2625
-      expect(day_type_breakdown.weekend.co2).to round_to_two_digits(3410.18) # 3410.1756624999994
-      expect(day_type_breakdown.weekend.percent).to round_to_two_digits(0.18) # 0.18039705359639674
-      expect(day_type_breakdown.weekend.£).to round_to_two_digits(3632.29) # 3632.289374999999
+      it 'returns the weekend usage analysis' do
+        expect(day_type_breakdown.weekend.kwh).to round_to_two_digits(24215.26) # 24215.2625
+        expect(day_type_breakdown.weekend.co2).to round_to_two_digits(3410.18) # 3410.1756624999994
+        expect(day_type_breakdown.weekend.percent).to round_to_two_digits(0.18) # 0.18039705359639674
+        expect(day_type_breakdown.weekend.£).to round_to_two_digits(3632.29) # 3632.289374999999
+      end
 
-      expect(day_type_breakdown.community.kwh).to round_to_two_digits(0) # 0
-      expect(day_type_breakdown.community.co2).to round_to_two_digits(0) # 0
-      expect(day_type_breakdown.community.percent).to round_to_two_digits(0) # 0
-      expect(day_type_breakdown.community.£).to round_to_two_digits(0) # 0
+      it 'returns the community use analysis' do
+        expect(day_type_breakdown.community.kwh).to round_to_two_digits(0) # 0
+        expect(day_type_breakdown.community.co2).to round_to_two_digits(0) # 0
+        expect(day_type_breakdown.community.percent).to round_to_two_digits(0) # 0
+        expect(day_type_breakdown.community.£).to round_to_two_digits(0) # 0
+      end
 
-      expect(day_type_breakdown.total.kwh).to round_to_two_digits(134233.14) # 134233.13750000004
-      expect(day_type_breakdown.total.co2).to round_to_two_digits(20762.91) # 20762.907862500004
+      it 'returns the totals' do
+        expect(day_type_breakdown.total.kwh).to round_to_two_digits(134233.14) # 134233.13750000004
+        expect(day_type_breakdown.total.co2).to round_to_two_digits(20762.91) # 20762.907862500004
+      end
 
-      exemplar_comparison = day_type_breakdown.potential_savings(versus: :exemplar_school)
-      expect(exemplar_comparison.co2).to eq(nil)
-      expect(exemplar_comparison.kwh).to round_to_two_digits(107386.51) # 107386.51000000004
-      expect(exemplar_comparison.percent).to round_to_two_digits(0.8) # 0.8
-      expect(exemplar_comparison.£).to round_to_two_digits(16107.98) # 16107.976499999997
+      it 'includes a comparison' do
+        exemplar_comparison = day_type_breakdown.potential_savings(versus: :exemplar_school)
+        expect(exemplar_comparison.co2).to eq(nil)
+        expect(exemplar_comparison.kwh).to round_to_two_digits(107386.51) # 107386.51000000004
+        expect(exemplar_comparison.percent).to round_to_two_digits(0.8) # 0.8
+        expect(exemplar_comparison.£).to round_to_two_digits(16107.98) # 16107.976499999997
+      end
     end
   end
 end


### PR DESCRIPTION
The `AnnualUsageBreakdownService` is used to calculate the kwh, co2 and costs for different categories of the school week: out of hours, open, closed, community usage.

The service was built for the new advice pages and by default returns the calculations for all three variables across all time periods.

However we are currently using the service in the `OutOfHoursUsageBenchmarkGenerator` in the application to just extract the out of hours kwh and total kwh for the year. This means that we incur costs of calculating additional metrics that we don't need.

This PR adds a new method for just returning those kwh values. This avoids having to calculate the co2 and cost values, which involve doing a lot of unnecessary aggregation of the data (via the charting framework). 

This adds up to avoiding running 3 extra charts/calculations per fuel type for each school.
