### PR TITLE
Change pupil chart axis

### DIFF
--- a/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
@@ -2183,7 +2183,6 @@ class ChartManager
       name:             'When your school used electricity over the past year. School day closed is the electricity used in the evenings and early mornings during term time.',
       timescale:        :year,
       inherits_from:     :daytype_breakdown_electricity,
-      yaxis_units:      :£,
       minimum_days_data_override: 180
     },
     pupil_dashboard_baseload_lastyear: {


### PR DESCRIPTION
Removes override of chart axis so the pupil pie charts breaking down gas and electricity use by day defaults to kWh