### PR TITLE
allow these to be logged to rollbar

### DIFF
--- a/lib/dashboard/charting_and_reports/content_base.rb
+++ b/lib/dashboard/charting_and_reports/content_base.rb
@@ -465,6 +465,7 @@ class ContentBase
           end
         end
       rescue StandardError => e
+        raise
         logger.error "Exception in variable_list for #{@school.name} for #{self.class} - #{e.class}: #{e.message}"
         list[type] = nil
       end


### PR DESCRIPTION
- need to wait until 'variable_list' errors are no longer appearing in production worker log