### PR TITLE
Fix bug in calculating solar offset co2

### DIFF
--- a/spec/lib/dashboard/alerts/common/management_summary_table_spec.rb
+++ b/spec/lib/dashboard/alerts/common/management_summary_table_spec.rb
@@ -10,10 +10,6 @@ describe ManagementSummaryTable do
 
   let(:start_date) { Date.new(2022, 11, 1) }
   let(:today) { Date.new(2023, 11, 30) }
-  let(:meter_collection) do
-    build(:meter_collection, :with_fuel_and_aggregate_meters,
-          start_date: start_date, end_date: today)
-  end
 
   # FIXME
   # The alert has some code that checks for whether Rails is defined and then formats
@@ -27,6 +23,11 @@ describe ManagementSummaryTable do
   end
 
   describe '#reporting_period' do
+    let(:meter_collection) do
+      build(:meter_collection, :with_fuel_and_aggregate_meters,
+            start_date: start_date, end_date: today)
+    end
+
     it 'returns expected period' do
       expect(alert.reporting_period).to eq(:last_12_months)
     end
@@ -40,32 +41,73 @@ describe ManagementSummaryTable do
       alert.variables_for_reporting
     end
 
-    it 'runs the calculation and produces expected variables' do
-      expect(result).to be true
-      expect(variables.dig(:summary_data, :electricity)).not_to be_nil
-      electricity_data = variables.dig(:summary_data, :electricity)
-      expect(electricity_data[:start_date]).to eq(start_date.iso8601)
-      expect(electricity_data[:end_date]).to eq(today.iso8601)
+    context 'when school has only electricity' do
+      let(:meter_collection) do
+        build(:meter_collection, :with_fuel_and_aggregate_meters,
+              start_date: start_date, end_date: today)
+      end
 
-      expect(electricity_data.dig(:year, :recent)).to be true
-      expect(electricity_data.dig(:workweek, :recent)).to be true
+      it 'runs the calculation and produces expected variables' do
+        expect(result).to be true
+        expect(variables.dig(:summary_data, :electricity)).not_to be_nil
+        electricity_data = variables.dig(:summary_data, :electricity)
+        expect(electricity_data[:start_date]).to eq(start_date.iso8601)
+        expect(electricity_data[:end_date]).to eq(today.iso8601)
 
-      # Notes on kwh, co2, £ calculations
-      # By default the meter collection factory creates meter with data that has
-      # 48 kWh per day, tariffs of 0.1 per kWh, co2 of rand(0.2..0.3).round(3)
-      expect(electricity_data.dig(:workweek, :kwh)).to eq(336.0)
-      expect(electricity_data.dig(:workweek, :£)).to be_within(0.0001).of(33.6)
-      expect(electricity_data.dig(:workweek, :co2)).to be > 0
+        expect(electricity_data.dig(:year, :recent)).to be true
+        expect(electricity_data.dig(:workweek, :recent)).to be true
 
-      expect(electricity_data.dig(:year, :kwh)).to eq(17_472.0)
-      expect(electricity_data.dig(:year, :£)).to be_within(0.0001).of(1747.20)
-      expect(electricity_data.dig(:year, :co2)).to be > 0
+        # Notes on kwh, co2, £ calculations
+        # By default the meter collection factory creates meter with data that has
+        # 48 kWh per day, tariffs of 0.1 per kWh, co2 of rand(0.2..0.3).round(3)
+        expect(electricity_data.dig(:workweek, :kwh)).to eq(336.0)
+        expect(electricity_data.dig(:workweek, :£)).to be_within(0.0001).of(33.6)
+        expect(electricity_data.dig(:workweek, :co2)).to be > 0
 
-      expect(variables.dig(:summary_data, :gas)).to be_nil
-      expect(variables.dig(:summary_data, :storage_heaters)).to be_nil
+        expect(electricity_data.dig(:year, :kwh)).to eq(17_472.0)
+        expect(electricity_data.dig(:year, :£)).to be_within(0.0001).of(1747.20)
+        expect(electricity_data.dig(:year, :co2)).to be > 0
+
+        expect(variables.dig(:summary_data, :gas)).to be_nil
+        expect(variables.dig(:summary_data, :storage_heaters)).to be_nil
+      end
     end
 
-    context 'with gas' do
+    context 'when school has electricity and solar' do
+      let(:meter_collection) do
+        meter_collection = build(:meter_collection, start_date: start_date, end_date: today)
+        electricity_meter = build(:meter,
+                                  :with_flat_rate_tariffs,
+                                  tariff_start_date: start_date,
+                                  tariff_end_date: today,
+                                  meter_collection: meter_collection,
+                                  type: :electricity,
+                                  meter_attributes: {
+                                    solar_pv: [{ start_date: start_date, kwp: 10.0 }]
+                                  },
+                                  amr_data: build(:amr_data, :with_date_range,
+                                                  type: :electricity,
+                                                  start_date: start_date,
+                                                  end_date: today,
+                                                  kwh_data_x48: Array.new(48, 1.0)))
+        meter_collection.add_electricity_meter(electricity_meter)
+        meter_collection
+      end
+
+      before do
+        AggregateDataService.new(meter_collection).aggregate_heat_and_electricity_meters
+      end
+
+      it 'calculates offset co2' do
+        expect(result).to be true
+        electricity_data = variables.dig(:summary_data, :electricity)
+        consumption = meter_collection.electricity_meters.first.amr_data.kwh_date_range(today - 363, today, :co2)
+        pv_production = meter_collection.aggregate_meter(:solar_pv).amr_data.kwh_date_range(today - 363, today, :co2)
+        expect(electricity_data.dig(:year, :co2)).to eq(consumption + pv_production)
+      end
+    end
+
+    context 'when school has gas' do
       let(:meter_collection) do
         build(:meter_collection, :with_fuel_and_aggregate_meters,
               start_date: start_date, end_date: today, fuel_type: :gas)
@@ -79,7 +121,7 @@ describe ManagementSummaryTable do
       end
     end
 
-    context 'with storage heaters' do
+    context 'when school has storage heaters' do
       let(:meter_collection) do
         build(:meter_collection, :with_fuel_and_aggregate_meters,
               start_date: start_date, end_date: today, storage_heaters: true)


### PR DESCRIPTION
When calculating the values to display on the management dashboard the co2 values include an "offset" when the school has solar panels. We reduce their co2 emissions by the amount of co2 that has been saved by consuming energy from the solar panels.

The offset calculation can return nil which cause some errors in the application. One reason it might return nil is if there's more limited solar generation data than there is for electricity consumption.

This can happen in a very specific circumstance:

- school has >1 electricity meter
- the panels are linked to a meter which has lagging data (so quite out of date)
- there is a meter attribute on that meter which says to ignore that end date

We then end up with a solar_pv production meter that has less data than the aggregate meter.

To try and improve the code I've changed the calculation so that it uses an "up_to_a_year" period, rather than "year". This means it'll tolerate less data, allowing us to calculate a better offset.

I've also fixed a bug which meant that we were calculating the co2 emissions twice for schools with solar (calculation was run, then results discarded).

The management table code needs a complete rework so considering this a temporary improvement. 

I've added a spec to ensure that we're testing the solar offset calculation code as it wasn't covered before.