### PR TITLE
Check for nil dates in date range check

### DIFF
--- a/app/services/aggregation_mixin.rb
+++ b/app/services/aggregation_mixin.rb
@@ -158,6 +158,9 @@ module AggregationMixin
     end
     min_date, max_date = combined_amr_data_date_range(meters, ignore_rules)
 
+    # If all meters have an ignore_start_date or ignore_end_date attribute we end up with null dates, so check and throw exception
+    raise EnergySparksUnexpectedStateException, 'Invalid AMR date range. Cannot calculate start date. Ensure at least one meter does not have ignore_start_date attribute' if min_date.nil?
+    raise EnergySparksUnexpectedStateException, 'Invalid AMR date range. Cannot calculate end date. Ensure at least one meter does not have ignore_end_date attribute' if max_date.nil?
     # This can happen if there are 2 meter, with non-overlapping date ranges
     # Without a check, the renaming code is run but we end up with an aggregate meter that
     # contains no readings and has default dates from HalfHourlyData.new. This can cause errors elsewhere as other

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -8,7 +8,7 @@ require_rel '../../test_support'
 # end
 
 # Romilly, gas
-asof_date = Date.new(2025, 1, 8)
+asof_date = Date.new(2024, 3, 25)
 schools = ['r*']
 
 # Mallaig, storage/electricity
@@ -28,7 +28,7 @@ overrides = {
 #    AlertThermostaticControl
 #    AlertEnergyAnnualVersusBenchmark,
 #    AlertSchoolWeekComparisonGas,
-    AlertOutOfHoursElectricityUsage,
+#    AlertOutOfHoursElectricityUsage,
 #    AlertElectricityBaseloadVersusBenchmark,
 #    AlertHeatingComingOnTooEarly,
 #    AlertPreviousYearHolidayComparisonElectricity,
@@ -58,7 +58,7 @@ overrides = {
     #AlertEnergyAnnualVersusBenchmark,
     #AlertAdditionalPrioritisationData,
     #AlertHotWaterEfficiency
-#    AlertGasHeatingHotWaterOnDuringHoliday,
+    AlertGasHeatingHotWaterOnDuringHoliday,
 #    AlertStorageHeaterHeatingOnDuringHoliday,
 #    AlertElectricityUsageDuringCurrentHoliday
     ],

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -8,7 +8,7 @@ require_rel '../../test_support'
 # end
 
 # Romilly, gas
-asof_date = Date.new(2024, 3, 25)
+asof_date = Date.new(2025, 1, 8)
 schools = ['r*']
 
 # Mallaig, storage/electricity
@@ -28,7 +28,7 @@ overrides = {
 #    AlertThermostaticControl
 #    AlertEnergyAnnualVersusBenchmark,
 #    AlertSchoolWeekComparisonGas,
-#    AlertOutOfHoursElectricityUsage,
+    AlertOutOfHoursElectricityUsage,
 #    AlertElectricityBaseloadVersusBenchmark,
 #    AlertHeatingComingOnTooEarly,
 #    AlertPreviousYearHolidayComparisonElectricity,
@@ -58,7 +58,7 @@ overrides = {
     #AlertEnergyAnnualVersusBenchmark,
     #AlertAdditionalPrioritisationData,
     #AlertHotWaterEfficiency
-    AlertGasHeatingHotWaterOnDuringHoliday,
+#    AlertGasHeatingHotWaterOnDuringHoliday,
 #    AlertStorageHeaterHeatingOnDuringHoliday,
 #    AlertElectricityUsageDuringCurrentHoliday
     ],

--- a/spec/app/models/open_close_times_spec.rb
+++ b/spec/app/models/open_close_times_spec.rb
@@ -15,6 +15,10 @@ describe OpenCloseTimes do
     # before Autumn holiday
     let(:day)                   { Date.new(last_year, 10, 16) }
 
+    before do
+      travel_to(Date.new(2024, 12, 1))
+    end
+
     describe 'with school times only' do
       it 'creates school times' do
         expect(open_close_times.open_times.length).to eq 1

--- a/spec/lib/dashboard/aggregation/community_use_breakdown_spec.rb
+++ b/spec/lib/dashboard/aggregation/community_use_breakdown_spec.rb
@@ -20,6 +20,7 @@ describe CommunityUseBreakdown do
 
   before do
     meter.amr_data.open_close_breakdown = open_close_breakdown
+    travel_to(Date.new(2024, 12, 1))
   end
 
   describe '#days_kwh_x48' do


### PR DESCRIPTION
We have a precondition check in the aggregation_mixin to sanity check aggregate meter date ranges before continuing with the aggregation process. Updated the check for nil start and end dates with suitable error messages.

Fixes an issue that came up in production due to a configuration error. Without the check the subsequent errors don't make it clear what has happened.