### PR TITLE
Don't run AlertHeatingComingOnTooEarly during holidays

### DIFF
--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_coming_on_too_early.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_coming_on_too_early.rb
@@ -16,6 +16,7 @@ class AlertHeatingComingOnTooEarly < AlertGasModelBase
 
   def initialize(school)
     super(school, :heatingcomingontooearly)
+    @relevance = :never_relevant if holiday?(@today)
   end
 
   def self.template_variables

--- a/spec/lib/dashboard/alerts/electricity/alert_electricity_usage_during_current_holiday_spec.rb
+++ b/spec/lib/dashboard/alerts/electricity/alert_electricity_usage_during_current_holiday_spec.rb
@@ -16,18 +16,9 @@ describe AlertElectricityUsageDuringCurrentHoliday do
     include_context 'with an aggregated meter with tariffs and school times' do
       let(:fuel_type) { :gas }
     end
+    include_context 'with today'
 
     let(:asof_date) { Date.new(2023, 12, 23) }
-    let(:today)     { asof_date.iso8601 }
-
-    # The alert checks the current date, but has option to override via
-    # an environment variable. So by default set it as if we're running
-    # on the asof_date
-    around do |example|
-      ClimateControl.modify ENERGYSPARKSTODAY: today do
-        example.run
-      end
-    end
 
     it 'is never relevant' do
       expect(alert.relevance).to eq(:never_relevant)

--- a/spec/lib/dashboard/alerts/gas/boiler_control/alert_gas_heating_hot_water_on_during_holiday_spec.rb
+++ b/spec/lib/dashboard/alerts/gas/boiler_control/alert_gas_heating_hot_water_on_during_holiday_spec.rb
@@ -19,18 +19,9 @@ describe AlertGasHeatingHotWaterOnDuringHoliday do
     include_context 'with an aggregated meter with tariffs and school times' do
       let(:fuel_type) { :electricity }
     end
+    include_context 'with today'
 
     let(:asof_date) { Date.new(2023, 12, 23) }
-    let(:today)     { asof_date.iso8601 }
-
-    # The alert checks the current date, but has option to override via
-    # an environment variable. So by default set it as if we're running
-    # on the asof_date
-    around do |example|
-      ClimateControl.modify ENERGYSPARKSTODAY: today do
-        example.run
-      end
-    end
 
     it 'is never relevant' do
       expect(alert.relevance).to eq(:never_relevant)

--- a/spec/lib/dashboard/alerts/gas/boiler_control/alert_heating_coming_on_too_early_spec.rb
+++ b/spec/lib/dashboard/alerts/gas/boiler_control/alert_heating_coming_on_too_early_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe AlertHeatingComingOnTooEarly do
+  subject(:alert) { described_class.new(meter_collection) }
+
+  include_context 'with an aggregated meter with tariffs and school times'
+  include_context 'with today'
+
+  context 'when during a holiday' do
+    let(:asof_date) { Date.new(2023, 12, 22) }
+
+    it 'is never relevant' do
+      alert.analyse(asof_date)
+      expect(alert.relevance).to eq(:never_relevant)
+    end
+  end
+end

--- a/spec/lib/dashboard/alerts/storage_heaters/alert_storage_heater_heating_on_during_holiday_spec.rb
+++ b/spec/lib/dashboard/alerts/storage_heaters/alert_storage_heater_heating_on_during_holiday_spec.rb
@@ -23,22 +23,13 @@ describe AlertStorageHeaterHeatingOnDuringHoliday do
     include_context 'with an aggregated meter with tariffs and school times' do
       let(:fuel_type) { :electricity }
     end
+    include_context 'with today'
 
     before do
       allow(meter_collection).to receive(:storage_heaters?).and_return(false) if fuel_type == :storage_heaters
     end
 
     let(:asof_date) { Date.new(2023, 12, 23) }
-    let(:today)     { asof_date.iso8601 }
-
-    # The alert checks the current date, but has option to override via
-    # an environment variable. So by default set it as if we're running
-    # on the asof_date
-    around do |example|
-      ClimateControl.modify ENERGYSPARKSTODAY: today do
-        example.run
-      end
-    end
 
     it 'is never relevant' do
       expect(alert.relevance).to eq(:never_relevant)

--- a/spec/support/shared_contexts/today.rb
+++ b/spec/support/shared_contexts/today.rb
@@ -7,6 +7,6 @@ RSpec.shared_context 'with today' do
   # an environment variable. So by default set it as if we're running
   # on the asof_date
   around do |example|
-    ClimateControl.modify ENERGYSPARKSTODAY: today { example.run }
+    ClimateControl.modify(ENERGYSPARKSTODAY: today) { example.run }
   end
 end

--- a/spec/support/shared_contexts/today.rb
+++ b/spec/support/shared_contexts/today.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'with today' do
+  let(:today) { asof_date.iso8601 }
+
+  # The alert checks the current date, but has option to override via
+  # an environment variable. So by default set it as if we're running
+  # on the asof_date
+  around do |example|
+    ClimateControl.modify ENERGYSPARKSTODAY: today { example.run }
+  end
+end

--- a/spec/support/shared_examples/holiday_usage_alert.rb
+++ b/spec/support/shared_examples/holiday_usage_alert.rb
@@ -2,16 +2,8 @@
 
 RSpec.shared_examples 'a holiday usage alert' do
   let(:asof_date) { Date.new(2023, 12, 23) }
-  let(:today)     { asof_date.iso8601 }
 
-  # The alert checks the current date, but has option to override via
-  # an environment variable. So by default set it as if we're running
-  # on the asof_date
-  around do |example|
-    ClimateControl.modify ENERGYSPARKSTODAY: today do
-      example.run
-    end
-  end
+  include_context 'with today'
 
   describe '#enough_data?' do
     context 'with enough data' do


### PR DESCRIPTION
looking at AlertUsageDuringCurrentHolidayBase for a possible implementation it overrides the relevance method but that doesn't look to be called.  It also puts a return in the calculate.