### PR TITLE
Fix up constructors in meter collection subclasses

### DIFF
--- a/lib/dashboard/charting_and_reports/virtual_schools/benchmark_school.rb
+++ b/lib/dashboard/charting_and_reports/virtual_schools/benchmark_school.rb
@@ -1,11 +1,14 @@
 require_relative './synthetic_school.rb'
 
 class BenchmarkSchool < SyntheticSchool
-  def initialize(school, benchmark_type: :benchmark)
+  def initialize(meter_collection, benchmark_type: :benchmark)
     puts "Creating school"
-    super(school)
+    super(meter_collection)
     @benchmark_type = benchmark_type
-    @name = benchmark_type.to_s
+  end
+
+  def name
+    @benchmark_type.to_s
   end
 
   def aggregated_electricity_meters

--- a/lib/dashboard/charting_and_reports/virtual_schools/synthetic_school.rb
+++ b/lib/dashboard/charting_and_reports/virtual_schools/synthetic_school.rb
@@ -1,13 +1,13 @@
 class SyntheticSchool < MeterCollection
-  def initialize(school)
-    super(school.school,
-          holidays:                 school.holidays,
-          temperatures:             school.temperatures,
-          solar_irradiation:        school.solar_irradiation,
-          solar_pv:                 school.solar_pv,
-          grid_carbon_intensity:    school.grid_carbon_intensity,
-          pseudo_meter_attributes:  school.pseudo_meter_attributes_private)
+  def initialize(meter_collection)
+    super(meter_collection.school,
+          holidays:                 meter_collection.holidays,
+          temperatures:             meter_collection.temperatures,
+          solar_irradiation:        meter_collection.solar_irradiation,
+          solar_pv:                 meter_collection.solar_pv,
+          grid_carbon_intensity:    meter_collection.grid_carbon_intensity,
+          pseudo_meter_attributes:  meter_collection.pseudo_meter_attributes_private)
 
-    @original_school = school
+    @original_school = meter_collection
   end
 end

--- a/lib/dashboard/modelling/targeting and tracking/target_meter.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_meter.rb
@@ -111,6 +111,9 @@ class TargetMeter < Dashboard::Meter
     @feedback
   end
 
+  #TODO: we only appear to ever use :day?
+  #Calculation type is provided as a parameter to meter_collection.target_school
+  #Defaults to :day but can be configured via charts. But charts only use :day
   def self.calculation_factory(type, meter_to_clone)
     case type
     when :month

--- a/spec/factories/school_factory.rb
+++ b/spec/factories/school_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :school, class: "Dashboard::School" do
     transient do
+      sequence(:id)   { |n| n }
       sequence(:name) { |n| "test #{n} school" }
       address         { '1 Station Road' }
       floor_area      { BigDecimal("1234.567") }
@@ -9,6 +10,8 @@ FactoryBot.define do
       area_name       { 'Bath' }
       sequence(:urn)
       postcode        { 'ab1 2cd' }
+      country         { :england }
+      funding_status  { :state }
       activation_date { Date.today }
       created_at      { Date.today }
       latitude        { 51.509865 }
@@ -16,10 +19,11 @@ FactoryBot.define do
       data_enabled    { true }
     end
 
-    initialize_with{ new(name: name, address: address, floor_area:
+    initialize_with{ new(id: id, name: name, address: address, floor_area:
       floor_area, number_of_pupils: number_of_pupils,
       school_type: school_type, area_name: area_name,
-      urn: urn, postcode: postcode, activation_date: activation_date,
-      created_at: created_at, location: [latitude, longitude], data_enabled: data_enabled) }
+      urn: urn, postcode: postcode, country: country, funding_status: funding_status,
+      activation_date: activation_date, created_at: created_at, location: [latitude, longitude],
+      data_enabled: data_enabled) }
   end
 end

--- a/spec/lib/dashboard/modelling/targeting_and_tracking/target_meter_spec.rb
+++ b/spec/lib/dashboard/modelling/targeting_and_tracking/target_meter_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe TargetMeter do
+
+  let(:pseudo_meter_attributes) do
+    {
+      :aggregated_electricity => {
+        :targeting_and_tracking => [{
+          :start_date => Date.yesterday,
+          :target => 0.95
+        }]
+      }
+    }
+  end
+
+  let(:meter_collection)    { build(:meter_collection, :with_electricity_meter, start_date: Date.today - 400, end_date: Date.yesterday, pseudo_meter_attributes: pseudo_meter_attributes)}
+  let(:meter)               { meter_collection.aggregated_electricity_meters }
+  let(:calculation_type)    { :day }
+
+  before do
+    AggregateDataService.new(meter_collection).aggregate_heat_and_electricity_meters
+  end
+
+  context '.calculation_factory' do
+    let(:target_meter)  { TargetMeter.calculation_factory(calculation_type, meter) }
+
+    context 'for :day' do
+      it 'returns a meter' do
+        expect(target_meter).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/dashboard/modelling/targeting_and_tracking/target_school_spec.rb
+++ b/spec/lib/dashboard/modelling/targeting_and_tracking/target_school_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe TargetSchool do
+
+  let(:pseudo_meter_attributes) { {} }
+
+  let(:meter_collection)    { build(:meter_collection, :with_electricity_meter, pseudo_meter_attributes: pseudo_meter_attributes) }
+
+  let(:calculation_type)    { :day }
+  let(:target_school)       { TargetSchool.new(meter_collection, calculation_type) }
+
+  describe '#name' do
+    it 'overrides name method' do
+      expect(target_school.name).to eq "#{meter_collection.name} : target"
+    end
+  end
+
+  describe '#aggregated_electricity_meters' do
+    let(:meter_collection)    { build(:meter_collection, :with_electricity_meter, start_date: Date.today - 400, end_date: Date.yesterday, pseudo_meter_attributes: pseudo_meter_attributes)}
+
+    before do
+      AggregateDataService.new(meter_collection).aggregate_heat_and_electricity_meters
+    end
+
+    context 'with no target set' do
+      it 'returns a nil aggregate meter' do
+        expect(target_school.aggregated_electricity_meters).to be_nil
+        expect(target_school.reason_for_nil_meter(:electricity)[:text]).to match(TargetSchool::NO_TARGET_SET)
+      end
+    end
+
+    context 'with target set for electricity' do
+      let(:pseudo_meter_attributes) do
+        {
+          :aggregated_electricity => {
+            :targeting_and_tracking => [{
+              :start_date => Date.yesterday,
+              :target => 0.95
+            }]
+          }
+        }
+      end
+
+      it 'calculates a target meter' do
+        expect(target_school.aggregated_electricity_meters).not_to be_nil
+        expect(target_school.reason_for_nil_meter(:electricity)).to be_nil
+      end
+
+      it 'returns nil meter for gas' do
+        expect(target_school.aggregated_heat_meters).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Refactoring and tidying the MeterCollection class I broke the constructor of the TargetSchool class.

This PR fixes this by updating the subclasses to override the `name` method of the MeterCollection class, rather than access a `@name` instance variable.

As this failed because of a gap in the test suite I've added a couple of basic tests around the targets feature which just confirms that we can successfully create a TargetSchool and a TargetMeter. This exercises the basic code but doesn't cover all the functionality.