### PR TITLE
Make meter attribute filtering optional

### DIFF
--- a/app/models/meter_attributes.rb
+++ b/app/models/meter_attributes.rb
@@ -641,10 +641,10 @@ class MeterAttributes
     structure MeterAttributes.generic_accounting_tariff
   end
 
-  def self.all
+  def self.all(filter: false)
     constants.inject({}) do |collection, constant_name|
       constant = const_get(constant_name)
-      collection[constant.attribute_id] = constant unless constant.internal?
+      collection[constant.attribute_id] = constant unless (filter && constant.internal?)
       collection
     end
   end

--- a/spec/meter_attributes_spec.rb
+++ b/spec/meter_attributes_spec.rb
@@ -8,11 +8,20 @@ describe MeterAttributes do
     it 'builds a list of attributes' do
       expect(MeterAttributes.all).not_to be_empty
     end
-    it 'filters analytics internal attributes that shouldnt be set by admins' do
-      expect(all_attributes.key?(:accounting_tariff_generic)).to be false
-      expect(all_attributes.key?(:open_close_times)).to be false
-      expect(all_attributes.key?(:targeting_and_tracking)).to be false
-      expect(all_attributes.key?(:estimated_period_consumption)).to be false
+    it 'returns all items by default' do
+      expect(all_attributes.key?(:accounting_tariff_generic)).to be true
+      expect(all_attributes.key?(:open_close_times)).to be true
+      expect(all_attributes.key?(:targeting_and_tracking)).to be true
+      expect(all_attributes.key?(:estimated_period_consumption)).to be true
+    end
+    context 'when filtering' do
+      let(:all_attributes) { MeterAttributes.all(filter: true) }
+      it 'filters analytics internal attributes that shouldnt be set by admins' do
+        expect(all_attributes.key?(:accounting_tariff_generic)).to be false
+        expect(all_attributes.key?(:open_close_times)).to be false
+        expect(all_attributes.key?(:targeting_and_tracking)).to be false
+        expect(all_attributes.key?(:estimated_period_consumption)).to be false
+      end
     end
   end
 


### PR DESCRIPTION
Add a flag to the `.all` method to optionally allow meter attributes to be filtered. Fixes issue with code mapping to the analytics cannot find the right definition.