### PR TITLE
fixes for exceptions from alerts seen in logs

### DIFF
--- a/lib/dashboard/alerts/gas/alert_gas_model_base.rb
+++ b/lib/dashboard/alerts/gas/alert_gas_model_base.rb
@@ -87,11 +87,11 @@ class AlertGasModelBase < AlertGasOnlyBase
   end
 
   def a
-    @a ||= @heating_model.average_heating_school_day_a
+    @a ||= @heating_model&.average_heating_school_day_a
   end
 
   def b
-    @b ||= @heating_model.average_heating_school_day_b
+    @b ||= @heating_model&.average_heating_school_day_b
   end
 
   def school_days_heating
@@ -111,7 +111,7 @@ class AlertGasModelBase < AlertGasOnlyBase
   end
 
   def non_school_days_heating
-    @non_school_days_heating ||= @heating_model.number_of_non_school_heating_days
+    @non_school_days_heating ||= @heating_model&.number_of_non_school_heating_days
   end
 
   def non_school_days_heating_adjective

--- a/lib/dashboard/alerts/gas/alert_gas_model_base.rb
+++ b/lib/dashboard/alerts/gas/alert_gas_model_base.rb
@@ -95,7 +95,7 @@ class AlertGasModelBase < AlertGasOnlyBase
   end
 
   def school_days_heating
-    @school_days_heating ||= @heating_model.number_of_heating_school_days
+    @school_days_heating ||= @heating_model&.number_of_heating_school_days
   end
 
   def school_days_heating_adjective


### PR DESCRIPTION
Exceptions seen in logs I assume when heating model wasn't able to be created

```
/var/log/rotated/worker.stdout.log1732806061.gz:Nov 28 14:35:21 ip-172-31-37-127 worker[491735]: E, [2024-11-28T14:35:21.786629 #491735] ERROR -- : [ActiveJob] [DailyRegenerationJob] [34de5e51-cf67-4952-8aca-fb5914b13fb3] Exception in variable_list for Midsomer Norton Primary School for AlertWeekendGasConsumptionShortTerm - NoMethodError: undefined method `number_of_non_school_heating_days' for nil:NilClass

/var/log/rotated/worker.stdout.log1732806061.gz:Nov 28 14:35:23 ip-172-31-37-127 worker[491735]: E, [2024-11-28T14:35:23.294005 #491735] ERROR -- : [ActiveJob] [DailyRegenerationJob] [34de5e51-cf67-4952-8aca-fb5914b13fb3] Exception in variable_list for Midsomer Norton Primary School for AlertHotWaterEfficiency - NoMethodError: undefined method `number_of_heating_school_days' for nil:NilClass

/var/log/rotated/worker.stdout.log1732806061.gz:Nov 28 14:35:23 ip-172-31-37-127 worker[491735]: E, [2024-11-28T14:35:23.207719 #491735] ERROR -- : [ActiveJob] [DailyRegenerationJob] [34de5e51-cf67-4952-8aca-fb5914b13fb3] Exception in variable_list for Midsomer Norton Primary School for AlertHotWaterEfficiency - NoMethodError: undefined method `average_heating_school_day_a' for nil:NilClass
```

