### PR TITLE
reverse tariff list as looks like we expect ascending order

### DIFF
--- a/app/services/tariffs/generic_tariff_manager.rb
+++ b/app/services/tariffs/generic_tariff_manager.rb
@@ -94,7 +94,7 @@ class GenericTariffManager
   def tariff_change_dates_in_period(start_date = @meter.amr_data.start_date, end_date = @meter.amr_data.end_date)
     list_of_tariffs = find_tariffs_between_dates(start_date, end_date)
     list_of_tariffs = list_of_tariffs.reject { |t| t.end_date == GenericAccountingTariff::MAX_DEFAULT_END_DATE }
-    list_of_tariffs.map { |t| t.end_date + 1 }
+    list_of_tariffs.map { |t| t.end_date + 1 }.reverse
   end
 
   # Costs::EconomicTariffsChangeCaveatsService

--- a/spec/app/services/costs/economic_tariffs_change_caveats_service_spec.rb
+++ b/spec/app/services/costs/economic_tariffs_change_caveats_service_spec.rb
@@ -35,6 +35,11 @@ describe Costs::EconomicTariffsChangeCaveatsService do
           tariffs = [
             create_accounting_tariff_generic(
               start_date: start_date,
+              end_date: start_date + 6,
+              rates: create_flat_rate(rate: 0.5)
+            ),
+            create_accounting_tariff_generic(
+              start_date: start_date + 7,
               end_date: newest_tariff_start - 1,
               rates: create_flat_rate(rate: 1.0)
             ),
@@ -54,7 +59,7 @@ describe Costs::EconomicTariffsChangeCaveatsService do
         expect(caveats.last_change_date).to eq(newest_tariff_start)
         expect(caveats.rate_after_£_per_kwh).to be_within(0.1).of(2.0)
         expect(caveats.rate_before_£_per_kwh).to be_within(0.1).of(1.0)
-        expect(caveats.percent_change).to be_within(0.1).of(0.9)
+        expect(caveats.percent_change).to be_within(0.1).of(1.0)
       end
     end
   end


### PR DESCRIPTION
`EconomicTariffsChangeCaveatsService` uses `tariff_change_dates_in_period` which uses `find_tariffs_between_dates` - this returns the tariffs in reverse order.  It appears as though we assume the last item in the list returned is the last date where it is actually the first.

Test updated to have an extra tariff so the order issue is exposed.

