### PR TITLE
Allow readings to be supplied by application

### DIFF
--- a/app/services/meter_collection_factory.rb
+++ b/app/services/meter_collection_factory.rb
@@ -78,7 +78,7 @@ class MeterCollectionFactory
     attributes.merge!(meter_attributes_overrides[mpxn]) if meter_attributes_overrides.key?(mpxn)
     amr_data = AMRData.new(meter_data[:type])
     meter_data[:readings].each do |reading|
-      add_reading(amr_data, reading)
+      add_reading(meter_data[:identifier], amr_data, reading)
     end
     Dashboard::Meter.new(
       meter_collection: meter_collection,
@@ -92,11 +92,11 @@ class MeterCollectionFactory
     )
   end
 
-  def add_reading(amr_data, reading)
+  def add_reading(meter_id, amr_data, reading)
     if reading.is_a?(OneDayAMRReading)
       amr_data.add(reading.date, reading)
     else
-      amr_data.add(reading[:reading_date], OneDayAMRReading.new(meter_data[:identifier], reading[:reading_date], reading[:type], reading[:substitute_date], reading[:upload_datetime], reading[:kwh_data_x48]))
+      amr_data.add(reading[:reading_date], OneDayAMRReading.new(meter_id, reading[:reading_date], reading[:type], reading[:substitute_date], reading[:upload_datetime], reading[:kwh_data_x48]))
     end
   end
 end

--- a/app/services/meter_collection_factory.rb
+++ b/app/services/meter_collection_factory.rb
@@ -78,7 +78,7 @@ class MeterCollectionFactory
     attributes.merge!(meter_attributes_overrides[mpxn]) if meter_attributes_overrides.key?(mpxn)
     amr_data = AMRData.new(meter_data[:type])
     meter_data[:readings].each do |reading|
-      amr_data.add(reading[:reading_date], OneDayAMRReading.new(meter_data[:identifier], reading[:reading_date], reading[:type], reading[:substitute_date], reading[:upload_datetime], reading[:kwh_data_x48]))
+      add_reading(amr_data, reading)
     end
     Dashboard::Meter.new(
       meter_collection: meter_collection,
@@ -90,5 +90,13 @@ class MeterCollectionFactory
       dcc_meter: meter_data[:dcc_meter],
       meter_attributes: attributes
     )
+  end
+
+  def add_reading(amr_data, reading)
+    if reading.is_a?(OneDayAMRReading)
+      amr_data.add(reading.date, reading)
+    else
+      amr_data.add(reading[:reading_date], OneDayAMRReading.new(meter_data[:identifier], reading[:reading_date], reading[:type], reading[:substitute_date], reading[:upload_datetime], reading[:kwh_data_x48]))
+    end
   end
 end


### PR DESCRIPTION
Allows the application to create the one day reading object, which will reduce memory overheads during creation of meter collections.

This change is backwards compatible, but idea is to make this the default behaviour eventually.