### PR TITLE
Correct period of enough data

### DIFF
--- a/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
@@ -175,7 +175,7 @@ module AlertJanAug20222023ComparisonMixIn
     {
       name:                   'Jan-August 2022 energy use comparison',
       max_days_out_of_date:   365,
-      enough_days_data:       1,
+      enough_days_data:       242,
       current_period:         Date.new(2023, 1, 1)..Date.new(2023, 8, 31),
       previous_period:        Date.new(2022, 1, 1)..Date.new(2022, 8, 31)
     }


### PR DESCRIPTION
When configuring this benchmark I had mistakenly left the `enough_days_data` configuration as 1 day. This means any school with at least one days data in either period will have the alert run.

This isn't the intended behaviour as it allows schools with less than a years data to crop up in the results. This fixes the problem as there are 242 days between the period. We only want schools with data for both periods.