### PR TITLE
Ensure usage is properly allocated across all half-hourly splits

### DIFF
--- a/lib/dashboard/aggregation/community_use_breakdown.rb
+++ b/lib/dashboard/aggregation/community_use_breakdown.rb
@@ -211,8 +211,8 @@ class CommunityUseBreakdown
   #
   # - School is open for only part of the period, e.g. open until 16:15
   # - School is open for half of the period, and community use for rest
-  # - Within the period the school closes at 16:20, and community use starts at
-  #   16:45
+  # - Within the period the school closes at 16:15, and community use starts at
+  #   16:20
   #
   # refer to charts in \Energy Sparks\Energy Sparks Project Team Documents\Analytics\Community use etc\
   def split_half_hour_kwhs(date, hhi, weights, baseload_kwh, kwh)

--- a/lib/dashboard/aggregation/community_use_breakdown.rb
+++ b/lib/dashboard/aggregation/community_use_breakdown.rb
@@ -145,7 +145,7 @@ class CommunityUseBreakdown
           set_hhi_value(kwh_breakdown, OpenCloseTime::COMMUNITY, hhi, (kwh - baseload_kwh))
         end
       else # slower more complex split half hour periods
-        open_kwh, community_kwh, community_baseload_kwh, closed_kwh = split_half_hour_kwhs(hhi_weights, baseload_kwh, kwh)
+        open_kwh, community_kwh, community_baseload_kwh, closed_kwh = split_half_hour_kwhs(date, hhi, hhi_weights, baseload_kwh, kwh)
 
         set_hhi_value(kwh_breakdown, OpenCloseTime::SCHOOL_OPEN,        hhi, open_kwh              ) unless open_kwh.zero?
         set_hhi_value(kwh_breakdown, OpenCloseTime::COMMUNITY_BASELOAD, hhi, community_baseload_kwh) unless community_baseload_kwh.zero?
@@ -201,37 +201,65 @@ class CommunityUseBreakdown
     end
   end
 
+  # This method is called for any half-hourly period which:
+  #
+  # - isn't a period when school is completely closed
+  # - isn't a period when school is open, with no other usage
+  # - isn't a period when school is open for community use, with no other usage
+  #
+  # So we're dealing some some mix of open/close/community use times, e.g.
+  #
+  # - School is open for only part of the period, e.g. open until 16:15
+  # - School is open for half of the period, and community use for rest
+  # - Within the period the school closes at 16:20, and community use starts at
+  #   16:45
+  #
   # refer to charts in \Energy Sparks\Energy Sparks Project Team Documents\Analytics\Community use etc\
-  def split_half_hour_kwhs(weights, baseload_kwh, kwh)
+  def split_half_hour_kwhs(date, hhi, weights, baseload_kwh, kwh)
     open_t, community_t, _closed_t = bucket_time_weights(weights)
 
     community_kwh = 0.0
     community_baseload_kwh = 0.0
 
-    #if we have any community use time
+    #do we have any community use time?
+    #otherwise its just an allocation of open/close times within half hour
     if community_t > 0.0
-       if baseload_kwh >= kwh
-         #assign all usage to community baseload if below the baseload
-         community_baseload_kwh = kwh
+       #this is a HH period where school is both open and has community use
+       if open_t > 0.0
+         if baseload_kwh > kwh
+           #allocate a portion of the usage to community baseload, not enough
+           #usage to allocate to :community
+           community_baseload_kwh  = kwh * community_t
+         else
+           #allocate a portion of the expected baseload to community baseload
+           community_baseload_kwh  = baseload_kwh * community_t
+         end
+        #this is a HH period where we have community use and rest of period is
+        #"closed"
        else
-         #otherwise allocate a portion of the baseload to community use
-         community_baseload_kwh  = baseload_kwh * community_t
-         #allocate portion of usage above baseload to community use
-         community_kwh = (kwh - baseload_kwh) * community_t
+         if baseload_kwh > kwh
+           #as school is not open in this period, assign all the usage to community
+           #baseload, as not enough usage for :community
+           community_baseload_kwh = kwh
+         else
+           #otherwise allocate a portion of the expected baseload to community use
+           community_baseload_kwh  = baseload_kwh * community_t
+           #also allocate a portion of usage above the baseload to community use
+           community_kwh = (kwh - baseload_kwh) * community_t
+         end
        end
     end
 
     #allocate portion of usage to opening times
     open_kwh                = kwh * open_t
 
-    #allocate remainder as "closed"
+    #allocate remainder as "closed", which might end up being mapped to
+    #school_day_closed or holiday in the calling method
     closed_kwh              = kwh - open_kwh - community_kwh - community_baseload_kwh
     closed_kwh              = 0.0 if closed_kwh.magnitude < 0.00000001 # remove floating point noise
 
-    # TODO(PH, 4Apr2022) there seems to be a problem with some Orsis solar schools providing small -tbe mains consumption
-    #                    hence kwh > 0.0 additjon below, needs further investigation of root cause
-    # LD, 2023 not sure this is happening, no signs of exception in the Rollbar reports
-    raise NegativeClosedkWhCalculation, "Negative closed allocation #{closed_kwh} Before #{kwh} => Open #{open_kwh} + Closed #{closed_kwh} + Comms baseload #{community_baseload_kwh} + Comms #{community_kwh} (Comms time #{community_t})" if closed_kwh < 0.0 && kwh > 0.0
+    # This is a sanity check to confirm that we dont end up over allocating usage across the periods
+    raise NegativeClosedkWhCalculation, "Negative closed allocation on #{date}[#{hhi}]. #{closed_kwh} Usage: #{kwh}. Open: #{open_kwh}, Closed: #{closed_kwh}, Community baseload #{community_baseload_kwh}, Commmunity use #{community_kwh} (Community time #{community_t})" if closed_kwh < 0.0 && kwh > 0.0
 
     [open_kwh, community_kwh, community_baseload_kwh, closed_kwh]
   end

--- a/spec/lib/dashboard/aggregation/community_use_breakdown_spec.rb
+++ b/spec/lib/dashboard/aggregation/community_use_breakdown_spec.rb
@@ -35,7 +35,7 @@ describe CommunityUseBreakdown do
           expect(days_kwh_x48.values.all?{ |v| v.size == 48 })
         end
 
-        it 'returns same total as the amr_data class' do
+        it 'should return the same total as the amr_data class' do
           expect(days_kwh_x48.values.flatten.sum).to be_within(0.0001).of( meter.amr_data.days_kwh_x48(day).sum )
         end
       end
@@ -52,7 +52,7 @@ describe CommunityUseBreakdown do
           expect(days_kwh_x48.keys).to match_array([:school_day_closed, :school_day_open, :community, :community_baseload])
         end
 
-        it 'returns same total as the amr_data class' do
+        it 'should return the same total as the amr_data class' do
           expect(days_kwh_x48.values.flatten.sum).to be_within(0.0001).of( meter.amr_data.days_kwh_x48(day).sum )
         end
 
@@ -180,25 +180,25 @@ describe CommunityUseBreakdown do
 
         context 'with :community_only filter' do
           let(:filter)    { :community_only }
-          it 'returns a breakdown of just the community use' do
+          it 'should return a breakdown of just the community use' do
             expect(days_kwh_x48.keys).to match_array([:community, :community_baseload])
           end
         end
 
         context 'with :school_only filter' do
           let(:filter)    { :school_only }
-          it 'returns a breakdown of just the school day' do
+          it 'should return a breakdown of just the school day' do
             expect(days_kwh_x48.keys).to match_array([:school_day_closed, :school_day_open])
           end
         end
 
         context 'with :all filter' do
           let(:filter)    { :all }
-          it 'returns a breakdown of all periods' do
+          it 'should return a breakdown of all periods' do
             expect(days_kwh_x48.keys).to match_array([:school_day_closed, :school_day_open, :community, :community_baseload])
           end
 
-          it 'returns same total as the amr_data class' do
+          it 'should return the same total as the amr_data class' do
             expect(days_kwh_x48.values.flatten.sum).to be_within(0.0001).of( meter.amr_data.days_kwh_x48(day).sum )
           end
         end
@@ -218,7 +218,7 @@ describe CommunityUseBreakdown do
         context 'with :community_use' do
           let(:aggregate) { :community_use }
           context 'when splitting out baseload' do
-            it 'does not apply a sum, as its unnecessary' do
+            it 'should not apply a sum, as its unnecessary' do
               not_aggregated = open_close_breakdown.days_kwh_x48(day, :kwh, community_use: nil)
               expect(days_kwh_x48[:community].sum).to be_within(0.0001).of( not_aggregated[:community].sum )
             end
@@ -229,13 +229,13 @@ describe CommunityUseBreakdown do
           context 'when not splitting out baseload' do
             let(:split_electricity_baseload)  { false }
 
-            it 'sums the community use as :community' do
+            it 'should sums the community use into :community' do
               not_aggregated = open_close_breakdown.days_kwh_x48(day, :kwh, community_use: nil)
               expected_sum = not_aggregated[:community].sum + not_aggregated[:community_baseload].sum
               expect(days_kwh_x48[:community].sum).to be_within(0.0001).of( expected_sum )
             end
 
-            it 'does not include the baseload' do
+            it 'should not include the baseload' do
               expect(days_kwh_x48.keys).to match_array([:school_day_closed, :school_day_open, :community])
             end
           end
@@ -244,7 +244,7 @@ describe CommunityUseBreakdown do
 
         context 'with :all_to_single_value' do
           let(:aggregate) { :all_to_single_value }
-          it 'returns an array with same total as the amr_data class' do
+          it 'should return an array with same total as the amr_data class' do
             expect(days_kwh_x48.sum).to be_within(0.0001).of( meter.amr_data.days_kwh_x48(day).sum )
           end
         end
@@ -261,11 +261,11 @@ describe CommunityUseBreakdown do
       end
 
       context 'with default filter' do
-        it 'returns a breakdown of all periods' do
+        it 'should return a breakdown of all periods' do
           expect(days_kwh_x48.keys).to match_array([:school_day_closed, :school_day_open, :community, :community_baseload])
         end
 
-        it 'returns same total as the amr_data class' do
+        it 'should return the same total as the amr_data class' do
           expect(days_kwh_x48.values.flatten.sum).to be_within(0.0001).of( meter.amr_data.days_kwh_x48(day).sum )
         end
       end
@@ -281,7 +281,7 @@ describe CommunityUseBreakdown do
 
     context 'with no community use time period' do
       context 'with default filter' do
-        it 'returns same total as the amr_data class' do
+        it 'should return the same total as the amr_data class' do
           expect(one_day_kwh.values.sum).to be_within(0.0001).of( meter.amr_data.one_day_kwh(day) )
         end
       end
@@ -293,11 +293,11 @@ describe CommunityUseBreakdown do
       end
 
       context 'with default filter' do
-        it 'returns a breakdown of all periods' do
+        it 'should return a breakdown of all periods' do
           expect(one_day_kwh.keys).to match_array([:school_day_closed, :school_day_open, :community, :community_baseload])
         end
 
-        it 'returns same total as the amr_data class' do
+        it 'should return the same total as the amr_data class' do
           expect(one_day_kwh.values.flatten.sum).to be_within(0.0001).of( meter.amr_data.one_day_kwh(day) )
         end
       end
@@ -313,25 +313,25 @@ describe CommunityUseBreakdown do
 
         context 'with :community_only filter' do
           let(:filter)    { :community_only }
-          it 'returns a breakdown of just the community use' do
+          it 'should return a breakdown of just the community use' do
             expect(one_day_kwh.keys).to match_array([:community, :community_baseload])
           end
         end
 
         context 'with :school_only filter' do
           let(:filter)    { :school_only }
-          it 'returns a breakdown of just the school day' do
+          it 'should return a breakdown of just the school day' do
             expect(one_day_kwh.keys).to match_array([:school_day_closed, :school_day_open])
           end
         end
 
         context 'with :all filter' do
           let(:filter)    { :all }
-          it 'returns a breakdown of all periods' do
+          it 'should return a breakdown of all periods' do
             expect(one_day_kwh.keys).to match_array([:school_day_closed, :school_day_open, :community, :community_baseload])
           end
 
-          it 'returns same total as the amr_data class' do
+          it 'should return the same total as the amr_data class' do
             expect(one_day_kwh.values.flatten.sum).to be_within(0.0001).of( meter.amr_data.one_day_kwh(day) )
           end
         end
@@ -351,24 +351,24 @@ describe CommunityUseBreakdown do
         context 'with :community_use' do
           let(:aggregate) { :community_use }
           context 'when splitting out baseload' do
-            it 'does not apply a sum, as its unnecessary' do
+            it 'should not apply a sum, as its unnecessary' do
               not_aggregated = open_close_breakdown.one_day_kwh(day, :kwh, community_use: nil)
               expect(one_day_kwh[:community]).to be_within(0.0001).of( not_aggregated[:community] )
             end
-            it 'includes the baseload' do
+            it 'should include the baseload' do
               expect(one_day_kwh.keys).to match_array([:school_day_closed, :school_day_open, :community, :community_baseload])
             end
           end
           context 'when not splitting out baseload' do
             let(:split_electricity_baseload)  { false }
 
-            it 'sums the community use as :community' do
+            it 'should sum the community use into :community' do
               not_aggregated = open_close_breakdown.one_day_kwh(day, :kwh, community_use: nil)
               expected_sum = not_aggregated[:community] + not_aggregated[:community_baseload]
               expect(one_day_kwh[:community]).to be_within(0.0001).of( expected_sum )
             end
 
-            it 'does not include the baseload' do
+            it 'should not include the baseload' do
               expect(one_day_kwh.keys).to match_array([:school_day_closed, :school_day_open, :community])
             end
           end
@@ -377,7 +377,7 @@ describe CommunityUseBreakdown do
 
         context 'with :all_to_single_value' do
           let(:aggregate) { :all_to_single_value }
-          it 'returns an array with same total as the amr_data class' do
+          it 'should return an array with same total as the amr_data class' do
             expect(one_day_kwh).to be_within(0.0001).of( meter.amr_data.one_day_kwh(day) )
           end
         end
@@ -397,7 +397,7 @@ describe CommunityUseBreakdown do
 
     context 'with no community use time period' do
       context 'with default filter' do
-        it 'returns same total as the amr_data class' do
+        it 'should return the same total as the amr_data class' do
           expect(kwh_date_range.values.sum).to be_within(0.0001).of( meter.amr_data.kwh_date_range(start_date, end_date) )
         end
       end
@@ -409,11 +409,11 @@ describe CommunityUseBreakdown do
       end
 
       context 'with default filter' do
-        it 'returns a breakdown of all periods' do
+        it 'should return the breakdown of all periods' do
           expect(kwh_date_range.keys).to match_array([:school_day_closed, :school_day_open, :community, :community_baseload, :weekend])
         end
 
-        it 'returns same total as the amr_data class' do
+        it 'should return the same total as the amr_data class' do
           expect(kwh_date_range.values.flatten.sum).to be_within(0.0001).of( meter.amr_data.kwh_date_range(start_date, end_date) )
         end
       end
@@ -430,7 +430,7 @@ describe CommunityUseBreakdown do
 
     context 'with no community use time period' do
       context 'with default filter' do
-        it 'returns same total as the amr_data class' do
+        it 'should return the same total as the amr_data class' do
           expect(kwh.values.sum).to be_within(0.0001).of( meter.amr_data.kwh(day, hh_index) )
         end
       end
@@ -442,11 +442,11 @@ describe CommunityUseBreakdown do
       end
 
       context 'with default filter' do
-        it 'returns a breakdown of all periods' do
+        it 'should return a breakdown of all periods' do
           expect(kwh.keys).to match_array([:school_day_closed, :school_day_open, :community, :community_baseload])
         end
 
-        it 'returns same total as the amr_data class' do
+        it 'should return the same total as the amr_data class' do
           expect(kwh.values.flatten.sum).to be_within(0.0001).of( meter.amr_data.kwh(day,hh_index) )
         end
       end
@@ -462,25 +462,25 @@ describe CommunityUseBreakdown do
 
         context 'with :community_only filter' do
           let(:filter)    { :community_only }
-          it 'returns a breakdown of just the community use' do
+          it 'should return a breakdown of just the community use' do
             expect(kwh.keys).to match_array([:community, :community_baseload])
           end
         end
 
         context 'with :school_only filter' do
           let(:filter)    { :school_only }
-          it 'returns a breakdown of just the school day' do
+          it 'should return a breakdown of just the school day' do
             expect(kwh.keys).to match_array([:school_day_closed, :school_day_open])
           end
         end
 
         context 'with :all filter' do
           let(:filter)    { :all }
-          it 'returns a breakdown of all periods' do
+          it 'should return a breakdown of all periods' do
             expect(kwh.keys).to match_array([:school_day_closed, :school_day_open, :community, :community_baseload])
           end
 
-          it 'returns same total as the amr_data class' do
+          it 'should return the same total as the amr_data class' do
             expect(kwh.values.flatten.sum).to be_within(0.0001).of( meter.amr_data.kwh(day, hh_index) )
           end
         end
@@ -493,7 +493,7 @@ describe CommunityUseBreakdown do
     let(:community_use_times)   { [] }
 
     context 'with no community use time period' do
-      it 'returns the default series' do
+      it 'should return the default series' do
         expect(open_close_breakdown.series_names(nil)).to match_array([:school_day_closed, :school_day_open, :holiday, :weekend])
       end
     end
@@ -502,7 +502,7 @@ describe CommunityUseBreakdown do
       let(:community_use_times) do
         [{day: :monday, usage_type: :community_use, opening_time: TimeOfDay.new(19,00), closing_time: TimeOfDay.new(21,30), calendar_period: :term_times}]
       end
-      it 'includes the community use series' do
+      it 'should include the community use series' do
         expect(open_close_breakdown.series_names(nil)).to match_array([:school_day_closed, :school_day_open, :holiday, :weekend, :community])
       end
     end


### PR DESCRIPTION
My [recent fix to the community use allocation](https://github.com/Energy-Sparks/energy-sparks_analytics/pull/624) seems to have introduced or -- judging from the comments and exception in the code -- reintroduced a bug.

The code was not properly dealing with a couple of scenarios:

- when a half-hourly period was split between community use and school day open, with no time when school was closed, e.g. school closes at 16:15 then community use period starts at 16:15
- when the half-hourly period was split across 3 different usage types, e.g. school is open until 16:10, is closed for 5 minutes and the community use time starts at 16:20

...but only when the usage in those half-hourly periods was below the baseload.

This was only happening for 4 schools during testing as a specific combination of opening hours and usage was required to expose the bug.

This further rework and the additional tests should now ensure that we've got coverage across all possible combinations of half-hourly splits, e.g for a half-hourly period the logic is now checking:

- is completely closed
- if school is open
- if period is entirely community use
- if period is split between open and community use
- if period is split between all three

...and then the tests check for periods where usage is above, at and below the baseload