### PR TITLE
Remove bookmarks

### DIFF
--- a/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -13,7 +13,7 @@ class AlertAnalysisBase < ContentBase
 
   ALERT_HELP_URL = 'https://blog.energysparks.uk/alerts'.freeze
 
-  attr_reader :status, :rating, :term, :default_summary, :default_content, :bookmark_url
+  attr_reader :status, :rating, :term, :default_summary, :default_content
   attr_reader :analysis_date, :max_asofdate, :calculation_worked
 
   attr_reader :capital_cost, :one_year_saving_£, :ten_year_saving_£, :payback_years
@@ -122,10 +122,6 @@ class AlertAnalysisBase < ContentBase
     term: {
       description: 'long term or short term',
       units:  Symbol
-    },
-    bookmark_url: {
-      description: 'Link to help URL',
-      units:  String
     },
     max_asofdate: {
       description: 'The latest date on which an alert can be run given the available data',

--- a/lib/dashboard/alerts/common/alert_out_of_hours_base_usage.rb
+++ b/lib/dashboard/alerts/common/alert_out_of_hours_base_usage.rb
@@ -23,11 +23,10 @@ class AlertOutOfHoursBaseUsage < AlertAnalysisBase
   attr_reader :tariff_has_changed_during_period_text
 
   def initialize(school, fuel,
-                 alert_type, bookmark, meter_definition,
+                 alert_type, meter_definition,
                  good_out_of_hours_use_percent, bad_out_of_hours_use_percent)
     super(school, alert_type)
     @fuel = fuel
-    @bookmark = bookmark
     @good_out_of_hours_use_percent = good_out_of_hours_use_percent
     @bad_out_of_hours_use_percent = bad_out_of_hours_use_percent
     @meter_definition = meter_definition
@@ -199,7 +198,6 @@ class AlertOutOfHoursBaseUsage < AlertAnalysisBase
     @status = @significant_out_of_hours_use ? :bad : :good
 
     @term = :longterm
-    @bookmark_url = add_book_mark_to_base_url(@bookmark)
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/electricity/alert_change_in_daily_electricity_short_term.rb
+++ b/lib/dashboard/alerts/electricity/alert_change_in_daily_electricity_short_term.rb
@@ -143,7 +143,6 @@ class AlertChangeInDailyElectricityShortTerm < AlertElectricityOnlyBase
     @rating = calculate_rating_from_range(-0.05, 0.15, @percent_change_in_consumption)
     @status = @signifcant_increase_in_electricity_consumption ? :bad : :good
     @term = :shortterm
-    @bookmark_url = add_book_mark_to_base_url('ElectricityChange')
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/electricity/alert_electricity_annual_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/alert_electricity_annual_versus_benchmark.rb
@@ -329,7 +329,6 @@ class AlertElectricityAnnualVersusBenchmark < AlertElectricityOnlyBase
     @status = @rating < 6.0 ? :bad : :good
 
     @term = :longterm
-    @bookmark_url = add_book_mark_to_base_url('AnnualElectricity')
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/electricity/alert_out_of_hours_electricity_usage.rb
+++ b/lib/dashboard/alerts/electricity/alert_out_of_hours_electricity_usage.rb
@@ -10,7 +10,6 @@ class AlertOutOfHoursElectricityUsage < AlertOutOfHoursBaseUsage
       school,
       'electricity',
       :electricityoutofhours,
-      'ElectricityOutOfHours',
       :allelectricity,
       BenchmarkMetrics::EXEMPLAR_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY,
       BenchmarkMetrics::BENCHMARK_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY

--- a/lib/dashboard/alerts/electricity/baseload/alert_change_in_electricity_baseload_short_term.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_change_in_electricity_baseload_short_term.rb
@@ -224,7 +224,6 @@ class AlertChangeInElectricityBaseloadShortTerm < AlertBaseloadBase
     @status = @significant_increase_in_baseload ? :bad : :good
 
     @term = :shortterm
-    @bookmark_url = add_book_mark_to_base_url('ElectricityBaseload')
   end
   alias_method :analyse_private, :calculate
 end

--- a/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_electricity_baseload_versus_benchmark.rb
@@ -266,7 +266,6 @@ class AlertElectricityBaseloadVersusBenchmark < AlertBaseloadBase
     @status = @rating < 6.0 ? :bad : :good
 
     @term = :longterm
-    @bookmark_url = add_book_mark_to_base_url('ElectricityBaseload')
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/electricity/baseload/alert_freezers_off_for_summer_holidays.rb
+++ b/lib/dashboard/alerts/electricity/baseload/alert_freezers_off_for_summer_holidays.rb
@@ -111,7 +111,6 @@ class AlertSummerHolidayRefrigerationAnalysis < AlertElectricityOnlyBase
     @rating = [@turn_off_rating, @reduction_rating].min
 
     @term = :longterm
-    @bookmark_url = add_book_mark_to_base_url('HeatingComingOnTooEarly')
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/gas/alert_change_in_daily_gas_short_term.rb
+++ b/lib/dashboard/alerts/gas/alert_change_in_daily_gas_short_term.rb
@@ -212,7 +212,6 @@ class AlertChangeInDailyGasShortTerm < AlertGasModelBase
     @status = @signficant_increase_in_gas_consumption ? :bad : :good
 
     @term = :shortterm
-    @bookmark_url = add_book_mark_to_base_url('GasChange')
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/gas/alert_gas_annual_versus_benchmark.rb
+++ b/lib/dashboard/alerts/gas/alert_gas_annual_versus_benchmark.rb
@@ -409,7 +409,6 @@ class AlertGasAnnualVersusBenchmark < AlertGasModelBase
     @status = @rating < 6.0 ? :bad : :good
 
     @term = :longterm
-    @bookmark_url = add_book_mark_to_base_url('AnnualGas')
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/gas/alert_out_of_hours_gas_usage.rb
+++ b/lib/dashboard/alerts/gas/alert_out_of_hours_gas_usage.rb
@@ -7,7 +7,6 @@ class AlertOutOfHoursGasUsage < AlertOutOfHoursBaseUsage
     school,
     fuel = 'gas',
     type = :gasoutofhours,
-    bookmark = 'GasOutOfHours',
     meter_defn_not_used = :allheat,
     good_out_of_hours_use_percent = BenchmarkMetrics::EXEMPLAR_OUT_OF_HOURS_USE_PERCENT_GAS,
     bad_out_of_hours_use_percent = BenchmarkMetrics::BENCHMARK_OUT_OF_HOURS_USE_PERCENT_GAS
@@ -16,7 +15,6 @@ class AlertOutOfHoursGasUsage < AlertOutOfHoursBaseUsage
       school,
       fuel,
       type,
-      bookmark,
       meter_defn_not_used,
       good_out_of_hours_use_percent,
       bad_out_of_hours_use_percent

--- a/lib/dashboard/alerts/gas/alert_weekend_gas_consumption_short_term.rb
+++ b/lib/dashboard/alerts/gas/alert_weekend_gas_consumption_short_term.rb
@@ -247,7 +247,6 @@ class AlertWeekendGasConsumptionShortTerm < AlertGasModelBase
     @status = @rating < 5.0 ? :bad : :good
 
     @term = :shortterm
-    @bookmark_url = add_book_mark_to_base_url('WeekendGas')
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/gas/boiler control/alert_heating_coming_on_too_early.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_heating_coming_on_too_early.rb
@@ -109,7 +109,6 @@ class AlertHeatingComingOnTooEarly < AlertGasModelBase
     @status = @rating.to_f < 7.0 ? :bad : :good
 
     @term = :shortterm
-    @bookmark_url = add_book_mark_to_base_url('HeatingComingOnTooEarly')
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/gas/boiler control/alert_optimum_start_analysis.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_optimum_start_analysis.rb
@@ -71,7 +71,6 @@ class AlertOptimumStartAnalysis < AlertGasModelBase
     @rating = calculate_rating_from_range(6.0, 3.0, results[:average_start_time])
 
     @term = :longterm
-    @bookmark_url = add_book_mark_to_base_url('HeatingComingOnTooEarly')
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/gas/boiler control/alert_school_heating_days.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_school_heating_days.rb
@@ -143,7 +143,6 @@ class AlertHeatingOnSchoolDaysDeprecated < AlertHeatingDaysBase
     @status = @rating < 5.0 ? :bad : :good
 
     @term = :longterm
-    @bookmark_url = add_book_mark_to_base_url('HeatingOnSchoolDays')
   end
   alias_method :analyse_private, :calculate
 end

--- a/lib/dashboard/alerts/gas/boiler control/alert_thermostatic_control.rb
+++ b/lib/dashboard/alerts/gas/boiler control/alert_thermostatic_control.rb
@@ -110,7 +110,6 @@ class AlertThermostaticControl < AlertGasModelBase
     @status = @rating < 5.0 ? :bad : :good
 
     @term = :longterm
-    @bookmark_url = add_book_mark_to_base_url('ThermostaticControl')
   end
   alias_method :analyse_private, :calculate
 

--- a/lib/dashboard/alerts/gas/hot water/alert_hot_water_efficiency.rb
+++ b/lib/dashboard/alerts/gas/hot water/alert_hot_water_efficiency.rb
@@ -135,7 +135,6 @@ class AlertHotWaterEfficiency < AlertGasModelBase
       @rating = calculate_rating_from_range(0.6, 0.05, @existing_gas_efficiency)
 
       @term = :shortterm
-      @bookmark_url = add_book_mark_to_base_url('HotWaterEfficiency')
     end
   end
   alias_method :analyse_private, :calculate

--- a/lib/dashboard/alerts/gas/hot water/alert_poorly_insulated_hotwater.rb
+++ b/lib/dashboard/alerts/gas/hot water/alert_poorly_insulated_hotwater.rb
@@ -105,7 +105,6 @@ class AlertHotWaterInsulationAdvice < AlertGasModelBase
       @status = !enough_data ? :fail : (rating > 3.0 ? :good : :bad)
     end
     @term = :longterm
-    @bookmark_url = nil
   end
   alias_method :analyse_private, :calculate
 end

--- a/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_period_comparison_base.rb
@@ -251,7 +251,6 @@ class AlertPeriodComparisonBase < AlertAnalysisBase
 
     @rating = calculate_rating(@change_in_weekly_percent, @change_in_weekly_£, fuel_type)
 
-    @bookmark_url = add_book_mark_to_base_url(url_bookmark)
     @term = :shortterm
   end
   alias_method :analyse_private, :calculate

--- a/spec/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator_spec.rb
+++ b/spec/lib/dashboard/alerts/electricity/alert_solar_pv_benefit_estimator_spec.rb
@@ -18,7 +18,6 @@ describe AlertSolarPVBenefitEstimator do
       status: '',
       rating: '5',
       term: '',
-      bookmark_url: '',
       max_asofdate: '',
       pupils: '961',
       floor_area: '5,900 m2',


### PR DESCRIPTION
The alerts all have old bookmark urls used to generate pages. We no longer need those and they don't work any more.

So removed them to very slightly reduce size of variables stored by application.