### PR TITLE
Add notify_aggregation_complete!

### DIFF
--- a/app/models/meter_collection.rb
+++ b/app/models/meter_collection.rb
@@ -482,4 +482,35 @@ class MeterCollection
   def is_school_usually_open?(_date, time_of_day)
     time_of_day >= @cached_open_time && time_of_day < @cached_close_time
   end
+
+  # Notify meter collection that aggregation process is over.
+  # Allows for any post aggregation clean-up to be carried out.
+  def notify_aggregation_complete!
+    clean_up_schedule_data!
+
+    # Set flags on each meter to indicate aggregation process has
+    # been completed.
+    #
+    # allows parameterised carbon/cost objects to cache data post
+    # aggregation, reducing memory footprint in front end cache prior to this
+    # while maintaining charting performance once out of cache
+    all_meters.each do |meter|
+      meter.amr_data.set_post_aggregation_state
+    end
+  end
+
+  #Clip the schedule data to the earliest date that we need for charting or
+  #subsequent analysis.
+  private def clean_up_schedule_data!
+    earliest_date = first_combined_meter_date
+    unless earliest_date.nil?
+      grid_carbon_intensity.set_start_date(earliest_date)
+      solar_pv.set_start_date(earliest_date)
+      solar_irradiation.set_start_date(earliest_date)
+
+      #we need a bit more temperature data for targets, so adjust date by one year
+      earliest_date = earliest_date - (365 + TargetMeterTemperatureCompensatedDailyDayTypeBase::TARGET_TEMPERATURE_DAYS_EITHER_SIDE)
+      temperatures.set_start_date(earliest_date)
+    end
+  end
 end

--- a/app/models/meter_collection.rb
+++ b/app/models/meter_collection.rb
@@ -503,14 +503,14 @@ class MeterCollection
   #subsequent analysis.
   private def clean_up_schedule_data!
     earliest_date = first_combined_meter_date
-    unless earliest_date.nil?
-      grid_carbon_intensity.set_start_date(earliest_date)
-      solar_pv.set_start_date(earliest_date)
-      solar_irradiation.set_start_date(earliest_date)
+    return if earliest_date.nil?
 
-      #we need a bit more temperature data for targets, so adjust date by one year
-      earliest_date = earliest_date - (365 + TargetMeterTemperatureCompensatedDailyDayTypeBase::TARGET_TEMPERATURE_DAYS_EITHER_SIDE)
-      temperatures.set_start_date(earliest_date)
-    end
+    grid_carbon_intensity.set_start_date(earliest_date)
+    solar_pv.set_start_date(earliest_date)
+    solar_irradiation.set_start_date(earliest_date)
+
+    #we need a bit more temperature data for targets, so adjust date by one year
+    earliest_date = earliest_date - (365 + TargetMeterTemperatureCompensatedDailyDayTypeBase::TARGET_TEMPERATURE_DAYS_EITHER_SIDE)
+    temperatures.set_start_date(earliest_date)
   end
 end

--- a/app/services/aggregation_service.rb
+++ b/app/services/aggregation_service.rb
@@ -80,9 +80,10 @@ class AggregateDataService
       #results for each aggregate meter
       process_community_usage_open_close_times
 
-      #set flags on amr data to indicate aggregation process
-      #has been completed
-      set_post_aggregation_state_on_all_meters
+      #notify meter collection that aggregation is complete
+      #carries out clean-up and sets flags on amr data to indicate aggregation process
+      #has been completed and caching can be enabled
+      @meter_collection.notify_aggregation_complete!
     end
     calc_text = "Calculated meter aggregation for |#{format('%-35.35s', @meter_collection.name)}| in |#{bm.round(3)}| seconds"
 
@@ -149,17 +150,6 @@ class AggregateDataService
     @meter_collection.solar_pv_panels? && @meter_collection.electricity_meters.length > 1
   end
 
-  # Set flags on each meter to indicate aggregation process has
-  # been completed.
-  #
-  # allows parameterised carbon/cost objects to cache data post
-  # aggregation, reducing memory footprint in front end cache prior to this
-  # while maintaining charting performance once out of cache
-  def set_post_aggregation_state_on_all_meters
-    @meter_collection.all_meters.each do |meter|
-      meter.amr_data.set_post_aggregation_state
-    end
-  end
 
   #Run the validation process on a list of meters.
   #

--- a/spec/app/models/meter_collection_spec.rb
+++ b/spec/app/models/meter_collection_spec.rb
@@ -9,4 +9,39 @@ describe MeterCollection do
       expect(meter_collection.inspect).to include(meter_collection.school.name)
     end
   end
+
+  describe '#notify_aggregation_complete!' do
+    let(:meter_collection)    { build(:meter_collection, :with_electricity_and_gas_meters) }
+
+    it 'notifies all data associated with all the meters' do
+      meter_collection.all_meters.each do |m|
+        expect(m.amr_data).to receive(:set_post_aggregation_state)
+      end
+      meter_collection.notify_aggregation_complete!
+    end
+
+    context 'when there is schedule data to clean up' do
+      let(:first_combined_meter_date)     { Date.today - 3 }
+      before do
+        allow(meter_collection).to receive(:first_combined_meter_date).and_return(first_combined_meter_date)
+        meter_collection.notify_aggregation_complete!
+      end
+
+      it 'cleans up the data as expected' do
+        expect(meter_collection.solar_irradiation.start_date).to eq first_combined_meter_date
+        expect(meter_collection.solar_pv.start_date).to eq first_combined_meter_date
+
+        #for some reason this class overrides start/end date to throw an exception
+        #so check for changes another way...
+        expect(meter_collection.grid_carbon_intensity.key?(first_combined_meter_date)).to eq true
+        expect(meter_collection.grid_carbon_intensity.key?(first_combined_meter_date - 1)).to eq false
+      end
+
+      it 'has a special case for temperatures' do
+        expect(meter_collection.temperatures.start_date).to eq (first_combined_meter_date - 369)
+      end
+    end
+
+  end
+
 end

--- a/spec/factories/amr_data_factory.rb
+++ b/spec/factories/amr_data_factory.rb
@@ -12,6 +12,26 @@ FactoryBot.define do
       end
     end
 
+    trait :with_date_range do
+      transient do
+        start_date   { Date.yesterday - 7 }
+        end_date     { Date.yesterday }
+        kwh_data_x48 { Array.new(48) { rand(0.0..1.0).round(2) } }
+      end
+
+      after(:build) do |amr_data, evaluator|
+        (evaluator.start_date..evaluator.end_date).each do |date|
+          reading = build(:one_day_amr_reading,
+                      date: date,
+                      type: 'ORIG',
+                      substitute_date: nil,
+                      upload_datetime: DateTime.now,
+                      kwh_data_x48: evaluator.kwh_data_x48)
+          amr_data.add(date, reading)
+        end
+      end
+    end
+
     trait :with_days do
       transient do
         day_count { 7 }

--- a/spec/factories/grid_carbon_intensity_factory.rb
+++ b/spec/factories/grid_carbon_intensity_factory.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :grid_carbon_intensity, class: "GridCarbonIntensity" do
+    initialize_with{ new() }
+
+    trait :with_days do
+      transient do
+        start_date { Date.yesterday - 7}
+        end_date { Date.yesterday }
+        kwh_data_x48 { Array.new(48) { rand(0.2..0.3).round(3) } }
+      end
+
+      after(:build) do |gci, evaluator|
+        (evaluator.start_date..evaluator.end_date).each do |date|
+          gci.add(date, evaluator.kwh_data_x48)
+        end
+      end
+    end
+
+  end
+end

--- a/spec/factories/meter_collection_factory.rb
+++ b/spec/factories/meter_collection_factory.rb
@@ -3,9 +3,9 @@ FactoryBot.define do
     transient do
       school                  { build(:school) }
       holidays                { build(:holidays, :with_academic_year) }
-      temperatures            { Temperatures.new('temperatures') }
-      solar_pv                { SolarPV.new('solar pv') }
-      grid_carbon_intensity   { GridCarbonIntensity.new }
+      temperatures            { build(:temperatures) }
+      solar_pv                { build(:solar_pv) }
+      grid_carbon_intensity   { build(:grid_carbon_intensity) }
       pseudo_meter_attributes { {} }
       solar_irradiation       { nil }
     end
@@ -15,5 +15,32 @@ FactoryBot.define do
       solar_irradiation: solar_irradiation, solar_pv: solar_pv,
       grid_carbon_intensity: grid_carbon_intensity,
       pseudo_meter_attributes: pseudo_meter_attributes) }
+
+    trait :with_electricity_meter do
+      transient do
+        amr_data          { build(:amr_data, :with_date_range) }
+      end
+
+      after(:build) do |meter_collection, evaluator|
+        meter = build(:meter, meter_collection: meter_collection, type: :electricity, amr_data: evaluator.amr_data)
+        meter_collection.add_electricity_meter(meter)
+      end
+    end
+
+    trait :with_gas_meter do
+      transient do
+        amr_data          { build(:amr_data, :with_date_range) }
+      end
+
+      after(:build) do |meter_collection, evaluator|
+        meter = build(:meter, meter_collection: meter_collection, type: :gas, amr_data: evaluator.amr_data)
+        meter_collection.add_heat_meter(meter)
+      end
+    end
+
+    trait :with_electricity_and_gas_meters do
+      with_electricity_meter
+      with_gas_meter
+    end
   end
 end

--- a/spec/factories/meter_collection_factory.rb
+++ b/spec/factories/meter_collection_factory.rb
@@ -1,11 +1,13 @@
 FactoryBot.define do
   factory :meter_collection, class: MeterCollection do
     transient do
+      start_date              { Date.yesterday - 7 }
+      end_date                { Date.yesterday }
       school                  { build(:school) }
       holidays                { build(:holidays, :with_academic_year) }
-      temperatures            { build(:temperatures) }
-      solar_pv                { build(:solar_pv) }
-      grid_carbon_intensity   { build(:grid_carbon_intensity) }
+      temperatures            { build(:temperatures, :with_days, start_date: start_date, end_date: end_date) }
+      solar_pv                { build(:solar_pv, :with_days, start_date: start_date, end_date: end_date) }
+      grid_carbon_intensity   { build(:grid_carbon_intensity, :with_days, start_date: start_date, end_date: end_date) }
       pseudo_meter_attributes { {} }
       solar_irradiation       { nil }
     end
@@ -17,23 +19,17 @@ FactoryBot.define do
       pseudo_meter_attributes: pseudo_meter_attributes) }
 
     trait :with_electricity_meter do
-      transient do
-        amr_data          { build(:amr_data, :with_date_range) }
-      end
-
       after(:build) do |meter_collection, evaluator|
-        meter = build(:meter, meter_collection: meter_collection, type: :electricity, amr_data: evaluator.amr_data)
+        amr_data = build(:amr_data, :with_date_range, start_date: evaluator.start_date, end_date: evaluator.end_date)
+        meter = build(:meter, meter_collection: meter_collection, type: :electricity, amr_data: amr_data)
         meter_collection.add_electricity_meter(meter)
       end
     end
 
     trait :with_gas_meter do
-      transient do
-        amr_data          { build(:amr_data, :with_date_range) }
-      end
-
       after(:build) do |meter_collection, evaluator|
-        meter = build(:meter, meter_collection: meter_collection, type: :gas, amr_data: evaluator.amr_data)
+        amr_data = build(:amr_data, :with_date_range, start_date: evaluator.start_date, end_date: evaluator.end_date)
+        meter = build(:meter, meter_collection: meter_collection, type: :gas, amr_data: amr_data)
         meter_collection.add_heat_meter(meter)
       end
     end

--- a/spec/factories/temperatures_factory.rb
+++ b/spec/factories/temperatures_factory.rb
@@ -1,0 +1,24 @@
+FactoryBot.define do
+  factory :temperatures, class: "Temperatures" do
+    transient do
+      type  { 'temperatures'}
+    end
+
+    initialize_with{ new(type) }
+
+    trait :with_days do
+      transient do
+        start_date { Date.yesterday - 7}
+        end_date { Date.yesterday }
+        kwh_data_x48 { Array.new(48) { rand(0.0..1.0).round(2) } }
+      end
+
+      after(:build) do |temperatures, evaluator|
+        (evaluator.start_date..evaluator.end_date).each do |date|
+          temperatures.add(date, evaluator.kwh_data_x48)
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
This PR implements an alternative approach to the "date bound schedule data" feature which was implemented in the application but never fully released.

We have increasingly long archives of temperature and solar data for some locations, and grid carbon intensity for the whole UK. This schedule data is passed to every meter collection along with the meter data.

However, in general, we don't need all this data. For some target meter and estimated annual usage calculations we need just over a year of temperature data before the earliest meter date. Otherwise we need nothing earlier than that date. For most schools this will only be a couple of years worth of data.

One approach to limiting the amount of data used is to only build the meter collection with a limited dataset. We've tried this on the application and confirmed that the meter collection sizes in the cache are much smaller, so this is worth doing. However with recent changes to the regeneration process we need to revisit and change that code

Another approach is to delegate to the meter collection to prune back any data it doesn't need, following completion of the aggregation process. This works regardless of whether we're starting from validated or unvalidated meter data.

This PR implements this second approach. It is slightly simpler in overall implementation and already builds on a post-aggregation process of settings flags across the meter data to enable caching, etc. 

It also gives us a foundation for potentially doing other clean-up or optimisations if required.