### PR TITLE
Define new two new charts

### DIFF
--- a/app/services/usage/holiday_usage_calculation_service.rb
+++ b/app/services/usage/holiday_usage_calculation_service.rb
@@ -108,7 +108,7 @@ module Usage
     # for the previous academic year
     def adding_missing_holidays(comparison_periods)
       year = previous_academic_year
-      missing = Holidays::MAIN_HOLIDAY_TYPES.sort - comparison_periods.map(&:type).sort
+      missing = Holidays::MAIN_HOLIDAY_TYPES.sort - comparison_periods.map(&:type).compact.sort
       comparison_periods.concat(@holidays.holidays.select { |h| h.academic_year == year && missing.include?(h.type) })
     end
 

--- a/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
+++ b/lib/dashboard/charting_and_reports/charts/chart_configuration.rb
@@ -2110,6 +2110,23 @@ class ChartManager
       calendar_picker_allow_up_to_1_week_past_last_meter_date: true,
       inherits_from:    :calendar_picker_electricity_week_chart
     },
+    public_displays_electricity_weekly_comparison: {
+      name:             'Public displays weekly electricity comparison',
+      chart1_type:      :column,
+      chart1_subtype:   nil,
+      meter_definition: :allelectricity,
+      series_breakdown: :none,
+      timescale:        [{ workweek: 0  }, { workweek: -1 }],
+      x_axis:           :day,
+      x_axis_reformat:  { date: '%A' },
+      yaxis_units:      :kwh,
+      yaxis_scaling:    :none
+    },
+    public_displays_gas_weekly_comparison: {
+      name:             'Public displays weekly electricity comparison',
+      inherits_from:    :public_displays_electricity_weekly_comparison,
+      meter_definition: :allheat
+    },
     calendar_picker_electricity_day_example_comparison_chart: {
       name:             'Calendar picker electricity example day comparison chart',
       timescale:        [


### PR DESCRIPTION
Adds two new chart configs for charts to be used on the "public displays" version of the pupil analysis.

Basically replaces some existing charts but with a default timescale.