### PR TITLE
Revise OVO benchmark configuration, disable normalisation

### DIFF
--- a/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
@@ -180,6 +180,18 @@ module AlertJanAug20222023ComparisonMixIn
       previous_period:        Date.new(2022, 1, 1)..Date.new(2022, 8, 31)
     }
   end
+
+  #Override to disable the default period normalisation and temperature compensation
+  #applied to the previous period. Instead just return the consumption values
+  #for the period, unchanged
+  def normalised_period_data(_current_period, previous_period)
+    meter_values_period(previous_period)
+  end
+
+  #Disable pupil and floor area adjustments between periods
+  def pupil_floor_area_adjustment
+    1.0
+  end
 end
 
 class AlertJanAug20222023ElectricityComparison < AlertArbitraryPeriodComparisonElectricityBase
@@ -189,6 +201,7 @@ class AlertJanAug20222023ElectricityComparison < AlertArbitraryPeriodComparisonE
   def comparison_configuration
     basic_configuration
   end
+
 end
 
 class AlertJanAug20222023GasComparison < AlertArbitraryPeriodComparisonGasBase

--- a/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
@@ -174,7 +174,6 @@ class AlertPeriodComparisonBase < AlertAnalysisBase
 
     current_period_data             = meter_values_period(current_period)
     previous_period_data            = normalised_period_data(current_period, previous_period)
-    previous_period_data_unadjusted = meter_values_period(current_period)
 
     @difference_kwh       = current_period_data[:kwh]       - previous_period_data[:kwh]
     @difference_£         = current_period_data[:£]         - previous_period_data[:£]

--- a/lib/dashboard/benchmarking/benchmark_configuration.rb
+++ b/lib/dashboard/benchmarking/benchmark_configuration.rb
@@ -1866,6 +1866,9 @@ module Benchmarking
             name: :metering,
             units: String
           },
+          { data: ->{ py23e_pnch ? 'Y' : 'N' }, name: :pupils, units: String },
+          { data: ->{ py23g_fach ? 'Y' : 'N' }, name: :floor_area, units: String },
+
           TARIFF_CHANGED_COL
         ],
         column_groups: [
@@ -1873,7 +1876,7 @@ module Benchmarking
           { name: :kwh,      span: 2 },
           { name: :co2_kg, span: 2 },
           { name: :cost,     span: 2 },
-          { name: '',         span: 1 }
+          { name: '',         span: 3 }
         ],
         where:   ->{ !sum_data([py23e_ppp£, py23g_ppp£], true).nil? },
         sort_by:  [0],
@@ -1907,6 +1910,7 @@ module Benchmarking
           { data: ->{ py23e_dif€ },  name: :change_£, units: :£current },
           { data: ->{ percent_change(py23e_ppp€, py23e_cpp€)}, name: :change_pct, units: :percent },
 
+          { data: ->{ py23e_pnch ? 'Y' : 'N' }, name: :pupils, units: String },
           { data: ->{ enba_solr == 'synthetic' ? 'Y' : '' }, name: :estimated,  units: String },
 
           TARIFF_CHANGED_COL
@@ -1916,7 +1920,8 @@ module Benchmarking
           { name: :kwh,      span: 4 },
           { name: :co2_kg, span: 4 },
           { name: :cost,     span: 4 },
-          { name: :solar_self_consumption,   span: 1 }
+          { name: '', span: 1 },
+          { name: :solar_self_consumption,   span: 1 },
         ],
         where:   ->{ !py23e_ppp£.nil? },
         sort_by:  [0],
@@ -1933,7 +1938,7 @@ module Benchmarking
           { data: ->{ addp_sact },  name: :energy_sparks_join_date, units: :date_mmm_yyyy },
 
           #kwh
-          { data: ->{ py23g_pppk },  name: :previous_year_temperature_adjusted, units: :kwh },
+          { data: ->{ py23g_pppk },  name: :previous_year_temperature_unadjusted, units: :kwh },
           { data: ->{ py23g_cppk},   name: :last_year, units: :kwh},
           { data: ->{ py23g_difk },  name: :change_kwh, units: :kwh },
           { data: ->{ percent_change(py23g_pppk, py23g_cppk)}, name: :change_pct, units: :percent },
@@ -1950,9 +1955,7 @@ module Benchmarking
           { data: ->{ py23g_dif€ },  name: :change_£, units: :£current },
           { data: ->{ percent_change(py23g_ppp€, py23g_cpp€)}, name: :change_pct, units: :percent },
 
-          { data: ->{ py23g_pppu },  name: :previous_year_temperature_unadjusted, units: :kwh },
-          { data: ->{ py23g_cppk - py23g_pppu },  name: :unadjusted_kwh, units: :kwh },
-          { data: ->{ percent_change(py23g_pppu, py23g_cppk)}, name: :change_pct, units: :percent },
+          { data: ->{ py23g_fach ? 'Y' : 'N' }, name: :floor_area, units: String },
 
           TARIFF_CHANGED_COL
         ],
@@ -1961,7 +1964,8 @@ module Benchmarking
           { name: :kwh,      span: 4 },
           { name: :co2_kg, span: 4 },
           { name: :cost,     span: 4 },
-          { name: :kwh, span: 3}
+          { name: :kwh, span: 3},
+          { name: '', span: 1}
         ],
         where:   ->{ !py23g_ppp£.nil? },
         sort_by:  [0],
@@ -1978,7 +1982,7 @@ module Benchmarking
           { data: ->{ addp_sact },  name: :energy_sparks_join_date, units: :date_mmm_yyyy },
 
           #kwh
-          { data: ->{ py23s_pppk },  name: :previous_year_temperature_adjusted, units: :kwh },
+          { data: ->{ py23s_pppk },  name: :previous_year_temperature_unadjusted, units: :kwh },
           { data: ->{ py23s_cppk},   name: :last_year, units: :kwh},
           { data: ->{ py23s_difk },  name: :change_kwh, units: :kwh },
           { data: ->{ percent_change(py23s_pppk, py23s_cppk)}, name: :change_pct, units: :percent },
@@ -1995,9 +1999,7 @@ module Benchmarking
           { data: ->{ py23s_dif€ },  name: :change_£, units: :£current },
           { data: ->{ percent_change(py23s_ppp€, py23s_cpp€)}, name: :change_pct, units: :percent },
 
-          { data: ->{ py23s_pppu },  name: :previous_year_temperature_unadjusted, units: :kwh },
-          { data: ->{ py23s_cppk - py23s_pppu },  name: :unadjusted_kwh, units: :kwh },
-          { data: ->{ percent_change(py23s_pppu, py23s_cppk)}, name: :change_pct, units: :percent },
+          { data: ->{ py23s_fach ? 'Y' : 'N' }, name: :floor_area, units: String },
 
           TARIFF_CHANGED_COL
         ],
@@ -2006,7 +2008,8 @@ module Benchmarking
           { name: :kwh,      span: 4 },
           { name: :co2_kg, span: 4 },
           { name: :cost,     span: 4 },
-          { name: :kwh, span: 3}
+          { name: :kwh, span: 3},
+          { name: '', span: 1}
         ],
         where:   ->{ !py23s_ppp£.nil? },
         sort_by:  [0],

--- a/script/standard/test_benchmarks.rb
+++ b/script/standard/test_benchmarks.rb
@@ -8,7 +8,7 @@ module Logging
   logger.level = :error
 end
 
-run_date = Date.new(2023,11,16)
+run_date = Date.new(2023,11,28)
 
 overrides = {
   schools: ['*'], # ['king-ja*', 'crook*', 'hunw*', 'combe*'], # ['king-james-e*', 'wyb*', 'batheas*', 'the-dur*'], # ['shrew*', 'bathamp*'],


### PR DESCRIPTION
The framework for the arbitrary period comparisons applies a set of normalisations to the data for the previous period:

- calculates average weekday and weekend usage figures and then scales those to the number of weekdays/weekends in the current period. This allows the periods being compared to have different lengths, e.g. summer holiday and autumn half term
- applies temperature compensation using the average temperature for the current period
- adjusted those values further depending on changes to the pupil numbers and floor areas in the school

While these are helpful in other contexts, for the Ovo report we just want to see a comparison against current and previous year without these adjustments. For a Jan-August period the temperature compensation may not be correct and the normalisation isn't needed as the period lengths are the same.

This PR adjusts the alerts that generate the variables plus the configuration.

I've tested this locally with the test_benchmarks.rb script to ensure it works as expected.

I've not added additional tests around this as we'll be reworking this code in the coming months.