### PR TITLE
Fix navigation issues on weekly breakdown charts

### DIFF
--- a/lib/dashboard/charting_and_reports/charts/chart_timescale_manipulation.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_timescale_manipulation.rb
@@ -204,6 +204,10 @@ class ChartManagerTimescaleManipulation
     type == :optimum_start ? 5 : 1
   end
 
+  private def weekly_x_axis?(chart_config)
+   chart_config.key?(:x_axis) && chart_config[:x_axis] == :week
+  end
+
   private def available_periods_by_type(chart_config_original)
     start_date, end_date = determine_chart_range(chart_config_original)
     timescale_type, value = timescale_type(chart_config_original)
@@ -211,9 +215,11 @@ class ChartManagerTimescaleManipulation
     when :year
       ((end_date - start_date + 1) / 365.0).floor
     when :up_to_a_year
-      # Replaced older logic to allow dashboard charts to navigate through the entire
-      # range of data.
-      Holidays.periods_cadence(start_date, end_date, include_partial_period: true).count
+      #allow navigation back to partial years
+      #aligning with saturday boundays ensures code is in sync with UpToAYearPeriods
+      move_to_saturday_boundary = weekly_x_axis?(chart_config_original) ? true : false
+      minimum_days = weekly_x_axis?(chart_config_original) ? 7 : nil
+      Holidays.periods_cadence(start_date, end_date, include_partial_period: true, move_to_saturday_boundary: move_to_saturday_boundary, minimum_days: minimum_days).count
     when :academicyear
       @school.holidays.academic_years(start_date, end_date).length
     when :workweek

--- a/lib/dashboard/charting_and_reports/charts/chart_timescale_manipulation.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_timescale_manipulation.rb
@@ -216,7 +216,7 @@ class ChartManagerTimescaleManipulation
       ((end_date - start_date + 1) / 365.0).floor
     when :up_to_a_year
       #allow navigation back to partial years
-      #aligning with saturday boundays ensures code is in sync with UpToAYearPeriods
+      #aligning with saturday boundarys ensures code is in sync with UpToAYearPeriods
       move_to_saturday_boundary = weekly_x_axis?(chart_config_original) ? true : false
       minimum_days = weekly_x_axis?(chart_config_original) ? 7 : nil
       Holidays.periods_cadence(start_date, end_date, include_partial_period: true, move_to_saturday_boundary: move_to_saturday_boundary, minimum_days: minimum_days).count

--- a/lib/dashboard/charting_and_reports/charts/x_axis_bucketor.rb
+++ b/lib/dashboard/charting_and_reports/charts/x_axis_bucketor.rb
@@ -162,7 +162,6 @@ class XBucketWeek < XBucketBase
     first_day_of_period = data_start_date
     # move to next Sunday boundaries so holiday/weekend bucketing looks ok
     @first_sunday = first_day_of_period + ((7 - first_day_of_period.wday) % 7)
-
     @key_string = "%d %b %Y"
   end
 
@@ -177,9 +176,6 @@ class XBucketWeek < XBucketBase
   end
 
   def create_x_axis
-    puts "First sunday: #{@first_sunday}"
-    puts "data_end_date: #{data_end_date}"
-    puts "data_start_date: #{data_start_date}"
     (@first_sunday..data_end_date).step(7) do |date|
       if date + 6 <= data_end_date # make sure it use the final week if partial
         @x_axis_bucket_date_ranges.push([date, date + 6])

--- a/lib/dashboard/charting_and_reports/charts/x_axis_bucketor.rb
+++ b/lib/dashboard/charting_and_reports/charts/x_axis_bucketor.rb
@@ -162,6 +162,7 @@ class XBucketWeek < XBucketBase
     first_day_of_period = data_start_date
     # move to next Sunday boundaries so holiday/weekend bucketing looks ok
     @first_sunday = first_day_of_period + ((7 - first_day_of_period.wday) % 7)
+
     @key_string = "%d %b %Y"
   end
 
@@ -176,6 +177,9 @@ class XBucketWeek < XBucketBase
   end
 
   def create_x_axis
+    puts "First sunday: #{@first_sunday}"
+    puts "data_end_date: #{data_end_date}"
+    puts "data_start_date: #{data_start_date}"
     (@first_sunday..data_end_date).step(7) do |date|
       if date + 6 <= data_end_date # make sure it use the final week if partial
         @x_axis_bucket_date_ranges.push([date, date + 6])

--- a/lib/dashboard/data_sources/utilities/holidays.rb
+++ b/lib/dashboard/data_sources/utilities/holidays.rb
@@ -401,7 +401,6 @@ class Holidays
     [saturday - 6, saturday, week_count]
   end
 
-  # was originally included in ActiveSupport code base, may be lost in rails integration
   # not sure whether it includes current Saturday, assume not, so if date is already a Saturday, returns date - 7
   def self.nearest_previous_saturday(date)
     date - (date.wday + 1)
@@ -477,7 +476,7 @@ class Holidays
   def self.periods_cadence(start_date, end_date, cadence_days: 52.0 * 7.0, include_partial_period: false, move_to_saturday_boundary: false, minimum_days: nil)
 
     last_date_of_period = end_date
-    # move to previous Saturday, so last date a Saturday - better for getting weekends and holidays on right boundaries
+    # move to previous Saturday, so last date always Saturday - better for getting weekends and holidays on right boundaries
     if move_to_saturday_boundary
       last_date_of_period = last_date_of_period.saturday? ? last_date_of_period : nearest_previous_saturday(last_date_of_period)
     end

--- a/lib/dashboard/data_sources/utilities/holidays.rb
+++ b/lib/dashboard/data_sources/utilities/holidays.rb
@@ -473,12 +473,13 @@ class Holidays
     yrs_to_date
   end
 
-  def self.periods_cadence(start_date, end_date, cadence_days: 52.0 * 7.0, include_partial_period: false, move_to_saturday_boundary: false)
+  #Currently only used by the ChartManagerTimescaleManipulation and UpToAYearPeriods
+  def self.periods_cadence(start_date, end_date, cadence_days: 52.0 * 7.0, include_partial_period: false, move_to_saturday_boundary: false, minimum_days: nil)
 
     last_date_of_period = end_date
     # move to previous Saturday, so last date a Saturday - better for getting weekends and holidays on right boundaries
     if move_to_saturday_boundary
-      last_date_of_period =nearest_previous_saturday(last_date_of_period)
+      last_date_of_period = last_date_of_period.saturday? ? last_date_of_period : nearest_previous_saturday(last_date_of_period)
     end
 
     days = last_date_of_period - start_date + 1
@@ -487,16 +488,20 @@ class Holidays
     whole_periods = include_partial_period ? periods.ceil : periods.floor
 
     i = -1
+
     period_index_list = Array.new(whole_periods){ i += 1 }
 
     period_dates = period_index_list.map { |v| [[last_date_of_period - (v + 1) * cadence_days + 1, start_date].max, last_date_of_period - v * cadence_days] }
 
     cadence = "cadence_#{cadence_days.to_i}_days".to_sym
 
-    period_dates.map.with_index do |period_range, period|
+    periods = period_dates.map.with_index do |period_range, period|
       description = "period #{-period} cadence #{cadence_days}"
       SchoolDatePeriod.new(cadence, description, period_range[0], period_range[1])
     end
+
+    periods.reject! {|period| period.days < minimum_days } if minimum_days
+    periods
   end
 
   # differs from 'year_to_date' as datum (0) if first whole year before activation

--- a/spec/lib/dashboard/utilities/holidays_spec.rb
+++ b/spec/lib/dashboard/utilities/holidays_spec.rb
@@ -9,7 +9,7 @@ describe Holidays do
     let(:minimum_days) { nil }
 
     let(:periods) do
-      Holidays.periods_cadence(
+      described_class.periods_cadence(
         start_date,
         end_date,
         include_partial_period: include_partial_period,
@@ -21,10 +21,20 @@ describe Holidays do
     let(:end_date) { Date.new(2024, 1, 1) }
 
     context 'with less than a year' do
-      let(:start_date) { end_date - 30 }
+      let(:start_date) { end_date - 362 }
 
-      it 'returns single period' do
-        expect(periods.length).to eq 0
+      it 'returns no periods' do
+        expect(periods).to be_empty
+      end
+
+      context 'when partial periods allowed' do
+        let(:include_partial_period) { true }
+
+        it 'returns a single period' do
+          expect(periods.length).to eq 1
+          expect(periods[0].start_date).to eq start_date
+          expect(periods[0].end_date).to eq end_date
+        end
       end
     end
 
@@ -33,13 +43,17 @@ describe Holidays do
 
       it 'returns single period' do
         expect(periods.length).to eq 1
+        expect(periods[0].start_date).to eq start_date
+        expect(periods[0].end_date).to eq end_date
       end
 
       context 'when partial periods allowed' do
         let(:include_partial_period) { true }
 
-        it 'returns single periods' do
+        it 'returns a single period' do
           expect(periods.length).to eq 1
+          expect(periods[0].start_date).to eq start_date
+          expect(periods[0].end_date).to eq end_date
         end
       end
     end
@@ -56,6 +70,11 @@ describe Holidays do
 
         it 'returns two periods' do
           expect(periods.length).to eq 2
+          expect(periods[0].start_date).to eq(Date.new(2023, 1, 3))
+          expect(periods[0].end_date).to eq end_date
+
+          expect(periods[1].start_date).to eq(start_date)
+          expect(periods[1].end_date).to eq(Date.new(2023, 1, 2))
         end
 
         context 'with minimum days per period' do
@@ -63,6 +82,8 @@ describe Holidays do
 
           it 'returns a single period' do
             expect(periods.length).to eq 1
+            expect(periods[0].start_date).to eq(Date.new(2023, 1, 3))
+            expect(periods[0].end_date).to eq end_date
           end
         end
       end
@@ -73,6 +94,11 @@ describe Holidays do
 
       it 'returns 2 periods' do
         expect(periods.length).to eq 2
+        expect(periods[0].start_date).to eq(Date.new(2023, 1, 3))
+        expect(periods[0].end_date).to eq end_date
+
+        expect(periods[1].start_date).to eq(Date.new(2022, 1, 4))
+        expect(periods[1].end_date).to eq(Date.new(2023, 1, 2))
       end
     end
 

--- a/spec/lib/dashboard/utilities/holidays_spec.rb
+++ b/spec/lib/dashboard/utilities/holidays_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Holidays do
+  describe '.periods_cadence' do
+    let(:include_partial_period) { false }
+    let(:move_to_saturday_boundary) { false }
+    let(:minimum_days) { nil }
+
+    let(:periods) do
+      Holidays.periods_cadence(
+        start_date,
+        end_date,
+        include_partial_period: include_partial_period,
+        move_to_saturday_boundary: move_to_saturday_boundary,
+        minimum_days: minimum_days
+      )
+    end
+
+    let(:end_date) { Date.new(2024, 1, 1) }
+
+    context 'with less than a year' do
+      let(:start_date) { end_date - 30 }
+
+      it 'returns single period' do
+        expect(periods.length).to eq 0
+      end
+    end
+
+    context 'with 364 days' do
+      let(:start_date) { end_date - 363 }
+
+      it 'returns single period' do
+        expect(periods.length).to eq 1
+      end
+
+      context 'when partial periods allowed' do
+        let(:include_partial_period) { true }
+
+        it 'returns single periods' do
+          expect(periods.length).to eq 1
+        end
+      end
+    end
+
+    context 'with 365 days' do
+      let(:start_date) { end_date - 364 }
+
+      it 'returns single period' do
+        expect(periods.length).to eq 1
+      end
+
+      context 'when partial periods allowed' do
+        let(:include_partial_period) { true }
+
+        it 'returns two periods' do
+          expect(periods.length).to eq 2
+        end
+
+        context 'with minimum days per period' do
+          let(:minimum_days) { 7 }
+
+          it 'returns a single period' do
+            expect(periods.length).to eq 1
+          end
+        end
+      end
+    end
+
+    context 'with 2 years' do
+      let(:start_date) { end_date - 364 * 2.0 }
+
+      it 'returns 2 periods' do
+        expect(periods.length).to eq 2
+      end
+    end
+  end
+end

--- a/spec/lib/dashboard/utilities/holidays_spec.rb
+++ b/spec/lib/dashboard/utilities/holidays_spec.rb
@@ -75,5 +75,32 @@ describe Holidays do
         expect(periods.length).to eq 2
       end
     end
+
+    context 'when moving to saturday' do
+      let(:end_date) { Date.new(2024, 1, 1) }
+      let(:start_date) { Date.new(2023, 12, 2) }
+
+      let(:include_partial_period) { true }
+      let(:move_to_saturday_boundary) { true }
+
+      let(:saturday_before_end_date) { Date.new(2023, 12, 30) }
+
+      it 'returns period ending on the previous saturday' do
+        # saturday before the 1st
+        expect(periods[0].end_date).to eq(saturday_before_end_date)
+        expect(periods[0].start_date).to eq(start_date)
+        expect(periods.length).to eq 1
+      end
+
+      context 'with an end date on a saturday' do
+        let(:end_date) { Date.new(2023, 12, 30) }
+
+        it 'doesnt change the date' do
+          expect(periods[0].end_date).to eq(end_date)
+          expect(periods[0].start_date).to eq(start_date)
+          expect(periods.length).to eq 1
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes 2 issues on the weekly breakdown charts, e.g. as used on the school dashboards:

- navigating backwards to a previous year breaks if there's less than a week's worth of data. If there's more data than that then the chart x-axis automatically adjusts, but with only a few days we can't display the data. Fix involved first ensuring that the same periods calculations are used across the code that decides whether navigation is possible and the code that calculates the x-axis periods. Then a minimum period size was introduced so user isn't given an option to navigate if we can't display the chart

- when we align the weekly series on the chart we use a Sunday-Saturday period. Currently the code just pushes the data back to a saturday without checking if the end date is already as saturday. That means we lose a week on the charts. Updated code to only adjust end date if needed