### PR TITLE
set relevance in the same way as other alerts

### DIFF
--- a/lib/dashboard/alerts/common/alert_usage_during_current_holiday_base.rb
+++ b/lib/dashboard/alerts/common/alert_usage_during_current_holiday_base.rb
@@ -8,6 +8,7 @@ class AlertUsageDuringCurrentHolidayBase < AlertAnalysisBase
   def initialize(school, report_type)
     super(school, report_type)
     @rating = 10.0
+    @relevance = :never_relevant unless holiday?(@today)
   end
 
   def self.template_variables
@@ -74,12 +75,6 @@ class AlertUsageDuringCurrentHolidayBase < AlertAnalysisBase
     }
   }.freeze
 
-  # Check whether we are in a holiday, otherwise delegate to parent
-  def relevance
-    return :never_relevant unless @school.holidays.holiday?(@today)
-    super
-  end
-
   # We have enough data so long as there is some recorded usage within the current holiday
   def enough_data
     holiday_period = @school.holidays.holiday(@today)
@@ -132,8 +127,6 @@ class AlertUsageDuringCurrentHolidayBase < AlertAnalysisBase
   # are currently within a holiday (@relevance) and we have the necessary aggregate
   # meter
   def calculate(asof_date)
-    return unless @school.holidays.holiday?(asof_date)
-
     @holiday_period     = @school.holidays.holiday(asof_date)
     holiday_date_range  = @holiday_period.start_date..@holiday_period.end_date
 


### PR DESCRIPTION
from https://github.com/Energy-Sparks/energy-sparks_analytics/pull/730 - this alert is overriding the `relevance` method, but in e.g. valid_alert? we check `@relevance` so seems confusing that different parts of code are using different relevance values.  Also since `calculate` now never runs the check can be removed in there.