### PR TITLE
Rework how benchmark and exemplar data is injected into charts

### DIFF
--- a/app/services/aggregate_data_service.rb
+++ b/app/services/aggregate_data_service.rb
@@ -94,11 +94,8 @@ class AggregateDataService
       # has been completed and caching can be enabled
       @meter_collection.notify_aggregation_complete!
     end
-    calc_text = "Calculated meter aggregation for |#{format('%-35.35s', @meter_collection.name)}| in |#{bm.round(3)}| seconds"
 
-    puts calc_text unless Object.const_defined?('Rails')
-
-    log calc_text
+    logger.debug { "Calculated meter aggregation for |#{format('%-35.35s', @meter_collection.name)}| in |#{bm.round(3)}| seconds" }
   end
 
   private

--- a/lib/dashboard/charting_and_reports/charts/aggregator.rb
+++ b/lib/dashboard/charting_and_reports/charts/aggregator.rb
@@ -64,6 +64,7 @@ class Aggregator
 
   def unpack_results2(res)
     @bucketed_data, @bucketed_data_count, @x_axis, @x_axis_bucket_date_ranges, @y2_axis, @series_manager, @series_names, @xbucketor, @data_labels, @x_axis_label, @chart_config[:y_axis_label], @last_meter_date = res.unpack2
+    @first_meter_date = multi_school_period_aggregator.min_combined_school_date
     @last_meter_date = multi_school_period_aggregator.max_combined_school_date
   end
 

--- a/lib/dashboard/charting_and_reports/charts/aggregator_benchmarks.rb
+++ b/lib/dashboard/charting_and_reports/charts/aggregator_benchmarks.rb
@@ -1,50 +1,46 @@
-require_relative '../../../../app/services/usage/annual_usage_benchmarks_service.rb'
+require_relative '../../../../app/services/usage/annual_usage_benchmarks_service'
 
-# adds benchmarking data as extra x axis onto benchmark charts
+# For charts configured with:
+#
+# ```
+# inject: :benchmark
+# ```
+#
+# This class will inject additional series based on calculating the usage
+# for an Exemplar of Benchmark ('Well Managed') school with similar characteristics
 class AggregatorBenchmarks < AggregatorBase
-  SCALESPLITCHAR = ':'
-  def self.exemplar_school_name
-    'Exemplar School'
-  end
-
-  def self.benchmark_school_name
-    'Benchmark (Good) School'
-  end
+  EXEMPLAR_SCHOOL_NAME = 'Exemplar School'.freeze
+  BENCHMARK_SCHOOL_NAME = 'Benchmark (Good) School'.freeze
 
   def inject_benchmarks
-    inject_benchmarks_private
-  end
-
-  private
-
-  def inject_benchmarks_private
-    # reverse X axis on benchmarks only following PM/CT request 18Jan2020
     results.reverse_x_axis
 
-    logger.info "Injecting national, regional and exemplar benchmark data: for #{results.bucketed_data.keys}"
+    logger.debug { "Injecting exemplar and well manage schooled benchmark data: for #{results.bucketed_data.keys}" }
 
-    results.x_axis.push(AggregatorBenchmarks.exemplar_school_name)
-    results.x_axis.push(AggregatorBenchmarks.benchmark_school_name)
+    results.x_axis.push(EXEMPLAR_SCHOOL_NAME)
+    results.x_axis.push(BENCHMARK_SCHOOL_NAME)
 
-    most_recent_date_range = results.x_axis_bucket_date_ranges.sort{ |dr1, dr2| dr1.first <=> dr2.first }.last
+    most_recent_date_range = results.x_axis_bucket_date_ranges.sort_by(&:first).last
     asof_date = most_recent_date_range.last
     datatype = @chart_config[:yaxis_units]
 
-    ['electricity', 'gas', Series::MultipleFuels::STORAGEHEATERS].each do |fuel_type_str|
-      if benchmark_required?(fuel_type_str)
-        fuel = fuel_type_str == Series::MultipleFuels::STORAGEHEATERS ? :storage_heaters : fuel_type_str.to_sym
-        set_benchmark_buckets(
-          results.bucketed_data[fuel_type_str],
-          benchmark_data(asof_date, fuel, :exemplar_school,  datatype),
-          benchmark_data(asof_date, fuel, :benchmark_school, datatype),
-        )
-      end
+    [Series::MultipleFuels::ELECTRICITY, Series::MultipleFuels::GAS, Series::MultipleFuels::STORAGEHEATERS].each do |fuel_type_str|
+      next unless benchmark_required?(fuel_type_str)
+
+      fuel = fuel_type_str == Series::MultipleFuels::STORAGEHEATERS ? :storage_heaters : fuel_type_str.to_sym
+      set_benchmark_buckets(
+        results.bucketed_data[fuel_type_str],
+        benchmark_data(asof_date, fuel, :exemplar_school,  datatype),
+        benchmark_data(asof_date, fuel, :benchmark_school, datatype)
+      )
     end
 
-    if benchmark_required?(Series::MultipleFuels::SOLARPV)
-      set_benchmark_buckets(results.bucketed_data[Series::MultipleFuels::SOLARPV], 0.0, 0.0, 0.0)
-    end
+    return unless benchmark_required?(Series::MultipleFuels::SOLARPV)
+
+    set_benchmark_buckets(results.bucketed_data[Series::MultipleFuels::SOLARPV], 0.0, 0.0, 0.0)
   end
+
+  private
 
   def benchmark_required?(fuel_type)
     results.bucketed_data.key?(fuel_type) && results.bucketed_data[fuel_type].is_a?(Array) && results.bucketed_data[fuel_type].sum > 0.0

--- a/script/standard/test_charts.rb
+++ b/script/standard/test_charts.rb
@@ -8,7 +8,7 @@ module Logging
 end
 
 charts = {
-  adhoc: %i[solar_pv_group_by_month]
+  adhoc: %i[benchmark]
 }
 
 no_charts = RunCharts.standard_charts_for_school
@@ -24,7 +24,7 @@ control = {
 }
 
 overrides = {
-  schools:  ['sh*'],
+  schools:  ['acc*'],
   cache_school: false,
   charts:   { charts: charts, control: control }
 }

--- a/spec/factories/meter_collection_factory.rb
+++ b/spec/factories/meter_collection_factory.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
     trait :with_electricity_meter do
       after(:build) do |meter_collection, evaluator|
         amr_data = build(:amr_data, :with_date_range, start_date: evaluator.start_date, end_date: evaluator.end_date)
-        meter = build(:meter, meter_collection: meter_collection, type: :electricity, amr_data: amr_data)
+        meter = build(:meter, :with_flat_rate_tariffs, meter_collection: meter_collection, type: :electricity, amr_data: amr_data, tariff_start_date: evaluator.start_date, tariff_end_date: evaluator.end_date)
         meter_collection.add_electricity_meter(meter)
       end
     end
@@ -35,7 +35,7 @@ FactoryBot.define do
     trait :with_gas_meter do
       after(:build) do |meter_collection, evaluator|
         amr_data = build(:amr_data, :with_date_range, start_date: evaluator.start_date, end_date: evaluator.end_date)
-        meter = build(:meter, meter_collection: meter_collection, type: :gas, amr_data: amr_data)
+        meter = build(:meter, :with_flat_rate_tariffs, meter_collection: meter_collection, type: :gas, amr_data: amr_data, tariff_start_date: evaluator.start_date, tariff_end_date: evaluator.end_date)
         meter_collection.add_heat_meter(meter)
       end
     end

--- a/spec/lib/dashboard/charting_and_reports/charts/aggregator_benchmarks_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/aggregator_benchmarks_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe AggregatorBenchmarks do
+  subject(:aggregator) do
+    described_class.new(meter_collection, chart_config, aggregator_results)
+  end
+
+  let(:chart_config) do
+    {
+      chart1_type: :bar,
+      chart1_subtype: :stacked,
+      meter_definition: :all,
+      x_axis: :year,
+      series_breakdown: :fuel,
+      yaxis_units: :kwh,
+      yaxis_scaling: :none,
+      inject: :benchmark
+    }
+  end
+
+  shared_examples 'the benchmark series have been injected' do |fuels:|
+    it 'adds series to x_axis' do
+      expect(aggregator_results.x_axis).to include(AggregatorBenchmarks.benchmark_school_name)
+      expect(aggregator_results.x_axis).to include(AggregatorBenchmarks.exemplar_school_name)
+    end
+
+    it 'adds calculated usage' do
+      # Should include one non-zero value for each type of benchmark school
+      fuels.each do |fuel|
+        expect(aggregator_results.bucketed_data[fuel].length).to eq(4)
+        expect(aggregator_results.bucketed_data[fuel].all? { |x| x > 0.0 }).to be true
+      end
+    end
+  end
+
+  describe '#inject_benchmarks' do
+    context 'with a single series' do
+      # Sets up the results as they would be following calculation of individual series
+      # in this case, benchmarking usage over 2 years.
+      #
+      # Note: these ignore the meter dates in the meter collection. Those are provided
+      # to allow the calculations to work, the dates here are to just allow us to test
+      # the code in isolation.
+      let(:aggregator_results) do
+        one_year_ago = Date.today - 365
+        AggregatorResults.new(
+          x_axis: %w[this_year last_year],
+          bucketed_data: { series_name => [1000.0, 12_000.0] },
+          x_axis_bucket_date_ranges: [[one_year_ago, Date.today], [one_year_ago - 365, one_year_ago]],
+          bucketed_data_count: { series_name => [1, 1] }
+        )
+      end
+
+      context 'with an electricity series' do
+        let(:meter_collection) do
+          build(:meter_collection, :with_fuel_and_aggregate_meters, fuel_type: :electricity, start_date: Date.new(2023, 1, 1), end_date: Date.new(2023, 12, 31))
+        end
+        before { aggregator.inject_benchmarks }
+
+        let(:series_name) { 'electricity' }
+
+        it_behaves_like 'the benchmark series have been injected', fuels: ['electricity']
+      end
+
+      context 'with a gas series' do
+        let(:meter_collection) do
+          build(:meter_collection, :with_fuel_and_aggregate_meters, fuel_type: :gas, start_date: Date.new(2023, 1, 1), end_date: Date.new(2023, 12, 31))
+        end
+        before { aggregator.inject_benchmarks }
+
+        let(:series_name) { 'gas' }
+
+        it_behaves_like 'the benchmark series have been injected', fuels: ['gas']
+      end
+
+      context 'with a storage heater series' do
+        let(:meter_collection) do
+          build(:meter_collection, :with_fuel_and_aggregate_meters, fuel_type: :electricity, start_date: Date.new(2023, 1, 1), end_date: Date.new(2023, 12, 31), storage_heaters: true)
+        end
+        let(:series_name) { 'storage heaters' }
+
+        before { aggregator.inject_benchmarks }
+
+        it_behaves_like 'the benchmark series have been injected', fuels: ['storage heaters']
+      end
+    end
+  end
+end

--- a/spec/lib/dashboard/charting_and_reports/charts/aggregator_benchmarks_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/aggregator_benchmarks_spec.rb
@@ -22,8 +22,8 @@ describe AggregatorBenchmarks do
 
   shared_examples 'the benchmark series have been injected' do |fuels:|
     it 'adds series to x_axis' do
-      expect(aggregator_results.x_axis).to include(AggregatorBenchmarks.BENCHMARK_SCHOOL_NAME)
-      expect(aggregator_results.x_axis).to include(AggregatorBenchmarks.EXEMPLAR_SCHOOL_NAME)
+      expect(aggregator_results.x_axis).to include(AggregatorBenchmarks::BENCHMARK_SCHOOL_NAME)
+      expect(aggregator_results.x_axis).to include(AggregatorBenchmarks::EXEMPLAR_SCHOOL_NAME)
     end
 
     it 'adds calculated usage' do

--- a/spec/lib/dashboard/charting_and_reports/charts/aggregator_benchmarks_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/aggregator_benchmarks_spec.rb
@@ -22,8 +22,8 @@ describe AggregatorBenchmarks do
 
   shared_examples 'the benchmark series have been injected' do |fuels:|
     it 'adds series to x_axis' do
-      expect(aggregator_results.x_axis).to include(AggregatorBenchmarks.benchmark_school_name)
-      expect(aggregator_results.x_axis).to include(AggregatorBenchmarks.exemplar_school_name)
+      expect(aggregator_results.x_axis).to include(AggregatorBenchmarks.BENCHMARK_SCHOOL_NAME)
+      expect(aggregator_results.x_axis).to include(AggregatorBenchmarks.EXEMPLAR_SCHOOL_NAME)
     end
 
     it 'adds calculated usage' do

--- a/spec/lib/dashboard/charting_and_reports/charts/aggregator_benchmarks_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/aggregator_benchmarks_spec.rb
@@ -86,5 +86,38 @@ describe AggregatorBenchmarks do
         it_behaves_like 'the benchmark series have been injected', fuels: ['storage heaters']
       end
     end
+
+    context 'with two series' do
+      let(:bucketed_data) do
+        {
+          'electricity' => [1000.0, 12_000.0],
+          'gas' => [1000.0, 12_000.0]
+        }
+      end
+
+      let(:aggregator_results) do
+        one_year_ago = Date.today - 365
+        AggregatorResults.new(
+          x_axis: %w[this_year last_year],
+          bucketed_data: bucketed_data,
+          x_axis_bucket_date_ranges: [[one_year_ago, Date.today], [one_year_ago - 365, one_year_ago]],
+          bucketed_data_count: bucketed_data
+        )
+      end
+
+      context 'with a gas and electricity series' do
+        let(:meter_collection) do
+          build(:meter_collection, :with_electricity_and_gas_meters,
+                start_date: Date.new(2023, 1, 1), end_date: Date.new(2023, 12, 31))
+        end
+
+        before do
+          AggregateDataService.new(meter_collection).aggregate_heat_and_electricity_meters
+          aggregator.inject_benchmarks
+        end
+
+        it_behaves_like 'the benchmark series have been injected', fuels: %w[electricity gas]
+      end
+    end
   end
 end

--- a/spec/lib/dashboard/charting_and_reports/charts/aggregator_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/aggregator_spec.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Aggregator do
+  subject(:aggregator) { described_class.new(meter_collection, chart_config) }
+
+  let(:start_date) { Date.new(2020, 1, 1) }
+  let(:end_date)   { Date.new(2023, 12, 31) }
+
+  let(:meter_collection) do
+    build(:meter_collection, :with_electricity_and_gas_meters,
+          start_date: start_date, end_date: end_date)
+  end
+
+  before do
+    AggregateDataService.new(meter_collection).aggregate_heat_and_electricity_meters
+  end
+
+  shared_examples 'a successful calculation' do |y2_axis: false|
+    it 'has a valid result' do
+      expect(aggregator.valid?).to be(true)
+    end
+
+    it 'has populated the results' do
+      expect(aggregator.x_axis).not_to be_nil
+      expect(aggregator.x_axis_bucket_date_ranges).not_to be_nil
+      expect(aggregator.bucketed_data).not_to be_nil
+    end
+
+    it 'has added a y2 axis', if: y2_axis do
+      expect(aggregator.y2_axis).not_to be_nil
+    end
+
+    it 'has used the right meter dates' do
+      expect(aggregator.first_meter_date).to eq(expected_start_date)
+      expect(aggregator.last_meter_date).to eq(expected_end_date)
+    end
+  end
+
+  shared_examples 'a successful benchmark chart' do
+    it 'has added the benchmark school series to the x_axis' do
+      expect(aggregator.x_axis).to include(AggregatorBenchmarks::BENCHMARK_SCHOOL_NAME)
+      expect(aggregator.x_axis).to include(AggregatorBenchmarks::EXEMPLAR_SCHOOL_NAME)
+      expect(aggregator.x_axis.length).to be > 2 # ensure there are other values in series
+    end
+  end
+
+  shared_examples 'a chart broken down by fuel' do
+    it 'broken down results by fuel' do
+      expect(aggregator.bucketed_data.keys).to match_array(expected_fuels)
+    end
+  end
+
+  # 4 years for default start/end
+  shared_examples 'a chart with the right timescale' do |series: 4|
+    it 'has the right number of series values' do
+      expect(aggregator.bucketed_data.values.all? { |v| v.length == series }).to be true
+    end
+  end
+
+  describe '#aggregate' do
+    describe 'with a series breakdown' do
+      let(:chart_config) do
+        {
+          name: 'Test benchmark chart',
+          meter_definition: :all,
+          x_axis: :year,
+          series_breakdown: :fuel,
+          yaxis_units: :kwh
+        }
+      end
+
+      before { aggregator.aggregate }
+
+      it_behaves_like 'a successful calculation' do
+        let(:expected_start_date) { start_date }
+        let(:expected_end_date) { end_date }
+      end
+
+      it_behaves_like 'a chart broken down by fuel' do
+        let(:expected_fuels) { %w[electricity gas] }
+      end
+
+      context 'with no timescale' do
+        it_behaves_like 'a chart with the right timescale'
+      end
+
+      context 'with a restriction on timescale' do
+        let(:chart_config) do
+          {
+            name: 'Test benchmark chart',
+            meter_definition: :all,
+            x_axis: :year,
+            series_breakdown: :fuel,
+            yaxis_units: :kwh,
+            timescale: :year
+          }
+        end
+
+        it_behaves_like 'a chart with the right timescale', series: 1
+      end
+
+      context 'with a filter on the fuels' do
+        let(:chart_config) do
+          {
+            name: 'Test benchmark chart',
+            meter_definition: :all,
+            x_axis: :year,
+            series_breakdown: :fuel,
+            yaxis_units: :kwh,
+            filter: { fuel: ['gas'] }
+          }
+        end
+
+        it_behaves_like 'a chart broken down by fuel' do
+          let(:expected_fuels) { ['gas'] }
+        end
+      end
+
+      context 'with a meter definition' do
+        let(:chart_config) do
+          {
+            name: 'Test benchmark chart',
+            meter_definition: :allheat,
+            x_axis: :year,
+            series_breakdown: :fuel,
+            yaxis_units: :kwh
+          }
+        end
+
+        it_behaves_like 'a chart broken down by fuel' do
+          let(:expected_fuels) { ['gas'] }
+        end
+      end
+
+      context 'with a y2 axis' do
+        let(:chart_config) do
+          {
+            name: 'Test benchmark chart',
+            meter_definition: :all,
+            x_axis: :year,
+            series_breakdown: :fuel,
+            yaxis_units: :kwh,
+            y2_axis: :irradiance
+          }
+        end
+
+        it_behaves_like 'a successful calculation', y2_axis: true do
+          let(:y2_axis) { true }
+          let(:expected_start_date) { start_date }
+          let(:expected_end_date) { end_date }
+        end
+      end
+    end
+
+    describe 'with a chart with benchmarks injected' do
+      let(:chart_config) do
+        {
+          name: 'Test benchmark chart',
+          meter_definition: :all,
+          x_axis: :year,
+          series_breakdown: :fuel,
+          yaxis_units: :kwh,
+          inject: :benchmark
+        }
+      end
+
+      before { aggregator.aggregate }
+
+      it_behaves_like 'a successful calculation' do
+        let(:expected_start_date) { start_date }
+        let(:expected_end_date) { end_date }
+      end
+
+      it_behaves_like 'a successful benchmark chart'
+
+      it_behaves_like 'a chart broken down by fuel' do
+        let(:expected_fuels) { %w[electricity gas] }
+      end
+
+      it_behaves_like 'a chart with the right timescale', series: 6 # 4 years, plus 2 for benchmarks
+    end
+  end
+end


### PR DESCRIPTION
Some charts have a configuration that includes:

```
inject: :benchmark
```

This causes the charting framework to inject the annual usage (in kwh, co2, or £) for an 'exemplar' or 'well managed' school with similar characteristics.

Currently this code relies on calling out to the alert framework running, e.g. AlertElectricityAnnualVersusBenchmark.

However the alerts may not run in some situations:

- if school has <1 year of data
- if school data is >90 days out of date
- if there's an error in the heating model analysis, which may be unrelated to calculating the benchmark usage

This causes the series to not be added to the charts for some schools. 

This PR reworks how the benchmark values are injected into the chart results to it calls the `Usage::AnnualUsageBenchmarkingService` instead. That service only calculates the required variables, avoiding the above issues. 

It may also be slightly quicker as we avoid extra overheads for e.g. calculating heating model for gas charts, or calculating unneeded variables which aren't used on the charts.

Tests have been added around the code that injects the benchmark values as well as an integration test that checks the entire chart processing.

The code in the `AggregatorBenchmark` class has been tidied and a couple of unrelated bugs (storage heater benchmarks weren't working at all?) have been fixed as well.