### PR TITLE
Fix schoolweek comparison alert

### DIFF
--- a/lib/dashboard/alerts/time period comparison/alert_schoolweek_comparison_gas.rb
+++ b/lib/dashboard/alerts/time period comparison/alert_schoolweek_comparison_gas.rb
@@ -42,12 +42,6 @@ class AlertSchoolWeekComparisonGas < AlertSchoolWeekComparisonElectricity
       current_week_kwhs:              { description: 'List of current school week kWh values', units:  String },
       previous_week_kwhs_unadjusted:  { description: 'List of previous school week kWh values (unadjusted)', units:  String  },
       previous_week_kwhs_adjusted:    { description: 'List of previous school week kWh values (adjusted)', units:  String  },
-      current_weeks_temperatures:     { description: 'Current week temperatures', units:  String  },
-      previous_weeks_temperatures:    { description: 'Previous week temperatures', units:  String  },
-
-      current_weeks_average_temperature:  { description: 'Current weeks average temperature',  units:  :temperature },
-      previous_weeks_average_temperature: { description: 'Previous weeks average temperature', units:  :temperature },
-
       current_week_kwh_total:             { description: 'Current week total kWh',                units:  :kwh  },
       previous_week_kwh_unadjusted_total: { description: 'Previous week total kWh (unadjusted)' , units:  :kwh, benchmark_code: 'najk'  },
       previous_week_kwh_total:            { description: 'Previous week total kWh (from chart, adjusted, maybe slightly different from previous_period_kwh which uses better underlying alert compensation )',    units:  :kwh, benchmark_code: 'ajkw'  },
@@ -92,9 +86,6 @@ class AlertSchoolWeekComparisonGas < AlertSchoolWeekComparisonElectricity
     @current_week_kwh_total             = unadjusted_data.values[1].sum
     @previous_week_kwh_unadjusted_total = unadjusted_data.values[0].sum
     @previous_week_kwh_total            = adjusted_data.values[0].sum
-
-    @current_weeks_temperatures,  @current_weeks_average_temperature  = weeks_temperatures(unadjusted_data.keys[1])
-    @previous_weeks_temperatures, @previous_weeks_average_temperature = weeks_temperatures(unadjusted_data.keys[0])
 
     @current_period  = SchoolDatePeriod.new(:schoolweek, 'Current school week',  unadjusted_data.keys[1].first, unadjusted_data.keys[1].last)
     @previous_period = SchoolDatePeriod.new(:schoolweek, 'Previous school week', unadjusted_data.keys[0].first, unadjusted_data.keys[0].last)

--- a/spec/lib/dashboard/alerts/time period comparison/alert_school_week_comparison_electricity_spec.rb
+++ b/spec/lib/dashboard/alerts/time period comparison/alert_school_week_comparison_electricity_spec.rb
@@ -31,9 +31,14 @@ describe AlertSchoolWeekComparisonElectricity do
 
   let(:analysis_date) { Date.new(2023, 10, 15) } # few weeks into autum term
 
+  around do |example|
+    travel_to analysis_date do
+      example.run
+    end
+  end
+
   describe '#analyse' do
     before do
-      travel_to analysis_date
       alert.analyse(analysis_date)
     end
 

--- a/spec/lib/dashboard/alerts/time period comparison/alert_school_week_comparison_electricity_spec.rb
+++ b/spec/lib/dashboard/alerts/time period comparison/alert_school_week_comparison_electricity_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe AlertSchoolWeekComparisonElectricity do
+  subject(:alert) { described_class.new(meter_collection) }
+
+  let(:meter_collection) do
+    temperatures = build(:temperatures, :with_summer_and_winter, start_date: Date.new(2023, 1, 1), end_date: Date.new(2023, 12, 31))
+
+    meter_collection = build(:meter_collection,
+                             holidays: build(:holidays, :with_calendar_year, year: 2023),
+                             temperatures: temperatures,
+                             start_date: Date.new(2023, 1, 1),
+                             end_date: Date.new(2023, 12, 31))
+
+    amr_data = build(:amr_data, :with_summer_and_winter_usage,
+                     type: :electricity,
+                     start_date: Date.new(2023, 1, 1),
+                     end_date: Date.new(2023, 12, 31))
+
+    meter = build(:meter, :with_flat_rate_tariffs,
+                  meter_collection: meter_collection,
+                  type: :electricity,
+                  amr_data: amr_data)
+    meter_collection.add_electricity_meter(meter)
+    AggregateDataService.new(meter_collection).aggregate_heat_and_electricity_meters
+
+    meter_collection
+  end
+
+  let(:analysis_date) { Date.new(2023, 10, 15) } # few weeks into autum term
+
+  describe '#analyse' do
+    before do
+      travel_to analysis_date
+      alert.analyse(analysis_date)
+    end
+
+    it 'uses the right periods' do
+      expect(alert.previous_period_start_date).to eq(Date.new(2023, 10, 1))
+      expect(alert.previous_period_end_date).to eq(Date.new(2023, 10, 7))
+
+      expect(alert.current_period_start_date).to eq(Date.new(2023, 10, 8))
+      expect(alert.current_period_end_date).to eq(Date.new(2023, 10, 14))
+
+      expect(alert.truncated_current_period).to be(false)
+    end
+
+    it_behaves_like 'a valid alert', date: Date.new(2023, 10, 15)
+  end
+end

--- a/spec/lib/dashboard/alerts/time period comparison/alert_school_week_comparison_gas_spec.rb
+++ b/spec/lib/dashboard/alerts/time period comparison/alert_school_week_comparison_gas_spec.rb
@@ -31,9 +31,14 @@ describe AlertSchoolWeekComparisonGas do
 
   let(:analysis_date) { Date.new(2023, 10, 15) } # few weeks into autum term
 
+  around do |example|
+    travel_to analysis_date do
+      example.run
+    end
+  end
+
   describe '#analyse' do
     before do
-      travel_to analysis_date
       stub_const('Rails', true) # FIXME: required because of ChartManager code, which needs removing.
       alert.analyse(analysis_date)
     end

--- a/spec/lib/dashboard/alerts/time period comparison/alert_school_week_comparison_gas_spec.rb
+++ b/spec/lib/dashboard/alerts/time period comparison/alert_school_week_comparison_gas_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe AlertSchoolWeekComparisonGas do
+  subject(:alert) { described_class.new(meter_collection) }
+
+  let(:meter_collection) do
+    temperatures = build(:temperatures, :with_summer_and_winter, start_date: Date.new(2023, 1, 1), end_date: Date.new(2023, 12, 31))
+
+    meter_collection = build(:meter_collection,
+                             holidays: build(:holidays, :with_calendar_year, year: 2023),
+                             temperatures: temperatures,
+                             start_date: Date.new(2023, 1, 1),
+                             end_date: Date.new(2023, 12, 31))
+
+    amr_data = build(:amr_data, :with_summer_and_winter_usage,
+                     type: :gas,
+                     start_date: Date.new(2023, 1, 1),
+                     end_date: Date.new(2023, 12, 31))
+
+    meter = build(:meter, :with_flat_rate_tariffs,
+                  meter_collection: meter_collection,
+                  type: :gas,
+                  amr_data: amr_data)
+    meter_collection.add_heat_meter(meter)
+    AggregateDataService.new(meter_collection).aggregate_heat_and_electricity_meters
+
+    meter_collection
+  end
+
+  let(:analysis_date) { Date.new(2023, 10, 15) } # few weeks into autum term
+
+  describe '#analyse' do
+    before do
+      travel_to analysis_date
+      stub_const('Rails', true) # FIXME: required because of ChartManager code, which needs removing.
+      alert.analyse(analysis_date)
+    end
+
+    it 'uses the right periods' do
+      expect(alert.previous_period_start_date).to eq(Date.new(2023, 10, 1))
+      expect(alert.previous_period_end_date).to eq(Date.new(2023, 10, 7))
+
+      expect(alert.current_period_start_date).to eq(Date.new(2023, 10, 8))
+      expect(alert.current_period_end_date).to eq(Date.new(2023, 10, 14))
+
+      expect(alert.truncated_current_period).to be(false)
+    end
+
+    it_behaves_like 'a valid alert', date: Date.new(2023, 10, 15)
+  end
+end

--- a/spec/lib/dashboard/alerts/time period comparison/alert_school_week_comparison_storage_heater_spec.rb
+++ b/spec/lib/dashboard/alerts/time period comparison/alert_school_week_comparison_storage_heater_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe AlertSchoolWeekComparisonStorageHeater do
+  subject(:alert) { described_class.new(meter_collection) }
+
+  let(:meter_collection) do
+    temperatures = build(:temperatures, :with_summer_and_winter, start_date: Date.new(2023, 1, 1), end_date: Date.new(2023, 12, 31))
+
+    meter_collection = build(:meter_collection,
+                             holidays: build(:holidays, :with_calendar_year, year: 2023),
+                             temperatures: temperatures,
+                             start_date: Date.new(2023, 1, 1),
+                             end_date: Date.new(2023, 12, 31))
+
+    # Fake up storage heater being on between 2am-6am all year round
+    amr_data = build(:amr_data, :with_date_range,
+                     type: :gas,
+                     start_date: Date.new(2023, 1, 1),
+                     end_date: Date.new(2023, 12, 31),
+                     kwh_data_x48: Array.new(4, 3.0) + Array.new(9, 33.0) + Array.new(35, 3.0))
+
+    meter_attributes = {
+      storage_heaters: [
+        { charge_start_time: TimeOfDay.parse('02:00'),
+          charge_end_time: TimeOfDay.parse('06:00') }
+      ]
+    }
+
+    meter = build(:meter, :with_flat_rate_tariffs,
+                  meter_collection: meter_collection,
+                  meter_attributes: meter_attributes,
+                  type: :electricity,
+                  amr_data: amr_data)
+    meter_collection.add_electricity_meter(meter)
+    AggregateDataService.new(meter_collection).aggregate_heat_and_electricity_meters
+
+    meter_collection
+  end
+
+  let(:analysis_date) { Date.new(2023, 10, 15) } # few weeks into autum term
+
+  describe '#analyse' do
+    before do
+      travel_to analysis_date
+      stub_const('Rails', true) # FIXME: required because of ChartManager code, which needs removing.
+      alert.analyse(analysis_date)
+    end
+
+    it 'uses the right periods' do
+      expect(alert.previous_period_start_date).to eq(Date.new(2023, 10, 1))
+      expect(alert.previous_period_end_date).to eq(Date.new(2023, 10, 7))
+
+      expect(alert.current_period_start_date).to eq(Date.new(2023, 10, 8))
+      expect(alert.current_period_end_date).to eq(Date.new(2023, 10, 14))
+
+      expect(alert.truncated_current_period).to be(false)
+    end
+
+    it_behaves_like 'a valid alert', date: Date.new(2023, 10, 15)
+  end
+end

--- a/spec/lib/dashboard/alerts/time period comparison/alert_school_week_comparison_storage_heater_spec.rb
+++ b/spec/lib/dashboard/alerts/time period comparison/alert_school_week_comparison_storage_heater_spec.rb
@@ -41,9 +41,14 @@ describe AlertSchoolWeekComparisonStorageHeater do
 
   let(:analysis_date) { Date.new(2023, 10, 15) } # few weeks into autum term
 
+  around do |example|
+    travel_to analysis_date do
+      example.run
+    end
+  end
+
   describe '#analyse' do
     before do
-      travel_to analysis_date
       stub_const('Rails', true) # FIXME: required because of ChartManager code, which needs removing.
       alert.analyse(analysis_date)
     end


### PR DESCRIPTION
Changes to base class broke the school week gas comparison.

PR fixes the comparison and adds a basic spec for all three variants confirming that they at least run and analyse the right time periods.