### PR TITLE
Fix sub_meter series breakdown

### DIFF
--- a/app/services/aggregation_service_solar_pv.rb
+++ b/app/services/aggregation_service_solar_pv.rb
@@ -174,7 +174,7 @@ class AggregateDataServiceSolar
   # Results in the meter having a reference to itself as a mains consumption meter
   # in its Dashboard::Submeters hash?
   def reference_as_sub_meter_for_subsequent_aggregation(mains_electricity_meter)
-    log 'Referencing mains consumption meter {mains_electricity_meter.mpan_mprn} without pv as sub meter for subsequent aggregation'
+    log "Referencing mains consumption meter #{mains_electricity_meter.mpan_mprn} without pv as sub meter for subsequent aggregation"
     mains_electricity_meter.sub_meters[:mains_consume] = mains_electricity_meter
   end
 

--- a/lib/dashboard/charting_and_reports/charts/series_data_manager.rb
+++ b/lib/dashboard/charting_and_reports/charts/series_data_manager.rb
@@ -597,6 +597,7 @@ module Series
     def configure_meters
       @aggregate_meter  = meter
       @component_meters = meter.sub_meters.values
+      @meter_to_series_names = meter_to_series_names
     end
   end
 

--- a/spec/factories/meter_collection_factory.rb
+++ b/spec/factories/meter_collection_factory.rb
@@ -64,5 +64,17 @@ FactoryBot.define do
         end
       end
     end
+
+    trait :with_sub_meters do
+      with_aggregate_meter
+
+      transient do
+        sub_meters { {} }
+      end
+      after(:build) do |meter_collection, evaluator|
+        aggregate_meter = meter_collection.aggregate_meter(evaluator.fuel_type)
+        aggregate_meter.sub_meters.merge!(evaluator.sub_meters)
+      end
+    end
   end
 end

--- a/spec/lib/dashboard/charting_and_reports/charts/series/sub_meter_breakdown_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/series/sub_meter_breakdown_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Series::SubMeterBreakdown do
+  subject(:series_manager) do
+    Series::SubMeterBreakdown.new(meter_collection, chart_config)
+  end
+
+  let(:meters)      { build_list(:meter, 3) }
+  let(:sub_meters)  { {} }
+  let(:meter_collection) { build(:meter_collection, :with_electricity_meters, :with_sub_meters, meters: meters, sub_meters: sub_meters) }
+
+  let(:chart_config) do
+    {
+      meter_definition: :allelectricity,
+      series_breakdown: :meter
+    }
+  end
+
+  describe '#series_name' do
+    context 'when there are no sub_meters' do
+      let(:sub_meters) { { mains_consume: build(:meter) } }
+
+      it 'uses meter series names' do
+        expect(series_manager.series_names).to match_array(sub_meters.values.map(&:series_name))
+      end
+    end
+
+    context 'when there are solar sub_meters' do
+      let(:sub_meters) do
+        {
+          mains_consume: build(:meter),
+          generation: build(:meter),
+          self_consume: build(:meter),
+          export: build(:meter)
+        }
+      end
+
+      it 'uses all meter series names' do
+        expect(series_manager.series_names).to match_array(sub_meters.values.map(&:series_name))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix the SubMeter series breakdown.

The sub class overrides the method to configure the meters used on the chart, but when making my other change I hadn't added the call to initialise the map of meters to series names.

Added a spec to expose the error. 

When a school doesn't have solar, then their individual meters will reference themselves as a sub_meter. When they do have solar then the aggregate meter will reference the individual submeters that capture the solar generation, export, self consumption, etc.