### PR TITLE
Cache kwh date range

### DIFF
--- a/lib/dashboard/aggregation/amr_data.rb
+++ b/lib/dashboard/aggregation/amr_data.rb
@@ -140,26 +140,6 @@ class AMRData < HalfHourlyData
     end
   end
 
-  # performance benefit in collatin the information
-  private def calculate_information_date_range_deprecated(start_date, end_date)
-    kwh = kwh_date_range(start_date, end_date, :kwh)
-    £   = kwh_date_range(start_date, end_date, :£)
-    co2 = kwh_date_range(start_date, end_date, :co2)
-
-    {
-      kwh:                      kwh,
-      co2:                      co2,
-      £:                        £,
-      co2_intensity_kw_per_kwh: co2 / kwh,
-      blended_£_per_kwh:        £ / kwh
-    }
-  end
-
-  def information_date_range_deprecated(start_date, end_date)
-    @cached_information ||= {}
-    @cached_information[start_date..end_date] ||= calculate_information_date_range_deprecated(start_date, end_date)
-  end
-
   def blended_£_per_kwh_date_range(start_date, end_date)
     @blended_£_per_kwh_date_range ||= {}
     @blended_£_per_kwh_date_range[start_date..end_date] ||= calculate_blended_£_per_kwh_date_range(start_date, end_date)
@@ -572,17 +552,6 @@ class AMRData < HalfHourlyData
     date_divisor = (date2 - date1 + 1)
     return 0.0 if date_divisor.zero?
     baseload_kwh_date_range(date1, date2, sheffield_solar_pv) / date_divisor / 24.0
-  end
-
-  def baseload_£_economic_cost_date_range_deprecated(date1 = up_to_1_year_ago, date2 = end_date, sheffield_solar_pv: false)
-    total_£ = 0.0
-
-    (date1..date2).each do |date|
-      bl_kw = baseload_kw(date, sheffield_solar_pv)
-      total_£ += @economic_tariff.calculate_baseload_cost(date, bl_kw)
-    end
-
-    total_£
   end
 
   def economic_cost_for_x48_kwhs(date, kwh_x48)

--- a/spec/lib/dashboard/aggregation/amr_data_spec.rb
+++ b/spec/lib/dashboard/aggregation/amr_data_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe AMRData do
+
+  let(:start_date)    { Date.new(2023,1,1) }
+  let(:end_date)      { Date.new(2023,1,31) }
+  let(:kwh_data_x48)  { Array.new(48, 0.01) }
+
+  subject(:amr_data)    { build(:amr_data, :with_days, day_count: 31, end_date: end_date, kwh_data_x48: kwh_data_x48) }
+
+  describe '#check_type' do
+    %i[kwh £ economic_cost co2 £current current_economic_cost accounting_cost].each do |type|
+      it { amr_data.check_type(type) }
+    end
+    it { expect{amr_data.check_type(:unknown)}.to raise_error(AMRData::UnexpectedDataType) }
+  end
+
+  describe '#one_day_kwh' do
+    it 'returns expected total' do
+      expect(amr_data.one_day_kwh(start_date)).to be_within(0.0001).of(kwh_data_x48.sum)
+    end
+  end
+
+  describe '#kwh_date_range' do
+    it 'returns expected total' do
+      expect(amr_data.kwh_date_range(start_date, end_date)).to be_within(0.0001).of(kwh_data_x48.sum * 31)
+    end
+
+    context 'post aggregation' do
+      before do
+        amr_data.set_post_aggregation_state
+      end
+
+      it 'returns expected total' do
+        expect(amr_data.kwh_date_range(start_date, end_date)).to be_within(0.0001).of(kwh_data_x48.sum * 31)
+        #confirm we are not recalculating
+        expect(amr_data).to_not receive(:one_day_kwh)
+        expect(amr_data.kwh_date_range(start_date, end_date)).to be_within(0.0001).of(kwh_data_x48.sum * 31)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
During running of alerts and other calculations we make repeated calls to `kwh_date_range` often with the same dates and types.

This PR adds a cache of precalculated values to the AMRData class to remove the need for repeated calculations. This is primarily intended to reduce CPU overheads of recalculating values rather than increase speed.