### PR TITLE
Update climate change levy key and figures

### DIFF
--- a/app/models/tariffs/climate_change_levy.rb
+++ b/app/models/tariffs/climate_change_levy.rb
@@ -1,31 +1,36 @@
+# frozen_string_literal: true
+
 require 'date'
 
 class ClimateChangeLevy
   class MissingClimateChangeLevyData < StandardError; end
 
   # https://www.gov.uk/guidance/climate-change-levy-rates
+  # Updated 2023-11-22
   DEFAULT_RATES = {
     electricity: {
       Date.new(2018, 4, 1)..Date.new(2019, 3, 31) => 0.00583,
       Date.new(2019, 4, 1)..Date.new(2020, 3, 31) => 0.00847,
       Date.new(2020, 4, 1)..Date.new(2021, 3, 31) => 0.00811,
       Date.new(2021, 4, 1)..Date.new(2022, 3, 31) => 0.00775,
-      Date.new(2022, 4, 1)..Date.new(2023, 3, 31) => 0.00775, # 22/23 numbers not set formally as of 26Jan2022?
-      Date.new(2023, 4, 1)..Date.new(2024, 3, 31) => 0.00775
+      Date.new(2022, 4, 1)..Date.new(2023, 3, 31) => 0.00775,
+      Date.new(2023, 4, 1)..Date.new(2024, 3, 31) => 0.00775,
+      Date.new(2024, 4, 1)..Date.new(2025, 3, 31) => 0.00775
     },
     gas: {
       Date.new(2018, 4, 1)..Date.new(2019, 3, 31) => 0.00203,
       Date.new(2019, 4, 1)..Date.new(2020, 3, 31) => 0.00339,
       Date.new(2020, 4, 1)..Date.new(2021, 3, 31) => 0.00406,
       Date.new(2021, 4, 1)..Date.new(2022, 3, 31) => 0.00465,
-      Date.new(2022, 4, 1)..Date.new(2023, 3, 31) => 0.00568, # 22/23 numbers not set formally as of 26Jan2022?
-      Date.new(2023, 4, 1)..Date.new(2024, 3, 31) => 0.00672
+      Date.new(2022, 4, 1)..Date.new(2023, 3, 31) => 0.00568,
+      Date.new(2023, 4, 1)..Date.new(2024, 3, 31) => 0.00672,
+      Date.new(2024, 4, 1)..Date.new(2025, 3, 31) => 0.00775
     }
-  }
+  }.freeze
 
   def self.rate(fuel_type, date)
     check_levy_set(fuel_type, date)
-    
+
     rate_range = DEFAULT_RATES[fuel_type].select do |date_range, _rate|
       # much faster than ruby matching as by default it scans the date range incrementally
       date >= date_range.first && date <= date_range.last
@@ -34,31 +39,13 @@ class ClimateChangeLevy
     if rate_range.nil? || rate_range.empty?
       [:climate_change_levy, 0.0]
     else
-      [ccl_key(rate_range.keys[0]), rate_range.values[0]]
+      [:climate_change_levy, rate_range.values[0]]
     end
-  end
-
-  def self.keyed_rates_within_date_range(fuel_type, start_date, end_date)
-    rates = rates_within_date_range(fuel_type, start_date, end_date)
-    rates.transform_keys { |date_range| ccl_key(date_range) }
-  end
-  
-  private_class_method def self.rates_within_date_range(fuel_type, start_date, end_date)
-    DEFAULT_RATES[fuel_type].select do |date_range, _rate|
-      (start_date >= date_range.first && start_date <= date_range.last) ||
-      (end_date   >= date_range.first && end_date   <= date_range.last)
-    end
-  end
-
-  private_class_method def self.ccl_key(date_range)
-    start_year = date_range.first.strftime('%Y')
-    end_year   = date_range.last.strftime('%y')
-    key = "climate_change_levy__#{start_year}_#{end_year}".to_sym
   end
 
   private_class_method def self.check_levy_set(fuel_type, date)
-    if date > DEFAULT_RATES[fuel_type].keys.map(&:last).max
-      raise MissingClimateChangeLevyData, "Internal Error: climate change levy not set for #{date}"
-    end
+    return unless date > DEFAULT_RATES[fuel_type].keys.map(&:last).max
+
+    raise MissingClimateChangeLevyData, "Internal Error: climate change levy not set for #{date}"
   end
 end

--- a/spec/app/models/tariffs/climate_change_levy_spec.rb
+++ b/spec/app/models/tariffs/climate_change_levy_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ClimateChangeLevy do
+  describe '.rate' do
+    let(:fuel_type) { :electricity }
+    let(:rate) { ClimateChangeLevy.rate(fuel_type, date) }
+
+    context 'with missing configuration' do
+      let(:date) { Date.new(2050, 1, 1) }
+
+      it 'throws an exception' do
+        expect { rate }.to raise_error ClimateChangeLevy::MissingClimateChangeLevyData
+      end
+    end
+
+    context 'with earlier data' do
+      let(:date) { Date.new(2017, 10, 1) }
+
+      it 'returns zero' do
+        expect(rate).to eq([:climate_change_levy, 0.0])
+      end
+    end
+
+    context 'when data is valid' do
+      context 'with electricity' do
+        let(:date) { Date.new(2023, 10, 1) }
+
+        it 'returns expected value' do
+          expect(rate).to eq([:climate_change_levy, 0.00775])
+        end
+      end
+
+      context 'with gas' do
+        let(:fuel_type) { :gas }
+        let(:date) { Date.new(2021, 6, 1) }
+
+        it 'returns expected value' do
+          expect(rate).to eq([:climate_change_levy, 0.00465])
+        end
+      end
+    end
+  end
+end

--- a/spec/app/models/tariffs/generic_accounting_tariff_spec.rb
+++ b/spec/app/models/tariffs/generic_accounting_tariff_spec.rb
@@ -206,7 +206,7 @@ describe GenericAccountingTariff do
 
         it 'includes the charge' do
           # value is from ClimateChangeLevy
-          expect(accounting_cost.all_costs_x48[:climate_change_levy__2023_24]).to eq Array.new(48, 0.01 * 0.00775)
+          expect(accounting_cost.all_costs_x48[:climate_change_levy]).to eq Array.new(48, 0.01 * 0.00775)
         end
       end
 

--- a/spec/lib/dashboard/aggregation/one_days_cost_data_spec.rb
+++ b/spec/lib/dashboard/aggregation/one_days_cost_data_spec.rb
@@ -31,13 +31,13 @@ describe OneDaysCostData do
         {
           'flat_rate' => Array.new(48, 0.1),
           'Feed in tariff levy' => Array.new(48, 0.1),
-          :climate_change_levy__2023_24 => Array.new(48, 0.1)
+          :climate_change_levy => Array.new(48, 0.1)
         }
       end
       let(:one_days_cost) { build(:one_days_cost, rates_x48: rates_x48) }
 
       it 'lists all of them' do
-        expect(bill_components).to eq ['flat_rate', 'Feed in tariff levy', :climate_change_levy__2023_24,
+        expect(bill_components).to eq ['flat_rate', 'Feed in tariff levy', :climate_change_levy,
                                        :standing_charge]
       end
     end


### PR DESCRIPTION
When the costs for the climate change levy are added to the calculated cost breakdown they currently use a different key for each year, e.g. `:climate_change_levy__22_23`. This means every year we need to update the application with new translation keys otherwise the costs are missing from the table.

There's no real need to have different line items for each version of the climate change levy, so this PR changes the code to just use a single key: `:climate_change_levy`.

I've also updated the class to include the costs for 2024/25.

Aside: there's some behaviour in the class which I've left in for now. It looks to see if we have missing configuration for recent years and then throws an exception. But for an older year it just defaults the rate to zero. The former is useful to catch problems where we've not updated the figures, but seemed a bit odd to have an exception and a default.