### PR TITLE
Fix tariff changed column naming

### DIFF
--- a/lib/dashboard/benchmarking/benchmark_content_base.rb
+++ b/lib/dashboard/benchmarking/benchmark_content_base.rb
@@ -188,11 +188,11 @@ module Benchmarking
 
     def includes_tariff_changed_column?(school_ids, filter, user_type)
       cols = column_headings(school_ids, filter, user_type)
-      cols.any?{ |col_name| col_name == :tariff_changed }
+      cols.any?{ |col_name| col_name == tariff_changed_column_name }
     end
 
     def tariff_has_changed?(school_ids, filter, user_type)
-      col_index = column_headings(school_ids, filter, user_type).index(:tariff_changed)
+      col_index = column_headings(school_ids, filter, user_type).index(tariff_changed_column_name)
       return false if col_index.nil?
 
       data = raw_data(school_ids, filter, user_type)
@@ -201,6 +201,10 @@ module Benchmarking
       tariff_changes = data.map { |row| row[col_index] }
 
       tariff_changes.any?
+    end
+
+    def tariff_changed_column_name
+      I18n.t("analytics.benchmarking.configuration.column_headings.#{:tariff_changed}")
     end
 
     def tariff_changed_explanation(school_ids, filter, user_type)
@@ -212,4 +216,3 @@ module Benchmarking
     end
   end
 end
-


### PR DESCRIPTION
There's some code in the benchmark content manager that decides whether to add the footnote about the school tariffs having changed. While the tables that are produced include a reference to the footnote, they footnote itself isn't displaying.

The issue is that the code is still looking for a column named with a symbol, but since the translation work all the column names get looked up and converted into strings. 

This PR changes code that references `:tariff_changed` to look for the translation instead: `I18n.t("analytics.benchmarking.configuration.column_headings.#{:tariff_changed}")`.

This causes the footnotes to appear properly.

Tested using the analytics test_benchmarks.rb script. Output:

![Screenshot from 2023-12-06 16-32-49](https://github.com/Energy-Sparks/energy-sparks_analytics/assets/109082/db2fcc3f-e9d3-4c41-b042-dbb43ab9bd46)
