### PR TITLE
Fix errors and remove debug variables in period comparison alerts

### DIFF
--- a/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_base.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_arbitrary_period_comparison_base.rb
@@ -7,11 +7,15 @@ class AlertArbitraryPeriodComparisonBase < AlertHolidayComparisonBase
   end
 
   private   def period_type;        'arbitrary period'          end
-  protected def period_name(period); basic_configuration[:name] end
+  protected def period_name(period); comparison_configuration[:name] end
   private def calculate_time_of_year_relevance(asof_date)
     return 10.0 if asof_date >= @current_period.end_date
     return  5.0 if asof_date >= @current_period.start_date
     0.0
+  end
+
+  def timescale
+    "custom"
   end
 end
 

--- a/lib/dashboard/alerts/time period comparison/alert_period_comparison_temperature_adjustment_mixin.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_period_comparison_temperature_adjustment_mixin.rb
@@ -21,10 +21,6 @@ module AlertPeriodComparisonTemperatureAdjustmentMixin
       total_previous_period_unadjusted_co2:{
         description: 'Total co2 in previous period, unadjusted for temperature or length of holiday',
         units:  :co2
-      },
-      previous_period_kwhs_adjusted: {
-        description: 'Previous period kwh values adjusted for temperature',
-        units:  String
       }
     }
   end
@@ -49,18 +45,7 @@ module AlertPeriodComparisonTemperatureAdjustmentMixin
 
     kwh = target_kwh(previous_date, data_type) * adjustment
 
-    saved_adjusted_kwhs_in_date_order(previous_date, kwh) if data_type == :kwh
-
     @previous_kwh_cache[previous_date][data_type] = kwh
-  end
-
-  def saved_adjusted_kwhs_in_date_order(previous_date, kwh)
-    @previous_period_kwhs_adjusted_data ||= {}
-    @previous_period_kwhs_adjusted_data[previous_date] = kwh
-    # a bit inefficient but as holidays then not too many elements
-    @previous_period_kwhs_adjusted_data = @previous_period_kwhs_adjusted_data.sort.to_h
-    component_kwhs = @previous_period_kwhs_adjusted_data.values.map { |kwh| kwh.round(0) }.join('+')
-    @previous_period_kwhs_adjusted = "#{@previous_period_kwhs_adjusted_data.values.sum.round(0)} = #{component_kwhs}"
   end
 
   private def target_kwh(date, data_type)

--- a/spec/lib/dashboard/alerts/time period comparison/alert_configurable_period_electricity_comparison_spec.rb
+++ b/spec/lib/dashboard/alerts/time period comparison/alert_configurable_period_electricity_comparison_spec.rb
@@ -21,6 +21,10 @@ describe AlertConfigurablePeriodElectricityComparison do
     }
   end
 
+  describe '#timescale' do
+    it { expect(alert.timescale).to eq('custom') }
+  end
+
   describe '#analyse' do
     it 'runs and sets variables' do
       expect(alert.valid_alert?).to be true
@@ -29,9 +33,11 @@ describe AlertConfigurablePeriodElectricityComparison do
       expect(alert.current_period_kwh).to be_within(0.01).of(48)
       expect(alert.current_period_start_date).to eq(Date.new(2023, 11, 24))
       expect(alert.current_period_end_date).to eq(Date.new(2023, 11, 24))
+      expect(alert.name_of_current_period).to eq(configuration[:name])
       expect(alert.previous_period_kwh).to be_within(0.01).of(48)
       expect(alert.previous_period_start_date).to eq(Date.new(2023, 11, 17))
       expect(alert.previous_period_end_date).to eq(Date.new(2023, 11, 17))
+      expect(alert.name_of_previous_period).to eq(configuration[:name])
     end
 
     it 'errors with not enough days of data' do

--- a/spec/lib/dashboard/alerts/time period comparison/alert_configurable_period_gas_comparison_spec.rb
+++ b/spec/lib/dashboard/alerts/time period comparison/alert_configurable_period_gas_comparison_spec.rb
@@ -7,16 +7,23 @@ describe AlertConfigurablePeriodGasComparison, :aggregate_failures do
     meter_collection = build(:meter_collection, :with_fuel_and_aggregate_meters,
                              start_date: Date.new(2022, 11, 1), end_date: Date.new(2023, 11, 30),
                              fuel_type: :gas, random_generator: Random.new(22))
-    configuration = {
+    alert = described_class.new(meter_collection)
+    alert.comparison_configuration = configuration
+    alert
+  end
+
+  let(:configuration) do
+    {
       name: 'Layer up power down day 24 November 2023',
       max_days_out_of_date: 365,
       enough_days_data: 1,
       current_period: Date.new(2023, 11, 24)..Date.new(2023, 11, 24),
       previous_period: Date.new(2023, 11, 17)..Date.new(2023, 11, 17)
     }
-    alert = described_class.new(meter_collection)
-    alert.comparison_configuration = configuration
-    alert
+  end
+
+  describe '#timescale' do
+    it { expect(alert.timescale).to eq('custom') }
   end
 
   describe '#analyse' do
@@ -24,6 +31,8 @@ describe AlertConfigurablePeriodGasComparison, :aggregate_failures do
       alert.analyse(Date.new(2023, 11, 30))
       expect(alert.previous_period_kwh).to be_within(0.01).of(48)
       expect(alert.current_period_kwh).to be_within(0.01).of(48)
+      expect(alert.name_of_current_period).to eq(configuration[:name])
+      expect(alert.name_of_previous_period).to eq(configuration[:name])
     end
   end
 end

--- a/spec/lib/dashboard/alerts/time period comparison/alert_configurable_period_storage_heater_comparison_spec.rb
+++ b/spec/lib/dashboard/alerts/time period comparison/alert_configurable_period_storage_heater_comparison_spec.rb
@@ -7,16 +7,23 @@ describe AlertConfigurablePeriodStorageHeaterComparison do
     meter_collection = build(:meter_collection, :with_fuel_and_aggregate_meters,
                              start_date: Date.new(2022, 11, 1), end_date: Date.new(2023, 11, 30),
                              storage_heaters: true)
-    configuration = {
+    alert = described_class.new(meter_collection)
+    alert.comparison_configuration = configuration
+    alert
+  end
+
+  let(:configuration) do
+    {
       name: 'Layer up power down day 24 November 2023',
       max_days_out_of_date: 365,
       enough_days_data: 1,
       current_period: Date.new(2023, 11, 24)..Date.new(2023, 11, 24),
       previous_period: Date.new(2023, 11, 17)..Date.new(2023, 11, 17)
     }
-    alert = described_class.new(meter_collection)
-    alert.comparison_configuration = configuration
-    alert
+  end
+
+  describe '#timescale' do
+    it { expect(alert.timescale).to eq('custom') }
   end
 
   describe '#analyse' do
@@ -24,6 +31,8 @@ describe AlertConfigurablePeriodStorageHeaterComparison do
       alert.analyse(Date.new(2023, 11, 30))
       expect(alert.previous_period_kwh).to be_within(0.01).of(27)
       expect(alert.current_period_kwh).to be_within(0.01).of(27)
+      expect(alert.name_of_current_period).to eq(configuration[:name])
+      expect(alert.name_of_previous_period).to eq(configuration[:name])
     end
   end
 end


### PR DESCRIPTION
Reviewing the alert table size, I noticed that the alerts with the largest records are those that do period comparisons. The configurable period alerts are the largest (>20kb text in `template_data`), but the other period comparisons are also large (> 2kb text in `template_data`).

Checking the output of these alerts I noticed that:

- there was an error thrown when generating the period names which is leading us to store a complete stack trace as the variable value. Repeated twice for each period and once each for the english and welsh formatted variables (`template_data`, `template_data_cy`) and the raw unformatted variables (`variables), this explains why some of the TOAST entries are very large
- there was a missing translation causing another error to appear in the `timescale` variable
- lengthy text to state the tariff has changed during the compared periods which is not used anywhere
- several debug variables which listed every temperature or daily kWh reading for the current and previous periods. Given that some of the periods span 6-9 months thats a lot of extra text

This PR fixes the bugs and removes a number of debug variables which are no longer needed.

These alerts run for most schools, so that's a lot of unnecessary text we're storing. This should greatly reduce the amount of data stored in the alerts TOAST table.

I've regenerated several schools using this version of the code and confirmed the fixes.