### PR TITLE
Add support for additional solar production meters

### DIFF
--- a/app/models/meter_attributes.rb
+++ b/app/models/meter_attributes.rb
@@ -357,7 +357,9 @@ class MeterAttributes
         production_mpan:    MeterAttributeTypes::String.define,
         self_consume_mpan:  MeterAttributeTypes::String.define,
         production_mpan2:   MeterAttributeTypes::String.define(hint: 'for 2nd generation meter'),
-        production_mpan3:   MeterAttributeTypes::String.define(hint: 'for 3rd generation meter')
+        production_mpan3:   MeterAttributeTypes::String.define(hint: 'for 3rd generation meter'),
+        production_mpan4:   MeterAttributeTypes::String.define(hint: 'for 4th generation meter'),
+        production_mpan5:   MeterAttributeTypes::String.define(hint: 'for 5th generation meter')
       }
     )
   end

--- a/app/models/meter_attributes.rb
+++ b/app/models/meter_attributes.rb
@@ -355,7 +355,7 @@ class MeterAttributes
         end_date:           MeterAttributeTypes::Date.define,
         export_mpan:        MeterAttributeTypes::String.define,
         production_mpan:    MeterAttributeTypes::String.define,
-        self_consume_mpan:  MeterAttributeTypes::String.define,
+        self_consume_mpan:  MeterAttributeTypes::String.define(hint: 'currently unsupported'),
         production_mpan2:   MeterAttributeTypes::String.define(hint: 'for 2nd generation meter'),
         production_mpan3:   MeterAttributeTypes::String.define(hint: 'for 3rd generation meter'),
         production_mpan4:   MeterAttributeTypes::String.define(hint: 'for 4th generation meter'),

--- a/app/models/solar_meter_map.rb
+++ b/app/models/solar_meter_map.rb
@@ -2,13 +2,15 @@
 
 require_relative '../../lib/dashboard/utilities/restricted_key_hash'
 # helper class for main solar aggregation service
-# keeps track of the 5 to 7 meters being manipulated
-class PVMap < RestrictedKeyHash
+# keeps track of the meter (between 7-9) meters being manipulated
+class SolarMeterMap < RestrictedKeyHash
   MPAN_KEY_MAPPINGS = {
     export_mpan: :export,
     production_mpan: :generation,
     production_mpan2: :generation2,
-    production_mpan3: :generation3
+    production_mpan3: :generation3,
+    production_mpan4: :generation4,
+    production_mpan5: :generation5
   }.freeze
 
   def self.unique_keys
@@ -17,6 +19,8 @@ class PVMap < RestrictedKeyHash
       generation
       generation2
       generation3
+      generation4
+      generation5
       self_consume
       mains_consume
       mains_plus_self_consume
@@ -29,6 +33,8 @@ class PVMap < RestrictedKeyHash
       generation
       generation2
       generation3
+      generation4
+      generation5
     ]
   end
 
@@ -36,6 +42,8 @@ class PVMap < RestrictedKeyHash
     %i[
       generation2
       generation3
+      generation4
+      generation5
       generation_meter_list
     ]
   end

--- a/app/models/solar_meter_map.rb
+++ b/app/models/solar_meter_map.rb
@@ -48,18 +48,23 @@ class SolarMeterMap < RestrictedKeyHash
     ]
   end
 
-  def self.mpan_maps(mpan_map)
+  # Extract just the meter mappings from a solar_pv_mpan_meter_mapping
+  # meter attribute configuration
+  def self.meter_mappings(mpan_map)
     mpan_map.select { |k, _v| MPAN_KEY_MAPPINGS.key?(k) }
   end
 
-  def self.attribute_map_meter_type(mpan_meter_type)
-    MPAN_KEY_MAPPINGS[mpan_meter_type]
+  # Turn meter attribute key into solar meter type
+  def self.meter_type(meter_attribute_key)
+    MPAN_KEY_MAPPINGS[meter_attribute_key]
   end
 
-  def self.meter_type_attribute_map(meter_type)
+  # Look up meter attribute key for a given solar meter type
+  def self.meter_attribute_key(meter_type)
     MPAN_KEY_MAPPINGS.key(meter_type)
   end
 
+  # Default name for solar meters of a specific type
   def self.meter_type_to_name_map
     {
       export: SolarPVPanels::SOLAR_PV_EXPORTED_ELECTRIC_METER_NAME,
@@ -81,6 +86,7 @@ class SolarMeterMap < RestrictedKeyHash
     count { |k, v| self.class.generation_meters.include?(k) && !v.nil? }
   end
 
+  # TODO rename / replace with more meaningful
   def set_nil_value(list_of_keys)
     list_of_keys.each do |k|
       self[k] = nil

--- a/app/services/aggregation_service_solar_pv.rb
+++ b/app/services/aggregation_service_solar_pv.rb
@@ -418,7 +418,7 @@ class AggregateDataServiceSolar
   # zero, or overridden by the synthetic Sheffield data if set
   def earliest_mpan_mapping_attribute(mains_meter, meter_type)
     mains_meter.attributes(:solar_pv_mpan_meter_mapping).map do |mpan_pv_map|
-      mpan_pv_map[SolarMeterMap.meter_type_attribute_map(meter_type)].nil? ? nil : meter_start_date(mpan_pv_map)
+      mpan_pv_map[SolarMeterMap.meter_attribute_key(meter_type)].nil? ? nil : meter_start_date(mpan_pv_map)
     end.compact.min
   end
 
@@ -496,10 +496,10 @@ class AggregateDataServiceSolar
     return if mappings.nil?
 
     mappings.each do |map|
-      SolarMeterMap.mpan_maps(map).each do |meter_type, mpan|
+      SolarMeterMap.meter_mappings(map).each do |meter_attribute_key, mpan|
         meter = @meter_collection.electricity_meters.find { |meter1| meter1.mpan_mprn.to_s == mpan }
         @meter_collection.electricity_meters.delete_if { |m| m.mpan_mprn.to_s == mpan.to_s }
-        pv_meter_map[SolarMeterMap.attribute_map_meter_type(meter_type)] = meter
+        pv_meter_map[SolarMeterMap.meter_type(meter_attribute_key)] = meter
         truncate_meter_dates(meter, map)
       end
     end

--- a/app/services/aggregation_service_solar_pv.rb
+++ b/app/services/aggregation_service_solar_pv.rb
@@ -20,7 +20,7 @@ class AggregateDataServiceSolar
   #
   # The list will either consist of original meters or a new "mains_plus_self_consume" meter
   def process_solar_pv_electricity_meters
-    log '=' * 80
+    logger.debug { '=' * 80 }
     electricity_meters_only = @electricity_meters.select { |meter| meter.fuel_type == :electricity }
 
     processed_electricity_meters = electricity_meters_only.map do |mains_electricity_meter|
@@ -33,7 +33,7 @@ class AggregateDataServiceSolar
         mains_electricity_meter
       end
     end
-    log '=' * 80
+    logger.debug { '=' * 80 }
     processed_electricity_meters
   end
 
@@ -71,7 +71,7 @@ class AggregateDataServiceSolar
   # @param SolarMeterMap [pv_meter_map] the map.
   # @param Dashboard:Meter representing the mains plus self consumption meter
   def process_solar_pv_electricity_meter(pv_meter_map)
-    log "Aggregation service: processing mains meter #{pv_meter_map[:mains_consume]} with solar pv"
+    logger.debug { "Aggregation service: processing mains meter #{pv_meter_map[:mains_consume]} with solar pv" }
     print_meter_map(pv_meter_map)
 
     aggregate_multiple_generation_meters(pv_meter_map) if pv_meter_map.number_of_generation_meters > 1
@@ -142,12 +142,12 @@ class AggregateDataServiceSolar
 
   # Debugging
   def print_meter_map(pv_meter_map)
-    log 'PV Meter map:'
+    logger.debug { 'PV Meter map:' }
     pv_meter_map.each do |meter_type, meter|
       if meter.is_a?(Array)
-        log "    #{meter_type} => #{meter.map { |m| format_meter(m) }.join('; ')}"
+        logger.debug { "    #{meter_type} => #{meter.map { |m| format_meter(m) }.join('; ')}" }
       else
-        log "    #{format('%-25.25s', meter_type)} -> #{format_meter(meter)}"
+        logger.debug { "    #{format('%-25.25s', meter_type)} -> #{format_meter(meter)}" }
       end
     end
   end
@@ -159,22 +159,16 @@ class AggregateDataServiceSolar
 
   # Debugging
   def print_final_setup(meter)
-    log "Final meter setup for #{meter} total #{meter.amr_data.total.round(0)}"
+    logger.debug { "Final meter setup for #{meter} total #{meter.amr_data.total.round(0)}" }
     meter.sub_meters.each do |meter_type, sub_meter|
-      log "    sub_meter: #{meter_type} => #{sub_meter} name #{sub_meter.name} total #{sub_meter.amr_data.total.round(0)}"
+      logger.debug { "    sub_meter: #{meter_type} => #{sub_meter} name #{sub_meter.name} total #{sub_meter.amr_data.total.round(0)}" }
     end
-  end
-
-  # Debugging
-  def log(str)
-    logger.info str
-    # puts str # "Got here" # comment out for release to production
   end
 
   # Results in the meter having a reference to itself as a mains consumption meter
   # in its Dashboard::Submeters hash?
   def reference_as_sub_meter_for_subsequent_aggregation(mains_electricity_meter)
-    log "Referencing mains consumption meter #{mains_electricity_meter.mpan_mprn} without pv as sub meter for subsequent aggregation"
+    logger.debug { "Referencing mains consumption meter #{mains_electricity_meter.mpan_mprn} without pv as sub meter for subsequent aggregation" }
     mains_electricity_meter.sub_meters[:mains_consume] = mains_electricity_meter
   end
 
@@ -209,7 +203,7 @@ class AggregateDataServiceSolar
   # achieve the same thing
   def create_export_meter(pv_meter_map)
     date_range = pv_meter_map[:mains_consume].amr_data.date_range
-    log "Creating empty export meter between #{date_range.first} and #{date_range.last}"
+    logger.debug { "Creating empty export meter between #{date_range.first} and #{date_range.last}" }
     amr_data = AMRData.create_empty_dataset(:exported_solar_pv, date_range.first, date_range.last, 'SOLE')
     create_modified_meter_copy(
       pv_meter_map[:mains_consume],
@@ -230,7 +224,7 @@ class AggregateDataServiceSolar
   # The values are added in this method, so this relies on the export
   # values having been made negative in previous step.
   def create_and_calculate_self_consumption_meter(pv_meter_map)
-    log 'Creating and calculating self consumption meter'
+    logger.debug { 'Creating and calculating self consumption meter' }
     # take the mains consumption, export and solar pv production
     # meter readings and calculate self consumption =
     # self_consumption = solar pv production - export
@@ -274,11 +268,11 @@ class AggregateDataServiceSolar
   end
 
   def aggregate_multiple_generation_meters(pv_meter_map)
-    log 'Aggregating multiple solar pv generation meters'
+    logger.debug { 'Aggregating multiple solar pv generation meters' }
 
     generation_meters = pv_meter_map.select { |type, meter| SolarMeterMap.generation_meters.include?(type) && !meter.nil? }.values
 
-    log "Aggregating these generation meters #{generation_meters.map(&:to_s).join(' + ')}"
+    logger.debug { "Aggregating these generation meters #{generation_meters.map(&:to_s).join(' + ')}" }
 
     mpan = Dashboard::Meter.synthetic_aggregate_generation_meter(pv_meter_map[:generation].mpan_mprn)
 
@@ -299,7 +293,7 @@ class AggregateDataServiceSolar
       {}
     )
 
-    log "Created aggregate generation meter #{generation_meter} #{generation_meter.amr_data.total.round(0)}"
+    logger.debug { "Created aggregate generation meter #{generation_meter} #{generation_meter.amr_data.total.round(0)}" }
 
     # hide constituent generation meters
     pv_meter_map.set_nil_value(SolarMeterMap.generation_meters)
@@ -319,7 +313,7 @@ class AggregateDataServiceSolar
     meters = %i[mains_consume self_consume export generation mains_plus_self_consume].map { |meter_type| pv_meter_map[meter_type] }
     start_date = meters.map { |m| m.amr_data.start_date }.max
     end_date   = meters.map { |m| m.amr_data.end_date }.min
-    log "Reducing sub meter date ranges to between #{start_date} and #{end_date}"
+    logger.debug { "Reducing sub meter date ranges to between #{start_date} and #{end_date}" }
     meters.each do |meter|
       meter.amr_data.set_start_date(start_date)
       meter.amr_data.set_end_date(end_date)
@@ -374,15 +368,15 @@ class AggregateDataServiceSolar
     pv_meter_map.each do |meter_type, meter|
       next if not_a_meter?(meter) || meter_type == :mains_consume
 
-      log "Mains meter start date #{mains_electricity_meter.amr_data.start_date} pv meter #{meter.mpan_mprn} #{meter.fuel_type} start date #{meter.amr_data.start_date}"
+      logger.debug { "Mains meter start date #{mains_electricity_meter.amr_data.start_date} pv meter  #{meter.mpan_mprn} #{meter.fuel_type} start date #{meter.amr_data.start_date}" }
       raise EnergySparksUnexpectedStateException, "Meter should have been backfilled to #{mains_electricity_meter.amr_data.start_date} but set to #{meter.amr_data.start_date}" if mains_electricity_meter.amr_data.start_date < meter.amr_data.start_date
 
       if meter.amr_data.start_date < mains_electricity_meter.amr_data.start_date
-        log "Truncating meter #{meter.mpan_mprn} to start date of electricity meter #{mains_electricity_meter.amr_data.start_date}"
+        logger.debug { "Truncating meter #{meter.mpan_mprn} to start date of electricity meter #{mains_electricity_meter.amr_data.start_date}" }
         meter.amr_data.set_start_date(mains_electricity_meter.amr_data.start_date)
       end
       if meter.amr_data.end_date > mains_electricity_meter.amr_data.end_date
-        log "Truncating meter #{meter.mpan_mprn} to end date of electricity meter #{mains_electricity_meter.amr_data.end_date}"
+        logger.debug { "Truncating meter #{meter.mpan_mprn} to end date of electricity meter #{mains_electricity_meter.amr_data.end_date}" }
         meter.amr_data.set_end_date(mains_electricity_meter.amr_data.end_date)
       end
     end
@@ -395,7 +389,7 @@ class AggregateDataServiceSolar
   # creates synthetic solar pv metering using 1/2 hour yield data from Sheffield University
   # for schools where we don't have real metering
   def create_solar_pv_sub_meters_using_sheffield_pv_estimates(pv_map)
-    log 'Creating solar PV data from Sheffield PV feed'
+    logger.debug { 'Creating solar PV data from Sheffield PV feed' }
 
     pv_map[:mains_consume].solar_pv_setup.process(pv_map, @meter_collection)
 
@@ -406,8 +400,10 @@ class AggregateDataServiceSolar
     # using 0.10000000001 as LCC seems to have lots of 0.1 values?????
     histo = amr_data.histogram_half_hours_data([-0.10000000001, +0.10000000001])
     negative = histo[0] > (histo[2] * 10) # 90%
-    message = negative ? 'is negative therefore leaving unchanged' : 'is positive therefore inverting to conform to internal convention'
-    logger.info "Export amr pv data #{message}"
+    logger.debug do
+      message = negative ? 'is negative therefore leaving unchanged' : 'is positive therefore inverting to conform to internal convention'
+      "Export amr pv data #{message}"
+    end
     amr_data.scale_kwh(-1.0) unless negative
     amr_data
   end
@@ -440,7 +436,7 @@ class AggregateDataServiceSolar
   def backfill_meter_with_zeros_deprecated(meter, mains_meter_start_date, _mpan_mapping_start_date)
     return if mains_meter_start_date >= meter.amr_data.start_date
 
-    log "Backfilling pv meter #{meter.mpan_mprn} with zeros between #{mains_meter_start_date} and #{meter.amr_data.start_date}"
+    logger.debug { "Backfilling pv meter #{meter.mpan_mprn} with zeros between #{mains_meter_start_date} and #{meter.amr_data.start_date}" }
     (mains_meter_start_date..meter.amr_data.start_date).each do |date|
       meter.amr_data.add(date, OneDayAMRReading.zero_reading(meter.id, date, 'BKPV'))
     end
@@ -452,7 +448,7 @@ class AggregateDataServiceSolar
   def backfill_meter_with_zeros(meter, start_date, end_date)
     return if start_date >= meter.amr_data.start_date
 
-    log "Backfilling pv meter #{meter.mpan_mprn} with zeros between #{start_date} and #{end_date}"
+    logger.debug { "Backfilling pv meter #{meter.mpan_mprn} with zeros between #{start_date} and #{end_date}" }
     (start_date..end_date).each do |date|
       meter.amr_data.add(date, OneDayAMRReading.zero_reading(meter.id, date, 'BKPV'))
     end
@@ -527,10 +523,10 @@ class AggregateDataServiceSolar
     # DEBUGGING, Ignore/remove
     if @apply_scaling_factor_for_debug
       scale_factor = 1.0
-      puts '*' * 50
-      puts "Scaling data by a factor of #{scale_factor} "
+      logger.debug { '*' * 50 }
+      logger.debug { "Scaling data by a factor of #{scale_factor} " }
       pv_meter_map[:generation].amr_data.scale_kwh(scale_factor, date1: am.start_date, date2: am.end_date)
-      puts '*' * 50
+      logger.debug { '*' * 50 }
     end
 
     # Use a customised sub-class of SolarPVPanels
@@ -560,11 +556,11 @@ class AggregateDataServiceSolar
     return if start_date.nil?
 
     if start_date < meter.amr_data.start_date
-      log "Error: solar_pv_mpan_meter_mapping meter attribute start_date #{start_date} < meter start_date #{meter.amr_data.start_date}"
+      logger.debug { "Error: solar_pv_mpan_meter_mapping meter attribute start_date #{start_date} < meter start_date #{meter.amr_data.start_date}" }
     elsif start_date > meter.amr_data.end_date
-      log "Error: solar_pv_mpan_meter_mapping meter attribute start_date #{start_date} > meter end_date #{meter.amr_data.end_date}"
+      logger.debug { "Error: solar_pv_mpan_meter_mapping meter attribute start_date #{start_date} > meter end_date #{meter.amr_data.end_date}" }
     else
-      log "Warning: overriding amr start date to #{start_date} for meter #{meter.mpan_mprn}"
+      logger.debug { "Warning: overriding amr start date to #{start_date} for meter #{meter.mpan_mprn}" }
       meter.amr_data.set_start_date(start_date)
     end
   end
@@ -574,11 +570,11 @@ class AggregateDataServiceSolar
     return if end_date.nil?
 
     if end_date > meter.amr_data.end_date
-      log "Error: solar_pv_mpan_meter_mapping meter attribute end_date #{end_date} > meter end_date #{meter.amr_data.end_date}"
+      logger.debug { "Error: solar_pv_mpan_meter_mapping meter attribute end_date #{end_date} > meter end_date #{meter.amr_data.end_date}" }
     elsif end_date < meter.amr_data.start_date
-      log "Error: solar_pv_mpan_meter_mapping meter attribute end_date #{end_date} < meter start_date #{meter.amr_data.start_date}"
+      logger.debug { "Error: solar_pv_mpan_meter_mapping meter attribute end_date #{end_date} < meter start_date #{meter.amr_data.start_date}" }
     else
-      log "Warning: overriding amr end date to #{end_date} for meter #{meter.mpan_mprn}"
+      logger.debug { "Warning: overriding amr end date to #{end_date} for meter #{meter.mpan_mprn}" }
       meter.amr_data.set_end_date(end_date)
     end
   end

--- a/lib/dashboard/modelling/solar/solar_pv_panels.rb
+++ b/lib/dashboard/modelling/solar/solar_pv_panels.rb
@@ -37,12 +37,12 @@ class SolarPVPanels
   # Main entry point into the service, called as part of the aggregation process.
   # Creates new meters and synthetic data as required.
   #
-  # The provided PVMap might be empty (other than the mains consumption meter) or
+  # The provided SolarMeterMap might be empty (other than the mains consumption meter) or
   # may contain entries from the `solar_pv_mpan_meter_mapping` meter attribute if
   # there is actual metered solar data. In this case we might end up overriding that
   # specific date ranges within that data if configured to do so.
   #
-  # @param [PVMap] pv_meter_map list of meters used for solar calculations
+  # @param [SolarMeterMap] pv_meter_map list of meters used for solar calculations
   # @param [MeterCollection] meter_collection the school whose solar data is being processed
   def process(pv_meter_map, meter_collection)
     #Print debug output. Unused unless @debug_date_range is set
@@ -89,7 +89,7 @@ class SolarPVPanels
   #For an existing meter, may just end up overridding specific days if
   #meter attributes are configured to do so
   #
-  # @param [PVMap] pv_meter_map the solar meters
+  # @param [SolarMeterMap] pv_meter_map the solar meters
   # @param [boolean] create_zero_if_no_config THIS IS ALWAYS FALSE
   def create_generation_data(pv_meter_map, create_zero_if_no_config)
     pv_meter_map[:generation] = create_generation_meter_from_map(pv_meter_map) if pv_meter_map[:generation].nil?
@@ -106,7 +106,7 @@ class SolarPVPanels
     pv_meter_map[:export] = create_export_meter_from_map(pv_meter_map) if pv_meter_map[:export].nil?
   end
 
-  # Calculate or override the solar export data for the export meter in the PVMap
+  # Calculate or override the solar export data for the export meter in the SolarMeterMap
   def create_or_override_export_data(pv_meter_map, meter_collection)
     override_export_data_detail(
       pv_meter_map[:mains_consume].amr_data,
@@ -121,7 +121,7 @@ class SolarPVPanels
     pv_meter_map[:self_consume] = create_self_consumption_meter_from_map(pv_meter_map) if pv_meter_map[:self_consume].nil?
   end
 
-  # Calculate or override the solar self consumption data for the self consumption meter in the PVMap
+  # Calculate or override the solar self consumption data for the self consumption meter in the SolarMeterMap
   def create_self_consumption_data(pv_meter_map, meter_collection)
     calculate_self_consumption_data(
       pv_meter_map[:mains_consume].amr_data,

--- a/spec/app/models/solar_meter_map_spec.rb
+++ b/spec/app/models/solar_meter_map_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SolarMeterMap do
+  let(:solar_pv_mpan_meter_mapping) do
+    {
+      start_date: Date.new(2017, 1, 1),
+      end_date: Date.new(2017, 2, 2),
+      export_mpan: '123456',
+      production_mpan: '10123457',
+      production_mpan2: '20123457',
+      production_mpan3: '30123457',
+      production_mpan4: '40123457',
+      production_mpan5: '50123457',
+      self_consume_mpan: '123458'
+    }
+  end
+
+  describe '.meter_mappings' do
+    it 'returns just the export and production meter mappings' do
+      expect(described_class.meter_mappings(solar_pv_mpan_meter_mapping)).to eq(
+        {
+          export_mpan: '123456',
+          production_mpan: '10123457',
+          production_mpan2: '20123457',
+          production_mpan3: '30123457',
+          production_mpan4: '40123457',
+          production_mpan5: '50123457'
+        }
+      )
+    end
+  end
+
+  describe '.meter_type' do
+    it 'returns the expected values' do
+      expect(described_class.meter_type(:export_mpan)).to eq(:export)
+      expect(described_class.meter_type(:production_mpan)).to eq(:generation)
+      expect(described_class.meter_type(:production_mpan2)).to eq(:generation2)
+      expect(described_class.meter_type(:production_mpan3)).to eq(:generation3)
+      expect(described_class.meter_type(:production_mpan4)).to eq(:generation4)
+      expect(described_class.meter_type(:production_mpan5)).to eq(:generation5)
+    end
+  end
+
+  describe '.meter_attribute_key' do
+    it 'returns the expected values' do
+      expect(described_class.meter_attribute_key(:export)).to eq(:export_mpan)
+      expect(described_class.meter_attribute_key(:generation)).to eq(:production_mpan)
+      expect(described_class.meter_attribute_key(:generation2)).to eq(:production_mpan2)
+      expect(described_class.meter_attribute_key(:generation3)).to eq(:production_mpan3)
+      expect(described_class.meter_attribute_key(:generation4)).to eq(:production_mpan4)
+      expect(described_class.meter_attribute_key(:generation5)).to eq(:production_mpan5)
+    end
+  end
+
+  describe '#number_of_generation_meters' do
+    subject(:solar_meter_map) do
+      SolarMeterMap.instance
+    end
+
+    it 'returns number of generation meters' do
+      expect(solar_meter_map.number_of_generation_meters).to eq(0)
+      solar_meter_map[:generation] = build(:meter)
+      expect(solar_meter_map.number_of_generation_meters).to eq(1)
+      solar_meter_map[:generation2] = build(:meter)
+      solar_meter_map[:generation3] = build(:meter)
+      solar_meter_map[:generation4] = build(:meter)
+      solar_meter_map[:generation5] = build(:meter)
+      expect(solar_meter_map.number_of_generation_meters).to eq(5)
+    end
+  end
+end

--- a/spec/app/services/aggregate_data_service_solar_spec.rb
+++ b/spec/app/services/aggregate_data_service_solar_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe AggregateDataServiceSolar do
+  subject(:service) do
+    described_class.new(meter_collection)
+  end
+
+  let(:meter_collection) do
+    build(:meter_collection)
+  end
+
+  let(:electricity_meter) do
+    build(:meter,
+          meter_collection: meter_collection,
+          type: :electricity, meter_attributes: meter_attributes)
+  end
+
+  context 'when school has metered solar' do
+    subject(:processed_meters) { service.process_solar_pv_electricity_meters }
+
+    let(:meter_attributes) do
+      {
+        solar_pv: [{ start_date: Date.new(2023, 1, 1), kwp: 10.0 }],
+        solar_pv_mpan_meter_mapping: [solar_pv_mpan_meter_mapping]
+      }
+    end
+
+    let(:solar_production_meter) { build(:meter, meter_collection: meter_collection, type: :solar_pv) }
+    let(:solar_pv_mpan_meter_mapping) do
+      {
+        production_mpan: solar_production_meter.mpan_mprn.to_s
+      }
+    end
+
+    let(:meters) { [electricity_meter, solar_production_meter] }
+
+    before do
+      meters.each do |meter|
+        meter_collection.add_electricity_meter(meter)
+      end
+    end
+
+    context 'with only production meter' do
+      it 'returns a single new electricity meter' do
+        expect(processed_meters.length).to eq(1)
+        expect(processed_meters.first.mpan_mprn).to eq(electricity_meter.mpan_mprn)
+        expect(processed_meters.first.meter_type).to eq(:electricity)
+      end
+
+      it 'configures the electricity and production meters as sub meters' do
+        sub_meters = processed_meters.first.sub_meters
+        expect(sub_meters[:mains_consume]).to eq(electricity_meter)
+        expect(sub_meters[:generation]).to eq(solar_production_meter)
+      end
+
+      it 'creates new self consumption and export meters' do
+        sub_meters = processed_meters.first.sub_meters
+        expect(sub_meters[:self_consume]).not_to be_nil
+        expect(sub_meters[:export]).not_to be_nil
+      end
+    end
+
+    context 'with production and export meters' do
+      let(:solar_export_meter) { build(:meter, meter_collection: meter_collection, type: :exported_solar_pv) }
+      let(:solar_pv_mpan_meter_mapping) do
+        {
+          export_mpan: solar_export_meter.mpan_mprn.to_s,
+          production_mpan: solar_production_meter.mpan_mprn.to_s
+        }
+      end
+      let(:meters) { [electricity_meter, solar_production_meter, solar_export_meter] }
+
+      it 'returns a single new electricity meter' do
+        expect(processed_meters.length).to eq(1)
+        expect(processed_meters.first.mpan_mprn).to eq(electricity_meter.mpan_mprn)
+        expect(processed_meters.first.meter_type).to eq(:electricity)
+      end
+
+      it 'configures the electricity, export and production meters as sub meters' do
+        sub_meters = processed_meters.first.sub_meters
+        expect(sub_meters[:mains_consume]).to eq(electricity_meter)
+        expect(sub_meters[:generation]).to eq(solar_production_meter)
+        expect(sub_meters[:export]).to eq(solar_export_meter)
+      end
+
+      it 'creates a new self consumption meter' do
+        sub_meters = processed_meters.first.sub_meters
+        expect(sub_meters[:self_consume]).not_to be_nil
+      end
+    end
+
+    context 'with multiple production meters and no export meter' do
+      let(:solar_production_meters) { build_list(:meter, 5, meter_collection: meter_collection, type: :solar_pv) }
+      let(:solar_pv_mpan_meter_mapping) do
+        {
+          production_mpan: solar_production_meters[0].mpan_mprn.to_s,
+          production_mpan2: solar_production_meters[1].mpan_mprn.to_s,
+          production_mpan3: solar_production_meters[2].mpan_mprn.to_s,
+          production_mpan4: solar_production_meters[3].mpan_mprn.to_s,
+          production_mpan5: solar_production_meters[4].mpan_mprn.to_s
+        }
+      end
+      let(:meters) { solar_production_meters + [electricity_meter] }
+
+      it 'returns a single new electricity meter' do
+        expect(processed_meters.length).to eq(1)
+        expect(processed_meters.first.mpan_mprn).to eq(electricity_meter.mpan_mprn)
+        expect(processed_meters.first.meter_type).to eq(:electricity)
+      end
+
+      it 'configures the electricity meter as a sub meter' do
+        sub_meters = processed_meters.first.sub_meters
+        expect(sub_meters[:mains_consume]).to eq(electricity_meter)
+      end
+
+      it 'creates new self consumption and export meters' do
+        sub_meters = processed_meters.first.sub_meters
+        expect(sub_meters[:self_consume]).not_to be_nil
+        expect(sub_meters[:export]).not_to be_nil
+      end
+
+      it 'creates a new generation meter from the 5 actual meters' do
+        sub_meters = processed_meters.first.sub_meters
+
+        # process creates a new generation meter out of those provided
+        expect(solar_production_meters).not_to include(sub_meters[:generation])
+
+        # uses mpan_mprn of first generation meter
+        expect(sub_meters[:generation].mpan_mprn).to eq(Dashboard::Meter.synthetic_aggregate_generation_meter(solar_production_meters.first.mpan_mprn))
+      end
+    end
+  end
+end

--- a/spec/app/services/aggregate_data_service_solar_spec.rb
+++ b/spec/app/services/aggregate_data_service_solar_spec.rb
@@ -22,7 +22,6 @@ describe AggregateDataServiceSolar do
 
     let(:meter_attributes) do
       {
-        solar_pv: [{ start_date: Date.new(2023, 1, 1), kwp: 10.0 }],
         solar_pv_mpan_meter_mapping: [solar_pv_mpan_meter_mapping]
       }
     end
@@ -30,6 +29,7 @@ describe AggregateDataServiceSolar do
     let(:solar_production_meter) { build(:meter, meter_collection: meter_collection, type: :solar_pv) }
     let(:solar_pv_mpan_meter_mapping) do
       {
+        start_date: Date.new(2023, 1, 1),
         production_mpan: solar_production_meter.mpan_mprn.to_s
       }
     end
@@ -66,6 +66,7 @@ describe AggregateDataServiceSolar do
       let(:solar_export_meter) { build(:meter, meter_collection: meter_collection, type: :exported_solar_pv) }
       let(:solar_pv_mpan_meter_mapping) do
         {
+          start_date: Date.new(2023, 1, 1),
           export_mpan: solar_export_meter.mpan_mprn.to_s,
           production_mpan: solar_production_meter.mpan_mprn.to_s
         }
@@ -95,6 +96,7 @@ describe AggregateDataServiceSolar do
       let(:solar_production_meters) { build_list(:meter, 5, meter_collection: meter_collection, type: :solar_pv) }
       let(:solar_pv_mpan_meter_mapping) do
         {
+          start_date: Date.new(2023, 1, 1),
           production_mpan: solar_production_meters[0].mpan_mprn.to_s,
           production_mpan2: solar_production_meters[1].mpan_mprn.to_s,
           production_mpan3: solar_production_meters[2].mpan_mprn.to_s,

--- a/spec/lib/dashboard/modelling/solar/solar_pv_panels_spec.rb
+++ b/spec/lib/dashboard/modelling/solar/solar_pv_panels_spec.rb
@@ -27,7 +27,7 @@ describe SolarPVPanels, type: :service do
           data_x48: solar_yield)
   end
 
-  let(:pv_meter_map)       { PVMap.new }
+  let(:pv_meter_map)       { SolarMeterMap.new }
 
   let(:is_holiday)         { false }
   let(:holidays)           { double('holidays') }

--- a/spec/meter_attributes_spec.rb
+++ b/spec/meter_attributes_spec.rb
@@ -368,7 +368,11 @@ describe MeterAttributes do
                                           start_date: '1/1/2017',
                                           end_date: '2/2/2017',
                                           export_mpan: '123456',
-                                          production_mpan: '123457',
+                                          production_mpan: '10123457',
+                                          production_mpan2: '20123457',
+                                          production_mpan3: '30123457',
+                                          production_mpan4: '40123457',
+                                          production_mpan5: '50123457',
                                           self_consume_mpan: '123458'
                                         })
       expect(attribute.to_analytics).to eq(
@@ -376,7 +380,11 @@ describe MeterAttributes do
           start_date: Date.new(2017, 1, 1),
           end_date: Date.new(2017, 2, 2),
           export_mpan: '123456',
-          production_mpan: '123457',
+          production_mpan: '10123457',
+          production_mpan2: '20123457',
+          production_mpan3: '30123457',
+          production_mpan4: '40123457',
+          production_mpan5: '50123457',
           self_consume_mpan: '123458'
         }
       )


### PR DESCRIPTION
We support a variety of different solar configurations, including associating multiple sets of solar meters with a single electricity meter which is recording mains consumption.

Currently the code only supports up to 3 solar meters (arrays) for each electricity meter. This PR changes that so we can support up to five.

The functional code change is just to change the configuration of the `solar_pv_mpan_meter_mapping` meter attribute and the "Solar Meter Mapping" class used to manage the collections of meters during the aggregation process, so that it can support additional meters (`production_mpan4`, `production_mpan4` and `generation4`, `generation5`).

In addition to making those changes I've:

- renamed the `PVMap` helper class to `SolarMeterMap`, tidied its public interface and added some specs
- added a spec for `AggregateDataServiceSolar` to provide some basic confirmation that the right types of meters are being created and associated with one another during the aggregation process. This includes checking that up to 5 solar meters are properly aggregated
- I've changed how this class logs to use `logger.debug {...}` style instead of `.info` to reduce noise and number of strings that are created and thrown away

This doesn't give us complete coverage of all the code in `AggregateDataServiceSolar` but is a start