### PR TITLE
Fix thermostatic charts

### DIFF
--- a/lib/dashboard/charting_and_reports/charts/filters/series_filter.rb
+++ b/lib/dashboard/charting_and_reports/charts/filters/series_filter.rb
@@ -18,7 +18,7 @@ module Charts
         to_keep = heating_filter(to_keep)
         to_keep = model_type_filter(to_keep)
         to_keep = simple_filters(to_keep)
-        to_keep = y2_axis_filter(to_keep)
+        to_keep = y2_axes(to_keep)
 
         remove_list = @results.bucketed_data.keys - to_keep
 
@@ -82,9 +82,13 @@ module Charts
         to_keep
       end
 
-      def y2_axis_filter(to_keep)
-        return to_keep unless @chart_config.y2_axis?
-
+      # This is not a filter. It ensures that any Y2 axes series names are retained in the results
+      #
+      # Some charts do not have a y2 axes, but include series that might also be used on a y2 axis
+      # E.g. thermostatic_regression.
+      #
+      # So this is applied to all charts, not just those with a y2 axis.
+      def y2_axes(to_keep)
         Series::ManagerBase.y2_series_types.each_value do |y2_series_name|
           base_name_length = y2_series_name.length
           to_keep += @results.bucketed_data.keys.select { |bucket_name| bucket_name[0...base_name_length] == y2_series_name }

--- a/spec/lib/dashboard/charting_and_reports/charts/aggregator_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/aggregator_spec.rb
@@ -60,7 +60,7 @@ describe Aggregator do
   end
 
   describe '#aggregate' do
-    describe 'with a series breakdown' do
+    describe 'with a series breakdown by fuel' do
       let(:chart_config) do
         {
           name: 'Test benchmark chart',
@@ -180,6 +180,34 @@ describe Aggregator do
       end
 
       it_behaves_like 'a chart with the right timescale', series: 6 # 4 years, plus 2 for benchmarks
+    end
+
+    describe 'with a thermostatic regression' do
+      let(:chart_config) do
+        {
+          name: 'Test thermostatic chart',
+          chart1_type: :scatter,
+          meter_definition: :allheat,
+          timescale: :up_to_a_year,
+          series_breakdown: %i[model_type temperature],
+          x_axis: :day,
+          yaxis_units: :kwh,
+          yaxis_scaling: :none
+        }
+      end
+
+      # TEMPORARY use anonymised data until we've implemented approach for creating synthetic
+      # AMR / Temperature / Holiday data to allow heating models to work
+      let(:meter_collection) do
+        load_unvalidated_meter_collection(school: 'acme-academy', validate_and_aggregate: true)
+      end
+
+      before { aggregator.aggregate }
+
+      it_behaves_like 'a successful calculation' do
+        let(:expected_start_date) { Date.new(2018, 9, 1) }
+        let(:expected_end_date) { Date.new(2023, 10, 10) }
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes a bug introduced during the recent refactoring of the chart filtering code.

Instead of filtering series that might appear on the y2 axes, these should always been included. This not only ensures that we retain the Y2 axes for charts that use them, but also ensures they are kept for charts, like the Thermostatic charts, that use the same series name.

There may be better ways to organise this but for now have reverted the changes to check for presence of y2 axis.

I've also added a spec that uses anonymised data to confirm the thermostatic charts run successfully. This plugs gap in the suite.