### PR TITLE
Qualify series names for meter breakdown charts

### DIFF
--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -15,7 +15,7 @@ module Dashboard
     attr_reader :constituent_meters
 
     # Energy Sparks activerecord fields:
-    attr_reader :active, :created_at, :meter_no, :meter_type, :school, :updated_at, :mpan_mprn, :dcc_meter
+    attr_reader :active, :created_at, :meter_type, :school, :updated_at, :mpan_mprn, :dcc_meter
     attr_accessor :id, :name, :external_meter_id
     # enum meter_type: [:electricity, :gas]
 
@@ -59,10 +59,6 @@ module Dashboard
     def set_meter_attributes(meter_attributes)
       @meter_attributes = meter_attributes
       process_meter_attributes
-    end
-
-    def amr_data=(amr_data)
-      @amr_data = amr_data
     end
 
     def set_mpan_mprn_id(identifier)
@@ -321,32 +317,31 @@ module Dashboard
       [:electricity, :solar_pv, :aggregated_electricity].include?(fuel_type)
     end
 
-    def set_meter_no(meter_no)
-      @meter_no = meter_no
-    end
-
     def insert_correction_rules_first(rules)
       @meter_correction_rules = rules + @meter_correction_rules
     end
 
     # Matches ES AR version
     def display_name
-      name.present? ? "#{meter_no} (#{name})" : display_meter_number
+      name.present? ? "#{mpan_mprn} (#{name})" : mpan_mprn.to_s
     end
 
+    #Default series name for this meter when displayed on a chart
     def series_name
-      name.present? ? name : mpxn.to_s
+      name.present? ? name : mpan_mprn.to_s
+    end
+
+    #Used to create a qualified series name for charts, when 2 meters for
+    #this school have the same name.
+    def qualified_series_name
+      name.present? ? "#{name} (#{mpan_mprn})" : mpan_mprn.to_s
     end
 
     def analytics_name
-      return mpxn.to_s unless name.present?
+      return mpan_mprn.to_s unless name.present?
 
-      bracketed_text = name.include?(mpxn.to_s) ? 'MPAN' : mpxn.to_s
+      bracketed_text = name.include?(mpan_mprn.to_s) ? 'MPAN' : mpxn.to_s
       "#{name} (#{bracketed_text})"
-    end
-
-    def display_meter_number
-      meter_no.present? ? meter_no : mpan_mprn.to_s
     end
 
     def synthetic_mpan_mprn?

--- a/spec/factories/meter_collection_factory.rb
+++ b/spec/factories/meter_collection_factory.rb
@@ -42,5 +42,27 @@ FactoryBot.define do
       with_electricity_meter
       with_gas_meter
     end
+
+    trait :with_aggregate_meter do
+      transient do
+        fuel_type { :electricity }
+      end
+      after(:build) do |meter_collection, evaluator|
+        amr_data = build(:amr_data, :with_date_range, start_date: evaluator.start_date, end_date: evaluator.end_date)
+        meter = build(:meter, meter_collection: meter_collection, type: evaluator.fuel_type, amr_data: amr_data)
+        meter_collection.set_aggregate_meter(evaluator.fuel_type, meter)
+      end
+    end
+
+    trait :with_electricity_meters do
+      transient do
+        meters { [] }
+      end
+      after(:build) do |meter_collection, evaluator|
+        evaluator.meters.each do |m|
+          meter_collection.add_electricity_meter(m)
+        end
+      end
+    end
   end
 end

--- a/spec/lib/dashboard/charting_and_reports/charts/series/meter_breakdown_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/series/meter_breakdown_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Series::MeterBreakdown do
+  let(:meters) { build_list(:meter, 3) }
+  let(:meter_collection) { build(:meter_collection, :with_aggregate_meter, :with_electricity_meters, meters: meters) }
+
+  let(:chart_config) do
+    {
+      meter_definition: :allelectricity,
+      series_breakdown: :meter
+    }
+  end
+
+  subject(:series_manager) do
+    Series::MeterBreakdown.new(meter_collection, chart_config)
+  end
+
+  describe '#series_name' do
+    context 'when meters have unique names' do
+      it 'uses meter series names' do
+        expect(series_manager.series_names).to match_array(meters.map(&:series_name))
+      end
+    end
+
+    context 'when meters have duplicate names' do
+      let(:meter_1) { build(:meter, name: 'Duplicate') }
+      let(:meter_2) { build(:meter, name: 'Duplicate') }
+      let(:meter_3) { build(:meter) }
+      let(:meters)  { [meter_1, meter_2, meter_3] }
+
+      it 'adjusts the individual series names' do
+        expect(series_manager.series_names).to contain_exactly(meter_1.qualified_series_name, meter_2.qualified_series_name, meter_3.series_name)
+      end
+    end
+  end
+end

--- a/spec/lib/dashboard/charting_and_reports/charts/series/meter_breakdown_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/series/meter_breakdown_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 
 describe Series::MeterBreakdown do
+  subject(:series_manager) do
+    Series::MeterBreakdown.new(meter_collection, chart_config)
+  end
+
   let(:meters) { build_list(:meter, 3) }
   let(:meter_collection) { build(:meter_collection, :with_aggregate_meter, :with_electricity_meters, meters: meters) }
 
@@ -11,10 +15,6 @@ describe Series::MeterBreakdown do
       meter_definition: :allelectricity,
       series_breakdown: :meter
     }
-  end
-
-  subject(:series_manager) do
-    Series::MeterBreakdown.new(meter_collection, chart_config)
   end
 
   describe '#series_name' do


### PR DESCRIPTION
There are a variety of "series manager" classes that are responsible for building the time series that are added to charts. The `MeterBreakdown` series is responsible for building series for charts that graph data for individual meters.

Currently there's a bug as if multiple meters of the same fuel type have the same name, then one series overwrites the others. This was introduced when we simplified the series names for meters to use the user supplied name rather than always including the MPAN/MPRNs.

This PR fixes that issues by qualifying the series names to add the MPAN/MPRN if there's a naming clash.

I've also slightly reworked a few naming/labeling methods on the `Dashboard::Meter` class. There as a `meter_no` attribute which was used to conditionally build names, but its not being set anywhere in the code. So probably a hold-over from earlier versions. Have removed it and simplified the methods.