### PR TITLE
Add missing mapping of fuel type to pseudo meter attribute

### DIFF
--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -120,6 +120,10 @@ module Dashboard
       case fuel_type
       when :storage_heater
         :storage_heater_aggregated
+      when :solar_pv
+        :solar_pv_consumed_sub_meter
+      when :exported_solar_pv
+        :solar_pv_exported_sub_meter
       else
         :"aggregated_#{fuel_type}"
       end

--- a/spec/app/models/dashboard/meter_spec.rb
+++ b/spec/app/models/dashboard/meter_spec.rb
@@ -76,6 +76,20 @@ describe Dashboard::Meter do
       end
     end
 
+    describe '.aggregate_pseudo_meter_attribute_key' do
+      {
+        storage_heater: :storage_heater_aggregated,
+        solar_pv: :solar_pv_consumed_sub_meter,
+        exported_solar_pv: :solar_pv_exported_sub_meter,
+        electricity: :aggregated_electricity,
+        gas: :aggregated_gas
+      }.each do |fuel_type, key|
+        it "returns #{key} for #{fuel_type}" do
+          expect(described_class.aggregate_pseudo_meter_attribute_key(fuel_type)).to eq(key)
+        end
+      end
+    end
+
     # TODO: check on fuel type not currently applied
     # it "raises error for unknown fuel type" do
     #   expect {


### PR DESCRIPTION
The `AlertEnergyAnnualVersusBenchmark` is failing for schools with >1 solar array. It fails when attempting to calculate the differences in costs between this year and last year.

Tracing this back through the code it turns out that when there are multiple arrays there is [a separate step in the aggregation process](https://github.com/Energy-Sparks/energy-sparks_analytics/blob/615d851ff52c9e4d36383f5f1eb732dae83a007b/app/services/aggregation_service.rb#L183). This combines, e.g. the generation and export meters for each array into a new AggregateMeter object.

When the aggregate meter is created in [this method](https://github.com/Energy-Sparks/energy-sparks_analytics/blob/615d851ff52c9e4d36383f5f1eb732dae83a007b/app/services/aggregation_service.rb#L283) in the [call to the constructor](https://github.com/Energy-Sparks/energy-sparks_analytics/blob/master/app/services/aggregation_service.rb#L307) a set of "pseudo meter attributes" are passed in. 

These meter attributes allow configuration to be set of "pseudo meters" such as the aggregated electricity and gas meters, and the solar meters created during the aggregation process.

The attributes are associated with a key which can be derived from the fuel type of the meter. The function [called here](https://github.com/Energy-Sparks/energy-sparks_analytics/blob/615d851ff52c9e4d36383f5f1eb732dae83a007b/app/services/aggregation_service.rb#L283) to find the key name currently only returns values for gas, electricity and storage heaters. 

This means that no meter attributes are passed to the aggregated solar meters created if there is >1 array.

Because the default tariffs are provided to the analytics as pseudo meter attributes, these meters end up without any tariff information. And this is ultimately the cause of the failure to run the `AlertEnergyAnnualVersusBenchmark` alert.

The fix is to update the method in the Meter class so that its consistent with what is being used elsewhere in the analytics and [the mapping in the main application code](https://github.com/Energy-Sparks/energy-sparks/blob/master/app/models/school.rb#L571C1-L575).

Simple change, but took a while to track this one down.

Have confirmed that this results in the alert running for schools for which it is currently failing. This means they will now appear properly in the school comparison pages.