### PR TITLE
Create new comparison alerts for latest energy sparks competition

### DIFF
--- a/config/locales/benchmarking/content_base.yml
+++ b/config/locales/benchmarking/content_base.yml
@@ -61,6 +61,7 @@ en:
         electricity_targets: Progress against electricity target
         gas_consumption_during_holiday: Gas use during current holiday
         gas_targets: Progress against gas target
+        heat_saver_march_2024: Heat Saver March 2024
         heating_coming_on_too_early: Heating start time
         heating_in_warm_weather: Heating used in warm weather
         holiday_usage_last_year: Cost of energy used in upcoming holiday last year

--- a/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
@@ -274,8 +274,8 @@ end
 module AlertHeatSaver2024BasicConfigMixIn
   def basic_configuration
     {
-      name:                   'Winder Heat Saver Feb-March 2024',
-      max_days_out_of_date:   30,
+      name:                   'Winter Heat Saver Feb-March 2024',
+      max_days_out_of_date:   365,
       enough_days_data:       1,
       current_period:         Date.new(2024, 2, 25)..Date.new(2024, 3, 23),
       previous_period:        Date.new(2023, 2, 26)..Date.new(2023, 3, 25),

--- a/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
@@ -303,10 +303,6 @@ class AlertHeatSaver2024GasComparison < AlertArbitraryPeriodComparisonGasBase
       comparison_chart:       :heat_saver_march_2024_gas_comparison_alert
     }.merge(basic_configuration)
   end
-
-  def calculate(asof_date)
-    super(asof_date)
-  end
 end
 
 class AlertHeatSaver2024StorageHeaterComparison < AlertArbitraryPeriodComparisonStorageHeaterBase

--- a/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_general.rb
@@ -268,3 +268,54 @@ class AlertLayerUpPowerdownNovember2023StorageHeaterComparison < AlertArbitraryP
     }.merge(basic_configuration)
   end
 end
+
+#===================================================================================================
+# Feb/March 2024 competition
+module AlertHeatSaver2024BasicConfigMixIn
+  def basic_configuration
+    {
+      name:                   'Winder Heat Saver Feb-March 2024',
+      max_days_out_of_date:   30,
+      enough_days_data:       1,
+      current_period:         Date.new(2024, 2, 25)..Date.new(2024, 3, 23),
+      previous_period:        Date.new(2023, 2, 26)..Date.new(2023, 3, 25),
+    }
+  end
+end
+
+class AlertHeatSaver2024ElectricityComparison < AlertArbitraryPeriodComparisonElectricityBase
+  include ArbitraryPeriodComparisonMixIn
+  include AlertHeatSaver2024BasicConfigMixIn
+
+  def comparison_configuration
+    {
+      comparison_chart:       :heat_saver_march_2024_electricity_comparison_alert
+    }.merge(basic_configuration)
+  end
+end
+
+class AlertHeatSaver2024GasComparison < AlertArbitraryPeriodComparisonGasBase
+  include ArbitraryPeriodComparisonMixIn
+  include AlertHeatSaver2024BasicConfigMixIn
+
+  def comparison_configuration
+    {
+      comparison_chart:       :heat_saver_march_2024_gas_comparison_alert
+    }.merge(basic_configuration)
+  end
+
+  def calculate(asof_date)
+    super(asof_date)
+  end
+end
+
+class AlertHeatSaver2024StorageHeaterComparison < AlertArbitraryPeriodComparisonStorageHeaterBase
+  include ArbitraryPeriodComparisonMixIn
+  include AlertHeatSaver2024BasicConfigMixIn
+
+  def comparison_configuration
+    {
+      comparison_chart:       :heat_saver_march_2024_storage_heater_comparison_alert
+    }.merge(basic_configuration)
+  end
+end

--- a/lib/dashboard/benchmarking/benchmark_configuration.rb
+++ b/lib/dashboard/benchmarking/benchmark_configuration.rb
@@ -150,7 +150,8 @@ module Benchmarking
       date_limited_comparisons: [
         :change_in_energy_use_since_joined_energy_sparks,
         :jan_august_2022_2023_energy_comparison,
-        :layer_up_powerdown_day_november_2023
+        :layer_up_powerdown_day_november_2023,
+        :heat_saver_march_2024
       ]
     }
 
@@ -2189,7 +2190,10 @@ module Benchmarking
         sort_by:  [9],
         type: %i[table],
         admin_only: true
-      }
+      },
+      heat_saver_march_2024: {
+        admin_only: true
+      } # only implemented in the application
     }.freeze
   end
 end

--- a/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
+++ b/spec/lib/dashboard/benchmarking/benchmark_manager_spec.rb
@@ -78,7 +78,8 @@ describe Benchmarking::BenchmarkManager, type: :service do
             benchmarks: {
               change_in_energy_use_since_joined_energy_sparks: 'Change in energy use since the school joined Energy Sparks',
               jan_august_2022_2023_energy_comparison: 'Jan to August 2022 to 2023 energy use',
-              layer_up_powerdown_day_november_2023: 'Change in energy for layer up power down day 24 November 2023 (compared with 17 November 2023)'
+              layer_up_powerdown_day_november_2023: 'Change in energy for layer up power down day 24 November 2023 (compared with 17 November 2023)',
+              heat_saver_march_2024: 'Heat Saver March 2024'
             }
           }
         ]
@@ -158,7 +159,8 @@ describe Benchmarking::BenchmarkManager, type: :service do
             benchmarks: {
               change_in_energy_use_since_joined_energy_sparks: 'Change in energy use since the school joined Energy Sparks',
               jan_august_2022_2023_energy_comparison: 'Jan to August 2022 to 2023 energy use',
-              layer_up_powerdown_day_november_2023: 'Change in energy for layer up power down day 24 November 2023 (compared with 17 November 2023)'
+              layer_up_powerdown_day_november_2023: 'Change in energy for layer up power down day 24 November 2023 (compared with 17 November 2023)',
+              heat_saver_march_2024: 'Heat Saver March 2024'
             }
           }
         ]


### PR DESCRIPTION
Adds new period comparison alerts and enough of a stubbed out benchmark config to allow the user interface to be built in the application.