### PR TITLE
Support selecting sub meters to display on charts

### DIFF
--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -189,12 +189,12 @@ module Dashboard
     end
 
     def inspect
-      "#{self.class.name} (mpan: #{@mpan_mprn.to_s}, fuel_type: #{@fuel_type.to_s}, object_id: #{"0x00%x" % (object_id << 1)})"
+      "object_id: #{"0x00%x" % (object_id << 1)}, #{self.class.name}, mpan: #{@mpan_mprn.to_s}, fuel_type: #{@fuel_type.to_s}"
     end
 
     def to_s
-      dates = amr_data.nil? ? ':no amr data' : ":#{amr_data.start_date} to #{amr_data.end_date}"
-      @mpan_mprn.to_s + ':' + @fuel_type.to_s + 'x' + (@amr_data.nil? ? '0' : @amr_data.length.to_s) + dates
+      dates = amr_data.nil? ? '|no amr data' : "|#{amr_data.start_date} to #{amr_data.end_date}"
+      @mpan_mprn.to_s + '|' + @fuel_type.to_s + '|x' + (@amr_data.nil? ? '0' : @amr_data.length.to_s) + dates
     end
 
     def attributes(type)

--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -305,7 +305,7 @@ module Dashboard
 
     # Matches ES AR version
     def display_name
-      name.present? ? "#{mpan_mprn} (#{name})" : mpan_mprn.to_s
+      name.present? ? "#{mpan_mprn} - #{name}" : mpan_mprn.to_s
     end
 
     #Default series name for this meter when displayed on a chart

--- a/app/models/meter_collection.rb
+++ b/app/models/meter_collection.rb
@@ -434,6 +434,47 @@ class MeterCollection
     end
   end
 
+  # Prints a description of the current metering setup for the meter collection.
+  #
+  # Dumps the list of aggregate meters for the whole school along with their sub meters,
+  # then the list of individual electricity and gas meters with their sub meters.
+  #
+  # If a category of meter or submeter isn't in the collection, then its skipped.
+  #
+  # Uses +Meter.inspect+ to print meters to help clarify both the meter/submeter configuration
+  # and the object ids as meters can effectively be cloned during aggregation (same type, date ranges
+  # mpan, etc)
+  #
+  # Intended to help with debugging any aggregation issues or just reviewing state of the
+  # collection.
+  def print_meter_setup
+    puts "Aggregated Data"
+    puts '-' * 35
+    [:aggregated_electricity_meters, :aggregated_heat_meters, :storage_heater_meter].each do |method|
+      meter = send(method)
+      if meter.present?
+        puts "#{format('%-35s', method)} #{meter.inspect}"
+        meter.sub_meters.each do |key, sub_meter|
+          puts "  - #{format('%-31s', key)} #{sub_meter.inspect}"
+        end
+      end
+    end
+    [:electricity, :heat, :storage_heater].each do |method|
+      meters = send("#{method}_meters")
+      if meters.any?
+        puts "\n#{method.to_s.humanize } Meters"
+        puts '-' * 35
+        meters.each.with_index(1) do |meter, index|
+          puts "  #{format('%-33s', index)} #{meter.inspect}"
+          meter.sub_meters.each do |key, sub_meter|
+            puts "    - #{format('%-29s', key)} #{sub_meter.inspect}"
+          end
+        end
+      end
+    end
+    puts '-' * 35
+  end
+
   #Clip the schedule data to the earliest date that we need for charting or
   #subsequent analysis.
   private def clean_up_schedule_data!

--- a/lib/dashboard/charting_and_reports/charts/chart_to_meter_map.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_to_meter_map.rb
@@ -25,8 +25,7 @@ class ChartToMeterMap
     meter_definition.is_a?(String) || meter_definition.is_a?(Integer)
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  def logical_meter_names(meter_collection, meter_definition)
+  def logical_meter_names(meter_collection, meter_definition) # rubocop:disable Metrics/CyclomaticComplexity
     case meter_definition
     when :all then                                        [meter_collection.aggregated_electricity_meters, meter_collection.aggregated_heat_meters]
     when :allheat then                                    meter_collection.aggregated_heat_meters
@@ -47,5 +46,4 @@ class ChartToMeterMap
       :not_mapped
     end
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/lib/dashboard/charting_and_reports/charts/chart_to_meter_map.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_to_meter_map.rb
@@ -7,10 +7,15 @@ class ChartToMeterMap
 
   include Singleton
 
-  def meter(meter_collection, meter_definition)
+  def meter(meter_collection, meter_definition, sub_meter_definition = nil)
     meter = logical_meter_names(meter_collection, meter_definition)
     return meter unless meter == :not_mapped
-    return meter_collection.meter?(meter_definition, true) if mpxn?(meter_definition)
+    if mpxn?(meter_definition)
+      meter = meter_collection.meter?(meter_definition, true)
+      return meter if (meter.nil? || sub_meter_definition.nil?)
+      return meter.sub_meters[sub_meter_definition]
+    end
+
     raise UnknownChartMeterDefinition, "Unknown chart meter definition type #{meter_definition}"
   end
 

--- a/lib/dashboard/charting_and_reports/charts/chart_to_meter_map.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_to_meter_map.rb
@@ -7,43 +7,37 @@ class ChartToMeterMap
 
   include Singleton
 
-  def meter(school, chart_meter_definition)
-    meter = logical_meter_names(school, chart_meter_definition)
+  def meter(meter_collection, meter_definition)
+    meter = logical_meter_names(meter_collection, meter_definition)
     return meter unless meter == :not_mapped
-
-    if chart_meter_definition == :all
-      # TODO: not storage heaters?
-      [school.aggregated_electricity_meters, school.aggregated_heat_meters]
-    elsif mpxn?(chart_meter_definition)
-      school.meter?(chart_meter_definition, true)
-    else
-      raise UnknownChartMeterDefinition, "Unknown chart meter definition type #{chart_meter_definition}"
-    end
+    return meter_collection.meter?(meter_definition, true) if mpxn?(meter_definition)
+    raise UnknownChartMeterDefinition, "Unknown chart meter definition type #{meter_definition}"
   end
 
   private
 
-  def mpxn?(chart_meter_definition)
-    chart_meter_definition.is_a?(String) || chart_meter_definition.is_a?(Integer)
+  def mpxn?(meter_definition)
+    meter_definition.is_a?(String) || meter_definition.is_a?(Integer)
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
-  def logical_meter_names(school, chart_meter_definition)
-    case chart_meter_definition
-    when :allheat then                                    school.aggregated_heat_meters
-    when :allelectricity then                             school.aggregated_electricity_meters
-    when :allelectricity_unmodified then                  school.aggregated_electricity_meters&.original_meter
-    when :allelectricity_without_community_use then       school.aggregated_electricity_meter_without_community_usage
-    when :allheat_without_community_use then              school.aggregated_heat_meters_without_community_usage
-    when :storage_heaters_without_community_use then      school.storage_heater_meter_without_community_usage
-    when :storage_heater_meter then                       school.storage_heater_meter
-    when :solar_pv_meter, :solar_pv then                  school.aggregated_electricity_meters.sub_meters[:generation]
-    when :unscaled_aggregate_target_electricity then      school.unscaled_target_meters[:electricity]
-    when :unscaled_aggregate_target_gas then              school.unscaled_target_meters[:gas]
-    when :unscaled_aggregate_target_storage_heater then   school.unscaled_target_meters[:storage_heater]
-    when :synthetic_aggregate_target_electricity then     school.synthetic_target_meters[:electricity]
-    when :synthetic_aggregate_target_gas then             school.synthetic_target_meters[:gas]
-    when :synthetic_aggregate_target_storage_heater then  school.synthetic_target_meters[:storage_heater]
+  def logical_meter_names(meter_collection, meter_definition)
+    case meter_definition
+    when :all then                                        [meter_collection.aggregated_electricity_meters, meter_collection.aggregated_heat_meters]
+    when :allheat then                                    meter_collection.aggregated_heat_meters
+    when :allelectricity then                             meter_collection.aggregated_electricity_meters
+    when :allelectricity_unmodified then                  meter_collection.aggregated_electricity_meters&.original_meter
+    when :allelectricity_without_community_use then       meter_collection.aggregated_electricity_meter_without_community_usage
+    when :allheat_without_community_use then              meter_collection.aggregated_heat_meters_without_community_usage
+    when :storage_heaters_without_community_use then      meter_collection.storage_heater_meter_without_community_usage
+    when :storage_heater_meter then                       meter_collection.storage_heater_meter
+    when :solar_pv_meter, :solar_pv then                  meter_collection.aggregated_electricity_meters.sub_meters[:generation]
+    when :unscaled_aggregate_target_electricity then      meter_collection.unscaled_target_meters[:electricity]
+    when :unscaled_aggregate_target_gas then              meter_collection.unscaled_target_meters[:gas]
+    when :unscaled_aggregate_target_storage_heater then   meter_collection.unscaled_target_meters[:storage_heater]
+    when :synthetic_aggregate_target_electricity then     meter_collection.synthetic_target_meters[:electricity]
+    when :synthetic_aggregate_target_gas then             meter_collection.synthetic_target_meters[:gas]
+    when :synthetic_aggregate_target_storage_heater then  meter_collection.synthetic_target_meters[:storage_heater]
     else
       :not_mapped
     end

--- a/lib/dashboard/charting_and_reports/charts/chart_to_meter_map.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_to_meter_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'singleton'
 
 class ChartToMeterMap
@@ -5,19 +7,12 @@ class ChartToMeterMap
 
   include Singleton
 
-  def backwards_compatible_series_data_manager_meter_map(school, chart_meter_definition)
-    meter = meter(school, chart_meter_definition)
-
-    return meter if meter.is_a?(Array)
-
-    meter.heat_meter? ? [nil, meter] : [meter, nil]
-  end
-
   def meter(school, chart_meter_definition)
-    meter = vanilla_single_meter_map(school, chart_meter_definition)
+    meter = logical_meter_names(school, chart_meter_definition)
     return meter unless meter == :not_mapped
 
     if chart_meter_definition == :all
+      # TODO: not storage heaters?
       [school.aggregated_electricity_meters, school.aggregated_heat_meters]
     elsif mpxn?(chart_meter_definition)
       school.meter?(chart_meter_definition, true)
@@ -32,24 +27,26 @@ class ChartToMeterMap
     chart_meter_definition.is_a?(String) || chart_meter_definition.is_a?(Integer)
   end
 
-  def vanilla_single_meter_map(school, chart_meter_definition)
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def logical_meter_names(school, chart_meter_definition)
     case chart_meter_definition
-    when :allheat;                                    school.aggregated_heat_meters
-    when :allelectricity;                             school.aggregated_electricity_meters
-    when :allelectricity_unmodified;                  school.aggregated_electricity_meters&.original_meter
-    when :allelectricity_without_community_use;       school.aggregated_electricity_meter_without_community_usage
-    when :allheat_without_community_use;              school.aggregated_heat_meters_without_community_usage
-    when :storage_heaters_without_community_use;      school.storage_heater_meter_without_community_usage
-    when :storage_heater_meter;                       school.storage_heater_meter
-    when :solar_pv_meter, :solar_pv;                  school.aggregated_electricity_meters.sub_meters[:generation]
-    when :unscaled_aggregate_target_electricity;      school.unscaled_target_meters[:electricity]
-    when :unscaled_aggregate_target_gas;              school.unscaled_target_meters[:gas]
-    when :unscaled_aggregate_target_storage_heater;   school.unscaled_target_meters[:storage_heater]
-    when :synthetic_aggregate_target_electricity;     school.synthetic_target_meters[:electricity]
-    when :synthetic_aggregate_target_gas;             school.synthetic_target_meters[:gas]
-    when :synthetic_aggregate_target_storage_heater;  school.synthetic_target_meters[:storage_heater]
+    when :allheat then                                    school.aggregated_heat_meters
+    when :allelectricity then                             school.aggregated_electricity_meters
+    when :allelectricity_unmodified then                  school.aggregated_electricity_meters&.original_meter
+    when :allelectricity_without_community_use then       school.aggregated_electricity_meter_without_community_usage
+    when :allheat_without_community_use then              school.aggregated_heat_meters_without_community_usage
+    when :storage_heaters_without_community_use then      school.storage_heater_meter_without_community_usage
+    when :storage_heater_meter then                       school.storage_heater_meter
+    when :solar_pv_meter, :solar_pv then                  school.aggregated_electricity_meters.sub_meters[:generation]
+    when :unscaled_aggregate_target_electricity then      school.unscaled_target_meters[:electricity]
+    when :unscaled_aggregate_target_gas then              school.unscaled_target_meters[:gas]
+    when :unscaled_aggregate_target_storage_heater then   school.unscaled_target_meters[:storage_heater]
+    when :synthetic_aggregate_target_electricity then     school.synthetic_target_meters[:electricity]
+    when :synthetic_aggregate_target_gas then             school.synthetic_target_meters[:gas]
+    when :synthetic_aggregate_target_storage_heater then  school.synthetic_target_meters[:storage_heater]
     else
       :not_mapped
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/lib/dashboard/charting_and_reports/charts/series_data_manager.rb
+++ b/lib/dashboard/charting_and_reports/charts/series_data_manager.rb
@@ -116,7 +116,7 @@ module Series
     end
 
     def determine_meter
-      ChartToMeterMap.instance.meter(school, chart_config[:meter_definition])
+      ChartToMeterMap.instance.meter(school, chart_config[:meter_definition], chart_config[:sub_meter_definition])
     end
 
     def series_names

--- a/spec/lib/dashboard/charting_and_reports/charts/chart_to_meter_map_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/chart_to_meter_map_spec.rb
@@ -106,5 +106,28 @@ describe ChartToMeterMap do
         expect(map.meter(meter_collection, '99999')).to be_nil
       end
     end
+
+    context 'with mpxn and sub meter definition' do
+      context 'when there are no sub meters' do
+        it 'returns nil' do
+          expect(map.meter(meter_collection, electricity_meter.mpan_mprn, :generation)).to be_nil
+        end
+      end
+
+      context 'when there are sub meters' do
+        it 'returns the correct solar sub meters' do
+          expect(map.meter(meter_collection, electricity_meter_with_solar.mpan_mprn, :mains_consume)).to eq(electricity_meter_with_solar)
+          expect(map.meter(meter_collection, electricity_meter_with_solar.mpan_mprn, :generation)).to eq(solar_pv_meter)
+          expect(map.meter(meter_collection, electricity_meter_with_solar.mpan_mprn, :export).fuel_type).to eq(:exported_solar_pv)
+          expect(map.meter(meter_collection, electricity_meter_with_solar.mpan_mprn, :self_consume).fuel_type).to eq(:solar_pv)
+        end
+
+        it 'returns the correct storage heater submeters' do
+          synthetic_mpan = Dashboard::Meter.synthetic_mpan_mprn(electricity_meter_with_storage_heaters.mpan_mprn, :storage_heater_disaggregated_electricity)
+          expect(map.meter(meter_collection, synthetic_mpan, :mains_consume)).to eq(electricity_meter_with_storage_heaters)
+          expect(map.meter(meter_collection, synthetic_mpan, :storage_heaters).fuel_type).to eq(:storage_heater)
+        end
+      end
+    end
   end
 end

--- a/spec/lib/dashboard/charting_and_reports/charts/chart_to_meter_map_spec.rb
+++ b/spec/lib/dashboard/charting_and_reports/charts/chart_to_meter_map_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ChartToMeterMap do
+  subject(:map) { ChartToMeterMap.instance }
+
+  describe '#meter' do
+    let(:meter_collection) { build(:meter_collection) }
+
+    let(:solar_pv_meter) { build(:meter, meter_collection: meter_collection, type: :solar_pv) }
+
+    let(:electricity_meter) { build(:meter, :with_flat_rate_tariffs, meter_collection: meter_collection, type: :electricity) }
+
+    let(:electricity_meter_with_solar) do
+      solar_attributes = {}
+      solar_attributes[:solar_pv_mpan_meter_mapping] = [{
+        start_date: Date.new(2023, 1, 1),
+        production_mpan: solar_pv_meter.mpan_mprn.to_s
+      }]
+
+      # ELECTRICITY WITH SOLAR
+      build(:meter,
+            :with_flat_rate_tariffs,
+            meter_collection: meter_collection,
+            type: :electricity,
+            meter_attributes: solar_attributes)
+    end
+
+    let(:electricity_meter_with_storage_heaters) { build(:meter, :with_storage_heater) }
+
+    let(:gas_meter) do
+      build(:meter,
+            :with_flat_rate_tariffs,
+            meter_collection: meter_collection,
+            type: :gas, meter_attributes: {})
+    end
+
+    # Build meter collection with electricity, heat, solar, storage heaters
+    before do
+      meter_collection.add_electricity_meter(solar_pv_meter)
+      meter_collection.add_electricity_meter(electricity_meter)
+      meter_collection.add_electricity_meter(electricity_meter_with_solar)
+      meter_collection.add_electricity_meter(electricity_meter_with_storage_heaters)
+      meter_collection.add_heat_meter(gas_meter)
+      AggregateDataService.new(meter_collection).aggregate_heat_and_electricity_meters
+      meter_collection
+    end
+
+    def expect_not_nil(definition)
+      expect(map.meter(meter_collection, definition)).not_to be_nil
+    end
+
+    context 'with logical meter names' do
+      it 'returns expected meters' do
+        expect(map.meter(meter_collection, :all)).to contain_exactly(meter_collection.aggregated_electricity_meters, meter_collection.aggregated_heat_meters)
+        # Check returns expected meter
+        expect(map.meter(meter_collection, :allheat)).to eq(meter_collection.aggregated_heat_meters)
+        expect(map.meter(meter_collection, :allelectricity)).to eq(meter_collection.aggregated_electricity_meters)
+        expect(map.meter(meter_collection, :storage_heater_meter)).to eq(meter_collection.storage_heater_meter)
+        expect(map.meter(meter_collection, :solar_pv_meter)).to eq(
+          meter_collection.aggregated_electricity_meters.sub_meters[:generation]
+        )
+        # ...but also check those meters aren't nil
+        %i[allheat allelectricity storage_heater_meter solar_pv_meter].each do |definition|
+          expect_not_nil(definition)
+        end
+      end
+
+      it 'raises error if unknown meter requested' do
+        expect { map.meter(meter_collection, :unknown) }.to raise_error(ChartToMeterMap::UnknownChartMeterDefinition)
+      end
+    end
+
+    context 'with mpxn' do
+      context 'when requesting meters that have not been aggregated' do
+        it 'returns expected meters' do
+          expect(map.meter(meter_collection, electricity_meter.mpan_mprn)).to eq(electricity_meter)
+          expect(map.meter(meter_collection, gas_meter.mpan_mprn)).to eq(gas_meter)
+          expect(map.meter(meter_collection, solar_pv_meter.mpan_mprn)).to eq(solar_pv_meter)
+        end
+      end
+
+      context 'when requesting meters that have been aggregated/disaggregated' do
+        # Solar aggregation process creating a new meter with same mpan.
+        it 'returns the mains+self consumption meter for the electricity meter mpan with solar' do
+          mains_plus_self_consume = map.meter(meter_collection, electricity_meter_with_solar.mpan_mprn)
+          expect(mains_plus_self_consume.sub_meters[:mains_consume]).to eq(electricity_meter_with_solar)
+        end
+
+        it 'returns the new electricity meter without storage heater usage for the electricity meter with storage heaters mpan' do
+          synthetic_mpan = Dashboard::Meter.synthetic_mpan_mprn(electricity_meter_with_storage_heaters.mpan_mprn, :storage_heater_disaggregated_electricity)
+          expect_not_nil(synthetic_mpan)
+          electricity_without_storage = map.meter(meter_collection, synthetic_mpan)
+          expect(electricity_without_storage.sub_meters[:mains_consume]).to eq(electricity_meter_with_storage_heaters)
+        end
+
+        # Storage heater aggregation process creates meters with synthetic mpans
+        it 'still returns the original electricity meter for the meter with attached storage heaters' do
+          meter = map.meter(meter_collection, electricity_meter_with_storage_heaters.mpan_mprn)
+          expect(meter).to eq(electricity_meter_with_storage_heaters)
+        end
+      end
+
+      it 'returns nil for unknown meter' do
+        expect(map.meter(meter_collection, '99999')).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
The charting code currently supports specifying the meter(s) used to build a chart using the `meter_definition` configuration. This is either:

- a "logical" name like `:allelectricity` or `:allheat`
- a specific meter which is referenced via its mpxn

Finding the initial meters is mostly done via `ChartToMeterMap` which will search in the meter collection.

The discovered meter(s) will either be used to directly build the data or will be used to lookup sub meters which are then displayed on the chart (via `series_breakdown: :submeter`).

We want to be able to display meters for some additional circumstances which the existing options don't cover. Specfically we want to be able to display a chart that shows:

- the electricity consumption from a meter plus consumption from any attached solar panels (mains plus self consumption)
- the electricity consumption from the above meter without the consumption from the solar panels (mains consumption only)

To achieve this we need to extend the chart syntax and meter lookup to allow a `sub_meter` to be specified, e.g. `sub_meter: :mains_consume`.

This PR adds that support.
