### PR TITLE
Add new benchmark for OVO report

### DIFF
--- a/config/locales/benchmarking/content_base.yml
+++ b/config/locales/benchmarking/content_base.yml
@@ -65,6 +65,7 @@ en:
         heating_in_warm_weather: Heating used in warm weather
         holiday_usage_last_year: Cost of energy used in upcoming holiday last year
         hot_water_efficiency: Hot Water Efficiency
+        jan_august_2022_2023_energy_comparison: Jan to August 2022 to 2023 energy use
         layer_up_powerdown_day_november_2022: Change in energy for layer up power down day 11 November 2022 (compared with 12 Nov 2021)
         recent_change_in_baseload: Recent change in baseload
         seasonal_baseload_variation: Seasonal baseload variation
@@ -388,6 +389,8 @@ en:
         benchmark_holidays_change_base:
           period_type: holiday
           period_types: holidays
+        benchmark_jan_august_2022_2023_gas_table:
+          introduction_text: 'The change columns are calculated using temperature adjusted values:'
         benchmark_sept_nov_2022_gas_table:
           introduction_text: 'The change columns are calculated using temperature adjusted values:'
         change_in_electricity_consumption_recent_school_weeks:
@@ -639,6 +642,15 @@ en:
           introduction_text_html: "<p>This benchmark shows the cost of electricity and gas used last year for the upcoming holidays. For example, if the next holidays are the Summer holidays 2023, the data shown will be for Summer 2022. This allows you to identify which schools in your group need to take the most action to cut holiday waste.</p>"
         hot_water_efficiency:
           introduction_text_html: "<p> This benchmark analyses the efficiency of schools' hot water systems and the potential savings from either improving the timing control of existing hot water systems or replacing it completely with point of use electric hot water systems. <p>"
+        jan_august_2023_2023_energy_comparison:
+          introduction_text_html: |-
+            <p>
+            This benchmark shows the change in energy consumption between January-August 2022 and 2023.
+            </p>
+            <p>
+            The first table provides an summary of overall change in energy usage, the other tables provide
+            more detail for electricity, gas and storage heaters.
+            </p>
         layer_up_powerdown_day_november_2022:
           introduction_text_html: |-
             <p>

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -600,7 +600,10 @@ class AlertAnalysisBase < ContentBase
       AlertEaster2023ShutdownElectricityComparison                => 'e23e',
       AlertEaster2023ShutdownGasComparison                        => 'e23g',
       AlertEaster2023ShutdownStorageHeaterComparison              => 'e23s',
-      AlertSolarGeneration                                        => 'sgen'
+      AlertSolarGeneration                                        => 'sgen',
+      AlertJanAug20222023ElectricityComparison                    => 'py23e',
+      AlertJanAug20222023GasComparison                            => 'py23g',
+      AlertJanAug20222023StorageHeaterComparison                  => 'py23s'
     }
   end
 

--- a/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
@@ -167,3 +167,44 @@ class AlertEaster2023ShutdownStorageHeaterComparison < AlertArbitraryPeriodCompa
     basic_configuration
   end
 end
+
+#===================================================================================================
+# Jan-August 2022-2023 comparison
+module AlertJanAug20222023ComparisonMixIn
+  def basic_configuration
+    {
+      name:                   'Jan-August 2022 energy use comparison',
+      max_days_out_of_date:   365,
+      enough_days_data:       1,
+      current_period:         Date.new(2023, 1, 1)..Date.new(2023, 8, 31),
+      previous_period:        Date.new(2022, 1, 1)..Date.new(2022, 8, 31)
+    }
+  end
+end
+
+class AlertJanAug20222023ElectricityComparison < AlertArbitraryPeriodComparisonElectricityBase
+  include ArbitraryPeriodComparisonMixIn
+  include AlertJanAug20222023ComparisonMixIn
+
+  def comparison_configuration
+    basic_configuration
+  end
+end
+
+class AlertJanAug20222023GasComparison < AlertArbitraryPeriodComparisonGasBase
+  include ArbitraryPeriodComparisonMixIn
+  include AlertJanAug20222023ComparisonMixIn
+
+  def comparison_configuration
+    basic_configuration
+  end
+end
+
+class AlertJanAug20222023StorageHeaterComparison < AlertArbitraryPeriodComparisonStorageHeaterBase
+  include ArbitraryPeriodComparisonMixIn
+  include AlertJanAug20222023ComparisonMixIn
+
+  def comparison_configuration
+    basic_configuration
+  end
+end

--- a/lib/dashboard/benchmarking/benchmark_content_general.rb
+++ b/lib/dashboard/benchmarking/benchmark_content_general.rb
@@ -857,4 +857,41 @@ module Benchmarking
     include BenchmarkingNoTextMixin
   end
 
+  #=======================================================================================
+  class BenchmarkJanAugust20222023Comparison < BenchmarkChangeAdhocComparison
+
+    def electricity_content(school_ids:, filter:)
+      extra_content(:jan_august_2022_2023_electricity_table, filter: filter)
+    end
+
+    def gas_content(school_ids:, filter:)
+      extra_content(:jan_august_2022_2023_gas_table, filter: filter)
+    end
+
+    def storage_heater_content(school_ids:, filter:)
+      extra_content(:jan_august_2022_2023_storage_heater_table, filter: filter)
+    end
+
+    private def introduction_text
+      text = I18n.t('analytics.benchmarking.content.jan_august_2023_2023_energy_comparison.introduction_text_html')
+      ERB.new(text).result(binding)
+    end
+
+  end
+
+  class BenchmarkJanAugust20222023ComparisonElectricityTable < BenchmarkContentBase
+    include BenchmarkingNoTextMixin
+  end
+
+  class BenchmarkJanAugust20222023ComparisonGasTable < BenchmarkContentBase
+    include BenchmarkingNoTextMixin
+
+    private def introduction_text
+      I18n.t('analytics.benchmarking.content.benchmark_jan_august_2022_2023_gas_table.introduction_text')
+    end
+  end
+
+  class BenchmarkJanAugust20222023ComparisonStorageHeaterTable < BenchmarkChangeAdhocComparisonGasTable
+    include BenchmarkingNoTextMixin
+  end
 end

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -7,16 +7,16 @@ require_rel '../../test_support'
 #   logger.level = :debug
 # end
 
-asof_date = Date.new(2023, 7, 19)
+asof_date = Date.new(2023, 11, 16)
 # schools = ['t*']
-schools = ['acme*']
+schools = ['m*']
 
 overrides = {
   schools:  schools,
   cache_school: false,
   alerts:   { alerts: nil, control: { asof_date: asof_date} },
   alerts:   { alerts: [
-    AlertElectricityBaseloadVersusBenchmark
+#    AlertElectricityBaseloadVersusBenchmark
 #    AlertThermostaticControl
 #    AlertEnergyAnnualVersusBenchmark,
 #    AlertSchoolWeekComparisonGas,
@@ -44,6 +44,10 @@ overrides = {
 #    AlertEaster2023ShutdownStorageHeaterComparison
 #    AlertOutOfHoursElectricityUsagePreviousYear
 #     AlertSolarGeneration
+#    AlertJanAug20222023ElectricityComparison,
+#    AlertJanAug20222023GasComparison,
+#    AlertJanAug20222023StorageHeaterComparison,
+    AlertEnergyAnnualVersusBenchmark
     ],
   control: { asof_date: asof_date, outputs: %i[raw_variables_for_saving html_template_variables], log: [:invalid_alerts] } },
   no_alerts:   { alerts: [], control: { asof_date: asof_date } }

--- a/script/standard/test_benchmarks.rb
+++ b/script/standard/test_benchmarks.rb
@@ -8,7 +8,7 @@ module Logging
   logger.level = :error
 end
 
-run_date = Date.new(2023,6,6)
+run_date = Date.new(2023,11,16)
 
 overrides = {
   schools: ['*'], # ['king-ja*', 'crook*', 'hunw*', 'combe*'], # ['king-james-e*', 'wyb*', 'batheas*', 'the-dur*'], # ['shrew*', 'bathamp*'],
@@ -17,7 +17,7 @@ overrides = {
     calculate_and_save_variables: true,
     asof_date: run_date,
     pages: %i[
-      solar_pv_benefit_estimate
+      jan_august_2022_2023_energy_comparison
     ],
     run_content: { asof_date: run_date } # , filter: ->{ !gpyc_difp.nil? && !gpyc_difp.infinite?.nil? } }
   }

--- a/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
+++ b/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
@@ -76,7 +76,8 @@ describe Benchmarking::BenchmarkManager, type: :service do
             name: 'Date limited comparisons',
             description: 'These benchmarks compare schools performance across specific date ranges.',
             benchmarks: {
-              change_in_energy_use_since_joined_energy_sparks: 'Change in energy use since the school joined Energy Sparks'
+              change_in_energy_use_since_joined_energy_sparks: 'Change in energy use since the school joined Energy Sparks',
+              jan_august_2022_2023_energy_comparison: 'Jan to August 2022 to 2023 energy use'
             }
           }
         ]
@@ -154,7 +155,8 @@ describe Benchmarking::BenchmarkManager, type: :service do
             name: 'Date limited comparisons',
             description: 'These benchmarks compare schools performance across specific date ranges.',
             benchmarks: {
-              change_in_energy_use_since_joined_energy_sparks: 'Change in energy use since the school joined Energy Sparks'
+              change_in_energy_use_since_joined_energy_sparks: 'Change in energy use since the school joined Energy Sparks',
+              jan_august_2022_2023_energy_comparison: 'Jan to August 2022 to 2023 energy use'
             }
           }
         ]


### PR DESCRIPTION
Adds a new school comparison report comparing between between Jan-August 2023 with Jan-August 2022.

Reuses the existing framework, so this is mostly configuration.