### PR TITLE
Allow an extra year of solar data

### DIFF
--- a/app/models/meter_collection.rb
+++ b/app/models/meter_collection.rb
@@ -510,11 +510,12 @@ class MeterCollection
     return if earliest_date.nil?
 
     grid_carbon_intensity.set_start_date(earliest_date)
+
+    #we need a bit more temperature and solar data for calculating targets and annual estimates,
+    #so adjust date by one year for solar and
+    earliest_date = earliest_date - (365 + TargetMeterTemperatureCompensatedDailyDayTypeBase::TARGET_TEMPERATURE_DAYS_EITHER_SIDE)
     solar_pv.set_start_date(earliest_date)
     solar_irradiation.set_start_date(earliest_date)
-
-    #we need a bit more temperature data for targets, so adjust date by one year
-    earliest_date = earliest_date - (365 + TargetMeterTemperatureCompensatedDailyDayTypeBase::TARGET_TEMPERATURE_DAYS_EITHER_SIDE)
     temperatures.set_start_date(earliest_date)
   end
 end

--- a/spec/app/models/meter_collection_spec.rb
+++ b/spec/app/models/meter_collection_spec.rb
@@ -28,24 +28,25 @@ describe MeterCollection do
       end
 
       it 'cleans up the data as expected' do
-        expect(meter_collection.solar_irradiation.start_date).to eq earliest_meter_date
-        expect(meter_collection.solar_pv.start_date).to eq earliest_meter_date
-
         #for some reason this class overrides start/end date to throw an exception
         #so check for changes another way...
         expect(meter_collection.grid_carbon_intensity.key?(earliest_meter_date)).to eq true
         expect(meter_collection.grid_carbon_intensity.key?(earliest_meter_date - 1)).to eq false
       end
 
-      context 'for the temperature data' do
+      context 'for the temperature and solar irradiation data' do
         let(:start_date) { Date.today - 3 }
         let(:end_date)   { Date.today }
 
+        let(:solar_pv)            { build(:solar_pv, :with_days, start_date: start_date, end_date: end_date) }
         let(:temperatures)        { build(:temperatures, :with_days, start_date: start_date, end_date: end_date) }
-        let(:meter_collection)    { build(:meter_collection, :with_electricity_and_gas_meters, temperatures: temperatures) }
+
+        let(:meter_collection)    { build(:meter_collection, :with_electricity_and_gas_meters, temperatures: temperatures, solar_pv: solar_pv) }
 
         it 'sets to earliest date' do
           expect(meter_collection.temperatures.start_date).to eq earliest_meter_date
+          expect(meter_collection.solar_irradiation.start_date).to eq earliest_meter_date
+          expect(meter_collection.solar_pv.start_date).to eq earliest_meter_date
         end
 
         context 'when there is earlier data' do
@@ -53,6 +54,8 @@ describe MeterCollection do
 
           it 'sets to about a year earlier' do
             expect(meter_collection.temperatures.start_date).to eq (earliest_meter_date - 369)
+            expect(meter_collection.solar_irradiation.start_date).to eq  (earliest_meter_date - 369)
+            expect(meter_collection.solar_pv.start_date).to eq  (earliest_meter_date - 369)
           end
         end
       end


### PR DESCRIPTION
When removing unneeded schedule data we need to also leave a year of solar data, not just temperature data. This is used to calculate annual estimates for schools that need it.