### PR TITLE
Configure alerts and comparison for the layer up / power down day in Nov 2023

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,8 @@ require:
 
 Naming/MethodParameterName:
   AllowedNames: ['kw', '£', 'co2']
+Naming/VariableNumber:
+  AllowedPatterns: ['_[0-9]+']
 Naming/VariableName:
   AllowedPatterns: ['_£', '£']
 Naming/MethodName:

--- a/config/locales/benchmarking/content_base.yml
+++ b/config/locales/benchmarking/content_base.yml
@@ -66,8 +66,8 @@ en:
         holiday_usage_last_year: Cost of energy used in upcoming holiday last year
         hot_water_efficiency: Hot Water Efficiency
         jan_august_2022_2023_energy_comparison: Jan to August 2022 to 2023 energy use
-        layer_up_powerdown_day_november_2023: Change in energy for layer up power down day 24 November 2023 (compared with 17 November 2023)
         layer_up_powerdown_day_november_2022: Change in energy for layer up power down day 11 November 2022 (compared with 12 Nov 2021)
+        layer_up_powerdown_day_november_2023: Change in energy for layer up power down day 24 November 2023 (compared with 17 November 2023)
         recent_change_in_baseload: Recent change in baseload
         seasonal_baseload_variation: Seasonal baseload variation
         sept_nov_2021_2022_energy_comparison: September to November 2021 versus 2022 energy use
@@ -393,9 +393,9 @@ en:
         benchmark_holidays_change_base:
           period_type: holiday
           period_types: holidays
-        benchmark_layer_up_powerdown_day_november_2023_gas_table:
-          introduction_text: 'The change columns are calculated using temperature adjusted values:'
         benchmark_jan_august_2022_2023_gas_table:
+          introduction_text: 'The change columns are calculated using temperature adjusted values:'
+        benchmark_layer_up_powerdown_day_november_2023_gas_table:
           introduction_text: 'The change columns are calculated using temperature adjusted values:'
         benchmark_sept_nov_2022_gas_table:
           introduction_text: 'The change columns are calculated using temperature adjusted values:'
@@ -657,6 +657,23 @@ en:
             The first table provides an summary of overall change in energy usage, the other tables provide
             more detail for electricity, gas and storage heaters.
             </p>
+        layer_up_powerdown_day_november_2022:
+          introduction_text_html: |-
+            <p>
+              This comparison below for gas and storage heaters has the
+              the previous period temperature compensated to the current
+              period's temperatures.
+            </p>
+            <p>
+              Schools' solar PV production has been removed from the comparison.
+            </p>
+            <p>
+              CO2 values for electricity (including where the CO2 is
+              aggregated across electricity, gas, storage heaters) is difficult
+              to compare for short periods as it is dependent on the carbon intensity
+              of the national grid on the days being compared and this could vary by up to
+              300&percnt; from day to day.
+            </p>
         layer_up_powerdown_day_november_2023:
           introduction_text_html: |-
             <p>
@@ -677,23 +694,6 @@ en:
             <p>
               The total kWh, CO2 and cost changes will only include the fuel types for which we have data. So, e.g. for a school does not have gas data for the
               17th November it will not appear in the gas table, but may still have its electricity data present.
-            </p>
-        layer_up_powerdown_day_november_2022:
-          introduction_text_html: |-
-            <p>
-              This comparison below for gas and storage heaters has the
-              the previous period temperature compensated to the current
-              period's temperatures.
-            </p>
-            <p>
-              Schools' solar PV production has been removed from the comparison.
-            </p>
-            <p>
-              CO2 values for electricity (including where the CO2 is
-              aggregated across electricity, gas, storage heaters) is difficult
-              to compare for short periods as it is dependent on the carbon intensity
-              of the national grid on the days being compared and this could vary by up to
-              300&percnt; from day to day.
             </p>
         optimum_start_analysis:
           caveat_text_html: |-

--- a/config/locales/benchmarking/content_base.yml
+++ b/config/locales/benchmarking/content_base.yml
@@ -66,6 +66,7 @@ en:
         holiday_usage_last_year: Cost of energy used in upcoming holiday last year
         hot_water_efficiency: Hot Water Efficiency
         jan_august_2022_2023_energy_comparison: Jan to August 2022 to 2023 energy use
+        layer_up_powerdown_day_november_2023: Change in energy for layer up power down day 24 November 2023 (compared with 17 November 2023)
         layer_up_powerdown_day_november_2022: Change in energy for layer up power down day 11 November 2022 (compared with 12 Nov 2021)
         recent_change_in_baseload: Recent change in baseload
         seasonal_baseload_variation: Seasonal baseload variation
@@ -208,6 +209,7 @@ en:
           last_year_storage_heater_kwh_pupil: Last year storage heater  kWh/pupil
           last_year_storage_heater_£: Last year Storage Heater £
           last_year_weekend_and_holiday_costs: Last year weekend and holiday costs
+          layer_down_day: Layer down day
           max_average_weekday_baseload_kw: Max average weekday baseload kW
           metering: Metering
           min_average_weekday_baseload_kw: Min average weekday baseload kW
@@ -229,6 +231,8 @@ en:
           potential_annual_saving_£: Potential annual saving £
           potential_max_annual_saving_£: Potential max annual saving £
           potential_saving: Potential saving (at latest tariff)
+          previous_day: Previous day
+          previous_day_temperature_unadjusted: Previous day (temperature unadjusted)
           previous_holiday: Previous holiday
           previous_year: Previous year
           previous_year_electricity_£: Previous year electricity £
@@ -389,6 +393,8 @@ en:
         benchmark_holidays_change_base:
           period_type: holiday
           period_types: holidays
+        benchmark_layer_up_powerdown_day_november_2023_gas_table:
+          introduction_text: 'The change columns are calculated using temperature adjusted values:'
         benchmark_jan_august_2022_2023_gas_table:
           introduction_text: 'The change columns are calculated using temperature adjusted values:'
         benchmark_sept_nov_2022_gas_table:
@@ -650,6 +656,27 @@ en:
             <p>
             The first table provides an summary of overall change in energy usage, the other tables provide
             more detail for electricity, gas and storage heaters.
+            </p>
+        layer_up_powerdown_day_november_2023:
+          introduction_text_html: |-
+            <p>
+              This comparison below for gas and storage heaters has the
+              the previous period temperature compensated to the current
+              period's temperatures.
+            </p>
+            <p>
+              Schools' solar PV production has been removed from the comparison.
+            </p>
+            <p>
+              CO2 values for electricity (including where the CO2 is
+              aggregated across electricity, gas, storage heaters) is difficult
+              to compare for short periods as it is dependent on the carbon intensity
+              of the national grid on the days being compared and this could vary by up to
+              300&percnt; from day to day.
+            </p>
+            <p>
+              The total kWh, CO2 and cost changes will only include the fuel types for which we have data. So, e.g. for a school does not have gas data for the
+              17th November it will not appear in the gas table, but may still have its electricity data present.
             </p>
         layer_up_powerdown_day_november_2022:
           introduction_text_html: |-

--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -603,7 +603,10 @@ class AlertAnalysisBase < ContentBase
       AlertSolarGeneration                                        => 'sgen',
       AlertJanAug20222023ElectricityComparison                    => 'py23e',
       AlertJanAug20222023GasComparison                            => 'py23g',
-      AlertJanAug20222023StorageHeaterComparison                  => 'py23s'
+      AlertJanAug20222023StorageHeaterComparison                  => 'py23s',
+      AlertLayerUpPowerdownNovember2023ElectricityComparison      => 'lu23e1',
+      AlertLayerUpPowerdownNovember2023GasComparison              => 'lu23g1',
+      AlertLayerUpPowerdownNovember2023StorageHeaterComparison    => 'lu23s1'
     }
   end
 

--- a/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
@@ -221,3 +221,54 @@ class AlertJanAug20222023StorageHeaterComparison < AlertArbitraryPeriodCompariso
     basic_configuration
   end
 end
+
+#===================================================================================================
+# Power up layer down day November 2023
+module AlertLayerUpPowerdownNovember2023BasicConfigMixIn
+  def basic_configuration
+    {
+      name:                   'Layer up power down day 24 November 2023',
+      max_days_out_of_date:   365,
+      enough_days_data:       1,
+      current_period:         Date.new(2023, 11, 24)..Date.new(2023, 11, 24),
+      previous_period:        Date.new(2023, 11, 17)..Date.new(2023, 11, 17)
+    }
+  end
+end
+
+class AlertLayerUpPowerdownNovember2023ElectricityComparison < AlertArbitraryPeriodComparisonElectricityBase
+  include ArbitraryPeriodComparisonMixIn
+  include AlertLayerUpPowerdownNovember2023BasicConfigMixIn
+
+  def comparison_configuration
+    {
+      comparison_chart:       :layerup_powerdown_november_2023_electricity_comparison_alert
+    }.merge(basic_configuration)
+  end
+end
+
+class AlertLayerUpPowerdownNovember2023GasComparison < AlertArbitraryPeriodComparisonGasBase
+  include ArbitraryPeriodComparisonMixIn
+  include AlertLayerUpPowerdownNovember2023BasicConfigMixIn
+
+  def comparison_configuration
+    {
+      comparison_chart:       :layerup_powerdown_november_2023_gas_comparison_alert
+    }.merge(basic_configuration)
+  end
+
+  def calculate(asof_date)
+    super(asof_date)
+  end
+end
+
+class AlertLayerUpPowerdownNovember2023StorageHeaterComparison < AlertArbitraryPeriodComparisonStorageHeaterBase
+  include ArbitraryPeriodComparisonMixIn
+  include AlertLayerUpPowerdownNovember2023BasicConfigMixIn
+
+  def comparison_configuration
+    {
+      comparison_chart:       :layerup_powerdown_november_2023_storage_heater_comparison_alert
+    }.merge(basic_configuration)
+  end
+end

--- a/lib/dashboard/benchmarking/benchmark_configuration.rb
+++ b/lib/dashboard/benchmarking/benchmark_configuration.rb
@@ -149,7 +149,8 @@ module Benchmarking
       ],
       date_limited_comparisons: [
         :change_in_energy_use_since_joined_energy_sparks,
-        :jan_august_2022_2023_energy_comparison
+        :jan_august_2022_2023_energy_comparison,
+        :layer_up_powerdown_day_november_2023
       ]
     }
 
@@ -2016,6 +2017,179 @@ module Benchmarking
         type: %i[table],
         admin_only: true
       },
+      layer_up_powerdown_day_november_2023: {
+        benchmark_class:  BenchmarkLayerUpPowerDownDay2023Comparison,
+        name:       'Change in energy for layer up power down day 24 November 2023 (compared with 17 November 2023)',
+        columns:  [
+          { data: 'addp_name', name: :name, units: :school_name, chart_data: true},
+
+          # kWh
+
+          { data: ->{ sum_if_complete([lu23e1_pppk, lu23g1_pppk, lu23s1_pppk], [lu23e1_cppk, lu23g1_cppk, lu23s1_cppk]) }, name: :previous_day, units: :kwh },
+          { data: ->{ sum_data([lu23e1_cppk, lu23g1_cppk, lu23s1_cppk]) },                                name: :layer_down_day,  units: :kwh },
+          {
+            data: ->{ percent_change(
+                                      sum_if_complete([lu23e1_pppk, lu23g1_pppk, lu23s1_pppk], [lu23e1_cppk, lu23g1_cppk, lu23s1_cppk]),
+                                      sum_data([lu23e1_cppk, lu23g1_cppk, lu23s1_cppk]),
+                                      true
+                                    ) },
+            name: :change_pct, units: :relative_percent_0dp
+          },
+
+          # CO2
+          { data: ->{ sum_if_complete([lu23e1_pppc, lu23g1_pppc, lu23s1_pppc], [lu23e1_cppc, lu23g1_cppc, lu23s1_cppc]) }, name: :previous_day, units: :co2 },
+          { data: ->{ sum_data([lu23e1_cppc, lu23g1_cppc, lu23s1_cppc]) },                                name: :layer_down_day,  units: :co2 },
+          {
+            data: ->{ percent_change(
+                                      sum_if_complete([lu23e1_pppc, lu23g1_pppc, lu23s1_pppc], [lu23e1_cppc, lu23g1_cppc, lu23s1_cppc]),
+                                      sum_data([lu23e1_cppc, lu23g1_cppc, lu23s1_cppc]),
+                                      true
+                                    ) },
+            name: :change_pct, units: :relative_percent_0dp
+          },
+
+          # £
+
+          { data: ->{ sum_if_complete([lu23e1_ppp£, lu23g1_ppp£, lu23s1_ppp£], [lu23e1_cpp£, lu23g1_cpp£, lu23s1_cpp£]) }, name: :previous_day, units: :£ },
+          { data: ->{ sum_data([lu23e1_cpp£, lu23g1_cpp£, lu23s1_cpp£]) },                                name: :layer_down_day,  units: :£ },
+          {
+            data: ->{ percent_change(
+                                      sum_if_complete([lu23e1_ppp£, lu23g1_ppp£, lu23s1_ppp£], [lu23e1_cpp£, lu23g1_cpp£, lu23s1_cpp£]),
+                                      sum_data([lu23e1_cpp£, lu23g1_cpp£, lu23s1_cpp£]),
+                                      true
+                                    ) },
+            name: :change_£, units: :relative_percent_0dp, chart_data: true
+          },
+
+          # Metering
+
+          { data: ->{
+              [
+                lu23e1_ppp£.nil? ? nil : :electricity,
+                lu23g1_ppp£.nil? ? nil : :gas,
+                lu23s1_ppp£.nil? ? nil : :storage_heaters
+              ].compact.join(', ')
+            },
+            name: :metering,
+            units: String
+          },
+        ],
+        column_groups: [
+          { name: '',         span: 1 },
+          { name: :kwh,       span: 3 },
+          { name: :co2_kg,    span: 3 },
+          { name: :cost,      span: 3 },
+          { name: '',         span: 1 }
+        ],
+        where:   ->{ !sum_data([lu23e1_ppp£, lu23g1_ppp£, lu23s1_ppp£], true).nil? },
+        sort_by:  [9],
+        type: %i[chart table],
+        admin_only: true
+      },
+      layer_up_powerdown_day_november_2023_electricity_table: {
+        benchmark_class:  BenchmarkLayerUpPowerDownDay2023ComparisonElectricityTable,
+        filter_out:     :dont_make_available_directly,
+        name:       'Change in electricity for layer up power down day November 2023',
+        columns:  [
+          { data: 'addp_name', name: :name, units: :school_name },
+
+          # kWh
+          { data: ->{ lu23e1_pppk }, name: :previous_day, units: :kwh },
+          { data: ->{ lu23e1_cppk }, name: :layer_down_day,  units: :kwh },
+          { data: ->{ percent_change(lu23e1_pppk, lu23e1_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          # CO2
+          { data: ->{ lu23e1_pppc }, name: :previous_day, units: :co2 },
+          { data: ->{ lu23e1_cppc }, name: :layer_down_day,  units: :co2 },
+          { data: ->{ percent_change(lu23e1_pppc, lu23e1_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          # £
+          { data: ->{ lu23e1_ppp£ }, name: :previous_day, units: :£ },
+          { data: ->{ lu23e1_cpp£ }, name: :layer_down_day,  units: :£ },
+          { data: ->{ percent_change(lu23e1_ppp£, lu23e1_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+        ],
+        column_groups: [
+          { name: '',         span: 1 },
+          { name: :kwh,      span: 4 },
+          { name: :co2_kg, span: 3 },
+          { name: :cost,     span: 3 }
+        ],
+        where:   ->{ !lu23e1_ppp£.nil? },
+        sort_by:  [9],
+        type: %i[table],
+        admin_only: true
+      },
+      layer_up_powerdown_day_november_2023_gas_table: {
+        benchmark_class:  BenchmarkLayerUpPowerDownDay2023ComparisonGasTable,
+        filter_out:     :dont_make_available_directly,
+        name:       'Change in gas for layer up power down day November 2023',
+        columns:  [
+          { data: 'addp_name', name: :name, units: :school_name },
+
+          # kWh
+          { data: ->{ lu23g1_pppu }, name: :previous_day_temperature_unadjusted, units: :kwh },
+          { data: ->{ lu23g1_pppk }, name: :previous_day, units: :kwh },
+          { data: ->{ lu23g1_cppk }, name: :layer_down_day,  units: :kwh },
+          { data: ->{ percent_change(lu23g1_pppk, lu23g1_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          # CO2
+          { data: ->{ lu23g1_pppc }, name: :previous_day, units: :co2 },
+          { data: ->{ lu23g1_cppc }, name: :layer_down_day,  units: :co2 },
+          { data: ->{ percent_change(lu23g1_pppc, lu23g1_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          # £
+          { data: ->{ lu23g1_ppp£ }, name: :previous_day, units: :£ },
+          { data: ->{ lu23g1_cpp£ }, name: :layer_down_day,  units: :£ },
+          { data: ->{ percent_change(lu23g1_ppp£, lu23g1_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+        ],
+        column_groups: [
+          { name: '',         span: 1 },
+          { name: :kwh,      span: 3 },
+          { name: :co2_kg, span: 3 },
+          { name: :cost,     span: 3 }
+        ],
+        where:   ->{ !lu23g1_ppp£.nil? },
+        sort_by:  [9],
+        type: %i[table],
+        admin_only: true
+      },
+      layer_up_powerdown_day_november_2023_storage_heater_table: {
+        benchmark_class:  BenchmarkLayerUpPowerDownDay2023ComparisonStorageHeaterTable,
+        filter_out:     :dont_make_available_directly,
+        name:       'Change in gas for layer up power down day November 2023',
+        columns:  [
+          { data: 'addp_name', name: :name, units: :school_name },
+
+          # kWh
+          { data: ->{ lu23s1_pppu }, name: :previous_day_temperature_unadjusted, units: :kwh },
+          { data: ->{ lu23s1_pppk }, name: :previous_day, units: :kwh },
+          { data: ->{ lu23s1_cppk }, name: :layer_down_day,  units: :kwh },
+          { data: ->{ percent_change(lu23s1_pppk, lu23s1_cppk, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          # CO2
+          { data: ->{ lu23s1_pppc }, name: :previous_day, units: :co2 },
+          { data: ->{ lu23s1_cppc }, name: :layer_down_day,  units: :co2 },
+          { data: ->{ percent_change(lu23s1_pppc, lu23s1_cppc, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+          # £
+          { data: ->{ lu23s1_ppp£ }, name: :previous_day, units: :£ },
+          { data: ->{ lu23s1_cpp£ }, name: :layer_down_day,  units: :£ },
+          { data: ->{ percent_change(lu23s1_ppp£, lu23s1_cpp£, true) }, name: :change_pct, units: :relative_percent_0dp },
+
+        ],
+        column_groups: [
+          { name: '',         span: 1 },
+          { name: :kwh,      span: 3 },
+          { name: :co2_kg, span: 3 },
+          { name: :cost,     span: 3 }
+        ],
+        where:   ->{ !lu23s1_ppp£.nil? },
+        sort_by:  [9],
+        type: %i[table],
+        admin_only: true
+      }
     }.freeze
   end
 end

--- a/lib/dashboard/benchmarking/benchmark_content_general.rb
+++ b/lib/dashboard/benchmarking/benchmark_content_general.rb
@@ -894,4 +894,42 @@ module Benchmarking
   class BenchmarkJanAugust20222023ComparisonStorageHeaterTable < BenchmarkChangeAdhocComparisonGasTable
     include BenchmarkingNoTextMixin
   end
+
+  #========================================================================================
+  class BenchmarkLayerUpPowerDownDay2023Comparison < BenchmarkChangeAdhocComparison
+
+    def electricity_content(school_ids:, filter:)
+      extra_content(:layer_up_powerdown_day_november_2023_electricity_table, filter: filter)
+    end
+
+    def gas_content(school_ids:, filter:)
+      extra_content(:layer_up_powerdown_day_november_2023_gas_table, filter: filter)
+    end
+
+    def storage_heater_content(school_ids:, filter:)
+      extra_content(:layer_up_powerdown_day_november_2023_storage_heater_table, filter: filter)
+    end
+
+    private def introduction_text
+      text = I18n.t('analytics.benchmarking.content.layer_up_powerdown_day_november_2023.introduction_text_html')
+      ERB.new(text).result(binding)
+    end
+
+  end
+
+  class BenchmarkLayerUpPowerDownDay2023ComparisonElectricityTable < BenchmarkContentBase
+    include BenchmarkingNoTextMixin
+  end
+
+  class BenchmarkLayerUpPowerDownDay2023ComparisonGasTable < BenchmarkContentBase
+    include BenchmarkingNoTextMixin
+
+    private def introduction_text
+      I18n.t('analytics.benchmarking.content.benchmark_layer_up_powerdown_day_november_2023_gas_table.introduction_text')
+    end
+  end
+
+  class BenchmarkLayerUpPowerDownDay2023ComparisonStorageHeaterTable < BenchmarkChangeAdhocComparisonGasTable
+    include BenchmarkingNoTextMixin
+  end
 end

--- a/script/standard/test_benchmarks.rb
+++ b/script/standard/test_benchmarks.rb
@@ -8,7 +8,7 @@ module Logging
   logger.level = :error
 end
 
-run_date = Date.new(2023,11,28)
+run_date = Date.new(2023,12,5)
 
 overrides = {
   schools: ['*'], # ['king-ja*', 'crook*', 'hunw*', 'combe*'], # ['king-james-e*', 'wyb*', 'batheas*', 'the-dur*'], # ['shrew*', 'bathamp*'],
@@ -17,7 +17,7 @@ overrides = {
     calculate_and_save_variables: true,
     asof_date: run_date,
     pages: %i[
-      jan_august_2022_2023_energy_comparison
+      layer_up_powerdown_day_november_2023
     ],
     run_content: { asof_date: run_date } # , filter: ->{ !gpyc_difp.nil? && !gpyc_difp.infinite?.nil? } }
   }

--- a/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
+++ b/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
@@ -77,7 +77,8 @@ describe Benchmarking::BenchmarkManager, type: :service do
             description: 'These benchmarks compare schools performance across specific date ranges.',
             benchmarks: {
               change_in_energy_use_since_joined_energy_sparks: 'Change in energy use since the school joined Energy Sparks',
-              jan_august_2022_2023_energy_comparison: 'Jan to August 2022 to 2023 energy use'
+              jan_august_2022_2023_energy_comparison: 'Jan to August 2022 to 2023 energy use',
+              layer_up_powerdown_day_november_2023: 'Change in energy for layer up power down day 24 November 2023 (compared with 17 November 2023)'
             }
           }
         ]
@@ -156,7 +157,8 @@ describe Benchmarking::BenchmarkManager, type: :service do
             description: 'These benchmarks compare schools performance across specific date ranges.',
             benchmarks: {
               change_in_energy_use_since_joined_energy_sparks: 'Change in energy use since the school joined Energy Sparks',
-              jan_august_2022_2023_energy_comparison: 'Jan to August 2022 to 2023 energy use'
+              jan_august_2022_2023_energy_comparison: 'Jan to August 2022 to 2023 energy use',
+              layer_up_powerdown_day_november_2023: 'Change in energy for layer up power down day 24 November 2023 (compared with 17 November 2023)'
             }
           }
         ]


### PR DESCRIPTION
This PR:

- Defines the three alerts required to calculate the comparisons between energy usage on 2023-11-24 as compared with 2023-11-17, giving them a unique prefix
- Declares a new school comparison benchmark which uses the variables from those alerts to build the required table and charts
- Adds additional column headings for the table

Tested locally using the analytics test framework to confirm that the benchmarks run with a range of schools.