### PR TITLE
Check for NaN value in Management Table

### DIFF
--- a/lib/dashboard/alerts/common/management_summary_table.rb
+++ b/lib/dashboard/alerts/common/management_summary_table.rb
@@ -270,6 +270,7 @@ class ManagementSummaryTable < ContentBase
   def difference_to_exemplar_£(actual_£, fuel_type)
     return nil if actual_£.nil?
     examplar = BenchmarkMetrics.exemplar_£(@school, fuel_type, nil, nil)
+    return nil if examplar.nan?
     [actual_£ - examplar, 0.0].max
   end
 


### PR DESCRIPTION
`BenchmarkMetrics.exemplar_£` can end up returning `NaN` if there is zero usage on an aggregate meter for the period. This is because attempting to calculate the blended rate returns `NaN`. Added a check for this to avoid an exception being thrown.

This has happened for a school with a problem with its gas meter and the readings are all zero for the last year. The meter should be disabled, but this fix avoids an error and makes it easier for admin to spot the issue.