### PR TITLE
error on formating NaN day

### DIFF
--- a/lib/dashboard/modelling/heating/heating_regression_models.rb
+++ b/lib/dashboard/modelling/heating/heating_regression_models.rb
@@ -1055,7 +1055,7 @@ module AnalyseHeatingAndHotWater
     end
 
     def number_of_heating_school_days
-      @meter.non_heating_only? ? Float::NAN : @models[HEATINGOCCUPIEDMODEL].samples
+      @meter.non_heating_only? ? nil : @models[HEATINGOCCUPIEDMODEL].samples
     end
 
     def average_heating_school_day_a


### PR DESCRIPTION
from `Exception in variable_list for Highfields Primary School for AlertHeatingComingOnTooEarly - FloatDomainError: NaN (/var/app/bundle/ruby/3.2.0/bundler/gems/energy-sparks_analytics-f9a9849f112b/lib/dashboard/utilities/format_energy_unit.rb:198:in `to_i')`