### PR TITLE
Improve meter breakdown pages

### DIFF
--- a/app/classes/usage/annual_usage_meter_breakdown.rb
+++ b/app/classes/usage/annual_usage_meter_breakdown.rb
@@ -27,6 +27,7 @@ module Usage
       @total_usage ||= CombinedUsageMetric.new(
         kwh: total_kwh,
         £: total_£,
+        co2: total_co2,
         percent: 1.0
       )
     end
@@ -43,6 +44,10 @@ module Usage
 
     def total_£
       @meter_breakdown.map { |_meter, usage| usage[:usage].£ || 0.0 }.sum
+    end
+
+    def total_co2
+      @meter_breakdown.map { |_meter, usage| usage[:usage].co2 || 0.0 }.sum
     end
   end
 end

--- a/app/services/usage/annual_usage_meter_breakdown_service.rb
+++ b/app/services/usage/annual_usage_meter_breakdown_service.rb
@@ -73,7 +73,8 @@ module Usage
         name: meter.analytics_name,
         usage: CombinedUsageMetric.new(
           kwh: this_year_kwh,
-          £: meter.amr_data.kwh_date_range(start_date, end_date, :£)
+          £: meter.amr_data.kwh_date_range(start_date, end_date, :£),
+          co2: meter.amr_data.kwh_date_range(start_date, end_date, :co2)
         ),
         annual_change: annual_percent_kwh_change(meter, this_year_kwh)
       }

--- a/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
@@ -965,7 +965,8 @@ class ChartManager
       x_axis:           :year,
       yaxis_units:      :kwh,
       yaxis_scaling:    :none,
-      y2_axis:          :degreedays
+      y2_axis:          :degreedays,
+      reverse_xaxis:    true
     },
     group_by_year_electricity_meter_breakdown: {
       name:             'By Year: Electricity (Meter Breakdown)',
@@ -975,29 +976,8 @@ class ChartManager
       series_breakdown: :meter,
       x_axis:           :year,
       yaxis_units:      :kwh,
-      yaxis_scaling:    :none
-    },
-    group_by_month_gas_meter_breakdown_unlimited: {
-      name:             'By Week: Gas (multi-year)',
-      chart1_type:      :column,
-      chart1_subtype:   :stacked,
-      zoomable:         true,
-      meter_definition: :allheat,
-      x_axis:           :month,
-      series_breakdown: :none,
-      yaxis_units:      :kwh,
-      yaxis_scaling:    :none
-    },
-    group_by_month_electricity_meter_breakdown_unlimited: {
-      name:             'By Week: Electricity (multi-year)',
-      chart1_type:      :column,
-      chart1_subtype:   :stacked,
-      zoomable:         true,
-      meter_definition: :allelectricity,
-      x_axis:           :month,
-      series_breakdown: :none,
-      yaxis_units:      :kwh,
-      yaxis_scaling:    :none
+      yaxis_scaling:    :none,
+      reverse_xaxis:    true
     },
     group_by_year_gas_unlimited_meter_breakdown_heating_model_fitter: {
       name:             'Gas meter breakdown by year',

--- a/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
@@ -841,7 +841,8 @@ class ChartManager
       name:             'By Week: Electricity (Meter Breakdown)',
       meter_definition: :allelectricity,
       inherits_from:    :group_by_week_gas_meter_breakdown,
-      series_breakdown: :meter
+      series_breakdown: :meter,
+      y2_axis:          nil
     },
     temp_test: {
       inherits_from:    :group_by_week_electricity_meter_breakdown,
@@ -931,6 +932,72 @@ class ChartManager
     group_by_week_gas_meter_breakdown_one_year: {
       inherits_from:    :group_by_week_gas_meter_breakdown,
       timescale:        :up_to_a_year
+    },
+    group_by_month_gas_meter_breakdown: {
+      name:             'By Month: Gas (Meter Breakdown)',
+      chart1_type:      :column,
+      chart1_subtype:   :stacked,
+      meter_definition: :allheat,
+      series_breakdown: :meter,
+      timescale:        :twelve_months,
+      x_axis:           :month,
+      yaxis_units:      :kwh,
+      yaxis_scaling:    :none,
+      y2_axis:          :degreedays
+    },
+    group_by_month_electricity_meter_breakdown: {
+      name:             'By Month: Electricity (Meter Breakdown)',
+      chart1_type:      :column,
+      chart1_subtype:   :stacked,
+      meter_definition: :allelectricity,
+      series_breakdown: :meter,
+      timescale:        :twelve_months,
+      x_axis:           :month,
+      yaxis_units:      :kwh,
+      yaxis_scaling:    :none
+    },
+    group_by_year_gas_meter_breakdown: {
+      name:             'By Year: Gas (Meter Breakdown)',
+      chart1_type:      :column,
+      chart1_subtype:   :stacked,
+      meter_definition: :allheat,
+      series_breakdown: :meter,
+      x_axis:           :year,
+      yaxis_units:      :kwh,
+      yaxis_scaling:    :none,
+      y2_axis:          :degreedays
+    },
+    group_by_year_electricity_meter_breakdown: {
+      name:             'By Year: Electricity (Meter Breakdown)',
+      chart1_type:      :column,
+      chart1_subtype:   :stacked,
+      meter_definition: :allelectricity,
+      series_breakdown: :meter,
+      x_axis:           :year,
+      yaxis_units:      :kwh,
+      yaxis_scaling:    :none
+    },
+    group_by_month_gas_meter_breakdown_unlimited: {
+      name:             'By Week: Gas (multi-year)',
+      chart1_type:      :column,
+      chart1_subtype:   :stacked,
+      zoomable:         true,
+      meter_definition: :allheat,
+      x_axis:           :month,
+      series_breakdown: :none,
+      yaxis_units:      :kwh,
+      yaxis_scaling:    :none
+    },
+    group_by_month_electricity_meter_breakdown_unlimited: {
+      name:             'By Week: Electricity (multi-year)',
+      chart1_type:      :column,
+      chart1_subtype:   :stacked,
+      zoomable:         true,
+      meter_definition: :allelectricity,
+      x_axis:           :month,
+      series_breakdown: :none,
+      yaxis_units:      :kwh,
+      yaxis_scaling:    :none
     },
     group_by_year_gas_unlimited_meter_breakdown_heating_model_fitter: {
       name:             'Gas meter breakdown by year',

--- a/spec/app/services/usage/annual_usage_meter_breakdown_service_spec.rb
+++ b/spec/app/services/usage/annual_usage_meter_breakdown_service_spec.rb
@@ -33,7 +33,7 @@ describe Usage::AnnualUsageMeterBreakdownService, type: :service do
           expect(format_unit(:relative_percent, percent)).to eq '+0.21&percnt;'
           old_building = usage_breakdown.usage(1_591_058_886_735)
           expect(format_unit(:kwh, old_building.kwh)).to eq '99,000'
-          # expect(old_building.kwh).to round_to_two_digits(98392.4)
+          expect(format_unit(:co2, old_building.co2)).to eq '17,000'
           expect(format_unit(:£, old_building.£)).to eq '&pound;15,000'
           expect(format_unit(:percent, old_building.percent)).to eq '24&percnt;'
 
@@ -43,6 +43,7 @@ describe Usage::AnnualUsageMeterBreakdownService, type: :service do
           expect(format_unit(:relative_percent, percent)).to eq '-14&percnt;'
           new_building = usage_breakdown.usage(1_580_001_320_420)
           expect(format_unit(:kwh, new_building.kwh)).to eq '310,000'
+          expect(format_unit(:co2, new_building.co2)).to eq '52,000'
           expect(format_unit(:£, new_building.£)).to eq '&pound;47,000'
           expect(format_unit(:percent, new_building.percent)).to eq '76&percnt;'
 
@@ -51,6 +52,7 @@ describe Usage::AnnualUsageMeterBreakdownService, type: :service do
           expect(format_unit(:relative_percent, percent)).to eq '-11&percnt;'
           usage_breakdown.total_usage
           expect(format_unit(:kwh, usage_breakdown.total_usage.kwh)).to eq '410,000'
+          expect(format_unit(:co2, usage_breakdown.total_usage.co2)).to eq '68,000'
           expect(format_unit(:£, usage_breakdown.total_usage.£)).to eq '&pound;61,000'
           expect(format_unit(:percent, usage_breakdown.total_usage.percent)).to eq '100&percnt;'
         end


### PR DESCRIPTION
Changes to support improvements in the new meter breakdown pages:

- adds new chart configurations for monthly and annual meter breakdown charts
- add missing co2 calculation to the annual usage breakdown we calculate for each meter 