### PR TITLE
Remove gas specific estimation of historical usage for targets

### DIFF
--- a/lib/dashboard/modelling/targeting and tracking/target_meter.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_meter.rb
@@ -120,7 +120,13 @@ class TargetMeter < Dashboard::Meter
       TargetMeterMonthlyDayType.new(meter_to_clone)
     when :day
       if meter_to_clone.fuel_type == :gas || storage_heater_fuel_type?(meter_to_clone.fuel_type)
-        TargetMeterTemperatureCompensatedDailyDayTypeMatchWeekendsAndHolidays.new(meter_to_clone)
+        # LD 2024-03-21. Remove gas specific modelling pending further work on the targets
+        # feature. This means instead of estimating the target usage for a day based on the heating model, and
+        # the profile of daily usage based on additional information such as when the heating was on,
+        # we instead just use the same process as electricity: taking the average usage over a few
+        # simialr days in the last year.
+        # TargetMeterTemperatureCompensatedDailyDayTypeMatchWeekendsAndHolidays.new(meter_to_clone)
+        TargetMeterDailyDayType.new(meter_to_clone)
       else
         TargetMeterDailyDayType.new(meter_to_clone)
       end

--- a/lib/dashboard/modelling/targeting and tracking/target_meter.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_meter.rb
@@ -124,7 +124,7 @@ class TargetMeter < Dashboard::Meter
         # feature. This means instead of estimating the target usage for a day based on the heating model, and
         # the profile of daily usage based on additional information such as when the heating was on,
         # we instead just use the same process as electricity: taking the average usage over a few
-        # simialr days in the last year.
+        # similar days in the last year.
         # TargetMeterTemperatureCompensatedDailyDayTypeMatchWeekendsAndHolidays.new(meter_to_clone)
         TargetMeterDailyDayType.new(meter_to_clone)
       else

--- a/lib/dashboard/modelling/targeting and tracking/temperature_compensation_match_weekends_and_holidays.rb
+++ b/lib/dashboard/modelling/targeting and tracking/temperature_compensation_match_weekends_and_holidays.rb
@@ -1,3 +1,4 @@
+# Originally used for gas / storage heater target meters for :day calculations
 class TargetMeterTemperatureCompensatedDailyDayTypeMatchWeekendsAndHolidays < TargetMeterTemperatureCompensatedDailyDayTypeBase
 
   private


### PR DESCRIPTION
As an initial fix for issues with the estimation of gas targets, switch over to always using the basic algorithm we use for electricity meters.

After reviewing a number of schools, this approach produces better overall summary of last years usage, i.e. averages that are closer to the actual consumption for the individual month. 