### PR TITLE
Revise how date times are added to RBee API calls

### DIFF
--- a/lib/dashboard/data_sources/metering/rbee/rbee_solar_pv_data.rb
+++ b/lib/dashboard/data_sources/metering/rbee/rbee_solar_pv_data.rb
@@ -88,11 +88,11 @@ class RbeeSolarPV
   # all the raw data returned by Rbee is in UTC(+0)
   # gets data in 6 day + 1 hour chunks, as opposed to API limit of 7 days,
   # as margin of 1 hour required for UTC to BST/GMT conversion
-  def smart_meter_data(meter_id, start_date, end_date, datetime = Time.now.utc)
+  def smart_meter_data(meter_id, start_date, end_date)
     data = {}
     raise EnergySparksUnexpectedStateException.new, 'Expecting start_date, end_time to be of class Date' unless start_date.is_a?(Date) && end_date.is_a?(Date)
     (start_date..end_date).each_slice(6) do |six_days|
-      data = data.deep_merge(smart_meter_data_6_days(meter_id, six_days.first, six_days.last, datetime))
+      data = data.deep_merge(smart_meter_data_6_days(meter_id, six_days.first, six_days.last, Time.now.utc))
     end
     data
   end
@@ -101,12 +101,12 @@ class RbeeSolarPV
   # in order to understand meter setup for Newport schools where
   # the inventory/full information call doesn't provide information about the underlying
   # metering
-  def smart_meter_data_analysis(meter_id, start_date, end_date, datetime = Time.now.utc)
+  def smart_meter_data_analysis(meter_id, start_date, end_date)
     totals = {}
     start_date = first_connection_date(meter_id) if start_date.nil?
     raise EnergySparksUnexpectedStateException.new, 'Expecting start_date, end_time to be of class Date' unless start_date.is_a?(Date) && end_date.is_a?(Date)
     (start_date..end_date).each_slice(6) do |six_days|
-      data = smart_meter_data_6_days_debug(meter_id, six_days.first, six_days.last, datetime)
+      data = smart_meter_data_6_days_debug(meter_id, six_days.first, six_days.last, Time.now.utc)
       data.each do |type, value|
         totals[type] ||= 0.0
         totals[type] += value.to_f
@@ -115,12 +115,12 @@ class RbeeSolarPV
     totals
   end
 
-  def smart_meter_data_by_component(meter_id, start_date, end_date, component = nil, datetime = Time.now.utc)
+  def smart_meter_data_by_component(meter_id, start_date, end_date, component = nil)
     raise InvalidComponent, "Component = #{component}" unless COMPONENTS.include?(component)
     data = {}
     raise EnergySparksUnexpectedStateException.new, 'Expecting start_date, end_time to be of class Date' unless start_date.is_a?(Date) && end_date.is_a?(Date)
     (start_date..end_date).each_slice(6) do |six_days|
-      data = data.deep_merge(smart_meter_data_6_days_by_component(meter_id, component, six_days.first, six_days.last, datetime))
+      data = data.deep_merge(smart_meter_data_6_days_by_component(meter_id, component, six_days.first, six_days.last, Time.now.utc))
     end
     data
   end


### PR DESCRIPTION
The RBee API used to fetch solar data requires requests to be signed:

- a checksum is added to the request using the username, password and timestamp
- the timetamp is added as a url parameter (`RequestDate`)

We are getting some API errors for some requests as the `RequestDate` parameter is too old.

Currently the timestamp for the URLs is generated when the method to download data is called and not when each request is sent. This means that when we do large data loads, or if their API takes a long time to respond, the timestamp we're using can be out of date.

The fix is to just generate the timestamp for each URL request. So have removed the optional parameters for the main method calls and added a timestamp in the code which fixes the issue.