### PR TITLE
Revise optimum start time analysis

### DIFF
--- a/lib/dashboard/modelling/heating/heating_regression_models.rb
+++ b/lib/dashboard/modelling/heating/heating_regression_models.rb
@@ -898,7 +898,11 @@ module AnalyseHeatingAndHotWater
       }
       interpolation = Interpolate::Points.new(optimum_start_regression)
       start_time = interpolation.at(temperature)
-      [TimeOfDay.time_of_day_from_halfhour_index(start_time * 2.0), (start_time * 2).to_i]
+      #previously we calculated time of day using start_time * 2.0. but this produces overly
+      #precise timings, e.g. 05.02, 03:57, 03:38, which we can't confidently use or display
+      #to users. So we now round to the half-hourly index, which aligns better with our
+      #prediction of when heating is on, which is only to an hh index.
+      [TimeOfDay.time_of_day_from_halfhour_index((start_time * 2).to_i), (start_time * 2).to_i]
     end
 
     def model_configuration_pairs_format

--- a/spec/lib/dashboard/modelling/heating/analyse_heating_and_hot_water/heating_model_temperature_space_spec.rb
+++ b/spec/lib/dashboard/modelling/heating/analyse_heating_and_hot_water/heating_model_temperature_space_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe AnalyseHeatingAndHotWater::HeatingModelTemperatureSpace do
+  # testing private method directly not ideal, but makes it easier to
+  # test variety of options, pending further refactoring of the heating model
+  # code
+  describe '#recommended_optimum_start_time' do
+    let(:meter) { build(:meter, type: :gas) }
+    let(:model_overrides) { {} }
+
+    let(:heating_model) { AnalyseHeatingAndHotWater::HeatingModelTemperatureSpace.new(meter, model_overrides) }
+
+    it 'returns expected half-hourly values' do
+      expect(heating_model.send(:recommended_optimum_start_time, nil, 3.0)).to eq [TimeOfDay.new(0, 0), 0]
+      expect(heating_model.send(:recommended_optimum_start_time, nil, 4.0)).to eq [TimeOfDay.new(3, 30), 7]
+      expect(heating_model.send(:recommended_optimum_start_time, nil, 10.0)).to eq [TimeOfDay.new(6, 30), 13]
+
+      expect(heating_model.send(:recommended_optimum_start_time, nil, 4.9)).to eq [TimeOfDay.new(3, 30), 7]
+      expect(heating_model.send(:recommended_optimum_start_time, nil, 7.1)).to eq [TimeOfDay.new(5, 0), 10]
+    end
+  end
+end


### PR DESCRIPTION
We provide an estimate of when a school should switch their heating on, we run a simple interpolation using temperature to half-hourly index. E.g. at 4.0C we recommend 3.30am, at 10.0C we recommend 6.30am and then interpolated times across that range

This means the code currently returns some very precise recommendations, e.g. 05.02am which we can't really be confident about using or displaying to users.

This PR changes the code so that after interpolation we use the half-hourly period for the interpolated time. So e.g. 05.02am is 05:00am, 3:38am becomes 3:30am, 3:57am becomes 3:30am, etc.

This means that some times may end up leading to slightly higher estimates as we're calculating cost savings across nearly a half hour rather than a few minutes, but these are only estimates anyway. For the annual savings it will likely round out.

Am testing the private method directly here as its tricky to otherwise setup a heating model. So wanted to be confident in the basic change.