### PR TITLE
Fix earliest date calculation

### DIFF
--- a/app/models/meter_collection.rb
+++ b/app/models/meter_collection.rb
@@ -163,6 +163,10 @@ class MeterCollection
     @calculated_floor_area_pupil_numbers ||= FloorAreaPupilNumbers.new(@floor_area, @number_of_pupils, pseudo_meter_attributes(:school_level_data))
   end
 
+  def earliest_meter_date
+    all_meters.map{|meter| meter.amr_data.start_date }.min
+  end
+
   def first_combined_meter_date
     all_aggregate_meters.map{ |meter| meter.amr_data.start_date }.max
   end
@@ -502,7 +506,7 @@ class MeterCollection
   #Clip the schedule data to the earliest date that we need for charting or
   #subsequent analysis.
   private def clean_up_schedule_data!
-    earliest_date = first_combined_meter_date
+    earliest_date = earliest_meter_date
     return if earliest_date.nil?
 
     grid_carbon_intensity.set_start_date(earliest_date)

--- a/lib/dashboard/utilities/half_hourly_data.rb
+++ b/lib/dashboard/utilities/half_hourly_data.rb
@@ -160,12 +160,14 @@ class HalfHourlyData < Hash
   end
 
   def set_start_date(date)
+    return if date < @min_date
     logger.info "setting start date to #{date} truncating prior data"
     @min_date = date
     self.delete_if{ |d, _value| d < date }
   end
 
   def set_end_date(date)
+    return if date > @max_date
     logger.info "setting end date to #{date} truncating post data"
     @max_date = date
     self.delete_if{ |d, _value| d > date }
@@ -205,7 +207,7 @@ class HalfHourlyData < Hash
   private
 
   def reset_min_max_date
-    # This method needs to remain private as it should only ever be called by 
+    # This method needs to remain private as it should only ever be called by
     # the `remove_dates!` method
     @min_date,@max_date = keys.minmax
   end

--- a/spec/lib/dashboard/half_hourly_data_spec.rb
+++ b/spec/lib/dashboard/half_hourly_data_spec.rb
@@ -10,4 +10,5 @@ describe HalfHourlyData do
      expect(data.inspect).to include("days: 0")
     end
   end
+
 end


### PR DESCRIPTION
Testing the recent changes to limit the schedule data I realised there was a bug in the date calculation.

I was using the `first_combined_meter_date` which doesn't actually calculate the earliest meter date range for all meters. It calculates the most recent start date for aggregated meters only.

I've added an `earliest_start_date` method which will return the earliest start date for any meter in the collection. This will ensure that the schedule data covers all of the amr data time series we have, plus at least a year or so extra for temperature data. We only need this when doing meter specific calculations and probably only then for gas meters, so opportunity to optimise further.

I've also tweaked the `set_start_date` and `set_end_date` methods in the HalfHourly data class. It will now ignore the set if the date is before the earliest date, or after the latest. This avoids scenario where we might set that date and end up with "gaps" in the data where the object believes its start date is before what is actually held in the internal hash.

Whilst this is a basic change in behaviour, I've reviewed where this method is called and don't think it will impact anything. We're only using it during validation (where we're always truncating data) and during limiting the schedule data.