### PR TITLE
Remove appending of partial year to time description

### DIFF
--- a/lib/dashboard/charting_and_reports/charts/aggregator_multi_schools_periods.rb
+++ b/lib/dashboard/charting_and_reports/charts/aggregator_multi_schools_periods.rb
@@ -101,8 +101,7 @@ class AggregatorMultiSchoolsPeriods < AggregatorBase
         time_description = number_of_periods <= 1 ? '' : time_description
         results.bucketed_data[      time_description] = period_data.results.bucketed_data.values[0]
         results.bucketed_data_count[time_description] = period_data.results.bucketed_data_count.values[0]
-      else      
-        time_description += "- partial year (from #{period_data.results[0]})" if period_data.results.x_axis.length < results.x_axis.length
+      else
         keys = period_data.results.x_axis.map{ |month_year| month_year[0..2]}
 
         new_x_data = results.x_axis.map do |month|


### PR DESCRIPTION
When producing charts that have 2 years of data, if there's not a full previous year the analytics is attempting to annotate the series name to indicate there's a partial year.

This is breaking as there's a bug in the code (`period_data.results[0]` is not correct, it would be `period_data.x_axis[0]`) so the chart fails to display. 

But the appended text isn't internationalised and in fact doesn't improve the chart display as the date range is already:

Fixed version:

![Screenshot from 2023-12-13 11-10-40](https://github.com/Energy-Sparks/energy-sparks_analytics/assets/109082/06ef9624-82b1-4f77-8381-690e8ff03c50)

I've instead just removed the annotation. This avoids need to internationalise the series name further and is still readable I think. This is the bug fixed version:

![Screenshot from 2023-12-13 11-11-10](https://github.com/Energy-Sparks/energy-sparks_analytics/assets/109082/329164e1-a627-4258-a969-0a33359fc0ff)

I've not wrapped this in tests as I'm not sure how to create the necessary setup to exercise this currently. So I've just tested and fixed manually.