### PR TITLE
Fallback to not calculating DUoS costs if cannot find region

### DIFF
--- a/app/models/tariffs/distribution_use_of_system_charges.rb
+++ b/app/models/tariffs/distribution_use_of_system_charges.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # https://www.catalyst-commercial.co.uk/dcp228-duos-charges/
 # https://en.wikipedia.org/wiki/Electricity_billing_in_the_UK/
 #
@@ -50,7 +52,7 @@ class DUOSCharges
     banding = {}
     (10..23).each do |region|
       banding[region] = { name: DUOS_BY_REGION[region][:name], weekdays: [], weekends: [] }
-      mpan = region * 100000000000
+      mpan = region * 100_000_000_000
       (0..47).each do |hhi|
         banding[region][:weekdays].push(DUOSCharges.band(mpan, Date.new(2021, 6, 4), hhi))
         banding[region][:weekends].push(DUOSCharges.band(mpan, Date.new(2021, 6, 5), hhi))
@@ -61,7 +63,7 @@ class DUOSCharges
 
   # reused by tnuos class
   def self.region_number(mpan)
-    region = (mpan / 100000000000).to_i
+    region = (mpan / 100_000_000_000).to_i
     check_region(mpan, region)
     region
   end
@@ -72,86 +74,73 @@ class DUOSCharges
   # which was cutted and pasted from https://www.catalyst-commercial.co.uk/dcp228-duos-charges/
   # with corrections from https://www.ofgem.gov.uk/sites/default/files/docs/2009/09/appendix-c_illustrative-charges-and-time-bands_0.pdf
   # region 16, weekends 12:30 => 16:30
-  DASH = "–" # the dash on the spreadsheet is not a minus sign
+  DASH = '–' # the dash on the spreadsheet is not a minus sign
 
   DUOS_BY_REGION = {
-    10 => {   name:  'Eastern (EELC)',
-      bands: { red:   { weekdays: '16:00 – 19:00 ' },
-      amber:  { weekdays: '07:00 – 16:00 & 19:00 – 23:00 '  },
-      green:  { weekdays: '00:00 – 07:00 & 23:00 – 24:00 '  , weekends: 'all day' },
-    },          },
-    11 => {   name:  'Western Power – Midlands, South West & Wales (EMEB)',
-        bands: { red:   { weekdays: '16:00 – 19:00 ' },
-        amber:  { weekdays: '07:30 – 16:00 & 19:00 – 21:00 '  },
-        green:  { weekdays: '00:00 – 07:30 & 21:00 – 24:00 '  , weekends: 'all day' },  },
-    },
-    12 => {   name:  'London Power (LOND)',
-        bands: { red:   { weekdays: '11:00 – 14:00 & 16:00 – 19:00 '  },
-        amber:  { weekdays: '07:00 – 11:00 & 14:00 – 16:00 & 19:00 – 23:00 ' },
-        green:  { weekdays: '00:00 – 07:00 & 23:00 – 24:00 '  , weekends: 'all day' },  },
-    },
-    13 => {   name:  'Manweb (MANW)',
-        bands: { red:   { weekdays: '16:30 – 19:30 ' },
-        amber:  { weekdays: '08:00 – 16:30 & 19:30 – 22:30 '  , weekends: '16:00 – 20:00' },
-        green:  { weekdays: '00:00 – 08:00 & 22:30 – 24:00 '  , weekends: '00:00 – 16:00 & 20:00 – 24:00' },  },
-    },
-    14 => {   name:  'Western Power – Midlands, South West & Wales (MIDE)',
-        bands: { red:   { weekdays: '16:00 – 19:00 ' },
-        amber:  { weekdays: '07:30 – 16:00 & 19:00 – 21:00 '  },
-        green:  { weekdays: '00:00 – 07:30 & 21:00 – 24:00 '  , weekends: 'all day' },  },
-    },
-    15 => {   name:  'NorthEast (NEEB)',
-        bands: { red:   { weekdays: '16:00 – 19:30 ' },
-        amber:  { weekdays: '08:00 – 16:00 & 19:30 – 22:00 '  },
-        green:  { weekdays: '00:00 – 08:00 & 22:00 – 24:00 '  , weekends: 'all day' },  },
-    },
-    16 => {   name:  'North West (NORW)',
-        bands: { red:   { weekdays: '16:30 – 18:30 & 19:30 – 22:00 '  },
-        amber:  { weekdays: '09:00 – 16:30 & 18:30 – 20:30 '  , weekends: '16:30 – 18:30' },
-        green:  { weekdays: '00:00 – 09:00 & 20:30 – 24:00 '  , weekends: '00:00 – 16:30 & 18:30 – 24:00' },  },
-    },
-    17 => {   name:  'Scottish Hydro (HYDE)',
-        bands: { red:   { weekdays: '12:30 – 14:30 & 16:30 – 21:00 '  },
-        amber:  { weekdays: '07:00 – 12:30 & 14:30 – 16:30 '  , weekends: '12:30 – 14:00 & 17:30 – 20:30' },
-        green:  { weekdays: '00:00 – 07:00 & 21:00 – 24:00 '  , weekends: '00:00 – 12:30 & 14:00 – 17:30 & 20:30 – 24:00' }, },
-    },
-    18 => {   name:  'Scottish Power (SPOW)',
-        bands: { red:   { weekdays: '16:30 – 19:30 ' },
-        amber:  { weekdays: '08:00 – 16:30 & 19:30 – 22:30 '  , weekends: '16:00 – 20:00' },
-        green:  { weekdays: '00:00 – 08:00 & 22:30 – 24:00 '  , weekends: '00:00 – 16:00 & 20:00 – 24:00' },  },
-    },
-    19 => {   name:  'South Eastern (SEEB)',
-        bands: { red:   { weekdays: '16:00 – 19:00 ' },
-        amber:  { weekdays: '07:00 – 16:00 & 19:00 – 23:00 '  },
-        green:  { weekdays: '00:00 – 07:00 & 23:00 – 24:00 '  , weekends: 'all day' },  },
-    },
-    20 => {   name:  'Southern Electric (SOUT)',
-        bands: { red:   { weekdays: '16:30 – 19:00 ' },
-        amber:  { weekdays: '09:00 – 16:30 & 19:00 – 20:30 '  },
-        green:  { weekdays: '00:00 – 09:00 & 20:30 – 24:00 '  , weekends: 'all day' },  },
-    },
-    21 => {   name:  'Western Power – Midlands, South West & Wales (SWALEC)',
-        bands: { red:   { weekdays: '17:00 – 19:30 ' },
-        amber:  { weekdays: '07:30 – 17:00 & 19:30 – 22:00 '  , weekends: '12:00 – 13:00 & 16:00 – 21:00' },
-        green:  { weekdays: '00:00 – 07:30 & 22:00 – 24:00 '  , weekends: '00:00 – 12:00 & 13:00 – 16:00 & 21:00 – 24:00' }, },
-    },
-    22 => {   name:  'Western Power – Midlands, South West & Wales (SWEB)',
-        bands: { red:   { weekdays: '17:00 – 19:00 ' },
-        amber:  { weekdays: '07:30 – 17:00 & 19:00 – 21:30 '  , weekends: '16:30 – 19:30' },
-        green:  { weekdays: '00:00 – 7:30 & 21:30 – 24:00 ' , weekends: '00:00 – 16:30 & 19:30 – 24:00' },  },
-    },
-    23 => {   name:  'NorthEast (YELG)',
-        bands: { red:   { weekdays: '16:00 – 19:30 ' },
-        amber:  { weekdays: '08:00 – 16:00 & 19:30 – 22:00 '  },
-        green:  { weekdays: '00:00 – 08:00 & 22:00 – 24:00 '  , weekends: 'all day' },  },
-    },
-  }
+    10 => { name: 'Eastern (EELC)',
+            bands: { red: { weekdays: '16:00 – 19:00 ' },
+                     amber: { weekdays: '07:00 – 16:00 & 19:00 – 23:00 '  },
+                     green: { weekdays: '00:00 – 07:00 & 23:00 – 24:00 ', weekends: 'all day' } } },
+    11 => { name: 'Western Power – Midlands, South West & Wales (EMEB)',
+            bands: { red: { weekdays: '16:00 – 19:00 ' },
+                     amber: { weekdays: '07:30 – 16:00 & 19:00 – 21:00 '  },
+                     green: { weekdays: '00:00 – 07:30 & 21:00 – 24:00 ', weekends: 'all day' } } },
+    12 => { name: 'London Power (LOND)',
+            bands: { red: { weekdays: '11:00 – 14:00 & 16:00 – 19:00 ' },
+                     amber: { weekdays: '07:00 – 11:00 & 14:00 – 16:00 & 19:00 – 23:00 ' },
+                     green: { weekdays: '00:00 – 07:00 & 23:00 – 24:00 ', weekends: 'all day' } } },
+    13 => { name: 'Manweb (MANW)',
+            bands: { red: { weekdays: '16:30 – 19:30 ' },
+                     amber: { weekdays: '08:00 – 16:30 & 19:30 – 22:30 ', weekends: '16:00 – 20:00' },
+                     green: { weekdays: '00:00 – 08:00 & 22:30 – 24:00 ', weekends: '00:00 – 16:00 & 20:00 – 24:00' } } },
+    14 => { name: 'Western Power – Midlands, South West & Wales (MIDE)',
+            bands: { red: { weekdays: '16:00 – 19:00 ' },
+                     amber: { weekdays: '07:30 – 16:00 & 19:00 – 21:00 '  },
+                     green: { weekdays: '00:00 – 07:30 & 21:00 – 24:00 ', weekends: 'all day' } } },
+    15 => { name: 'NorthEast (NEEB)',
+            bands: { red: { weekdays: '16:00 – 19:30 ' },
+                     amber: { weekdays: '08:00 – 16:00 & 19:30 – 22:00 '  },
+                     green: { weekdays: '00:00 – 08:00 & 22:00 – 24:00 ', weekends: 'all day' } } },
+    16 => { name: 'North West (NORW)',
+            bands: { red: { weekdays: '16:30 – 18:30 & 19:30 – 22:00 ' },
+                     amber: { weekdays: '09:00 – 16:30 & 18:30 – 20:30 ', weekends: '16:30 – 18:30' },
+                     green: { weekdays: '00:00 – 09:00 & 20:30 – 24:00 ', weekends: '00:00 – 16:30 & 18:30 – 24:00' } } },
+    17 => { name: 'Scottish Hydro (HYDE)',
+            bands: { red: { weekdays: '12:30 – 14:30 & 16:30 – 21:00 ' },
+                     amber: { weekdays: '07:00 – 12:30 & 14:30 – 16:30 ', weekends: '12:30 – 14:00 & 17:30 – 20:30' },
+                     green: { weekdays: '00:00 – 07:00 & 21:00 – 24:00 ', weekends: '00:00 – 12:30 & 14:00 – 17:30 & 20:30 – 24:00' } } },
+    18 => { name: 'Scottish Power (SPOW)',
+            bands: { red: { weekdays: '16:30 – 19:30 ' },
+                     amber: { weekdays: '08:00 – 16:30 & 19:30 – 22:30 ', weekends: '16:00 – 20:00' },
+                     green: { weekdays: '00:00 – 08:00 & 22:30 – 24:00 ', weekends: '00:00 – 16:00 & 20:00 – 24:00' } } },
+    19 => { name: 'South Eastern (SEEB)',
+            bands: { red: { weekdays: '16:00 – 19:00 ' },
+                     amber: { weekdays: '07:00 – 16:00 & 19:00 – 23:00 '  },
+                     green: { weekdays: '00:00 – 07:00 & 23:00 – 24:00 ', weekends: 'all day' } } },
+    20 => { name: 'Southern Electric (SOUT)',
+            bands: { red: { weekdays: '16:30 – 19:00 ' },
+                     amber: { weekdays: '09:00 – 16:30 & 19:00 – 20:30 '  },
+                     green: { weekdays: '00:00 – 09:00 & 20:30 – 24:00 ', weekends: 'all day' } } },
+    21 => { name: 'Western Power – Midlands, South West & Wales (SWALEC)',
+            bands: { red: { weekdays: '17:00 – 19:30 ' },
+                     amber: { weekdays: '07:30 – 17:00 & 19:30 – 22:00 ', weekends: '12:00 – 13:00 & 16:00 – 21:00' },
+                     green: { weekdays: '00:00 – 07:30 & 22:00 – 24:00 ', weekends: '00:00 – 12:00 & 13:00 – 16:00 & 21:00 – 24:00' } } },
+    22 => { name: 'Western Power – Midlands, South West & Wales (SWEB)',
+            bands: { red: { weekdays: '17:00 – 19:00 ' },
+                     amber: { weekdays: '07:30 – 17:00 & 19:00 – 21:30 ', weekends: '16:30 – 19:30' },
+                     green: { weekdays: '00:00 – 7:30 & 21:30 – 24:00 ', weekends: '00:00 – 16:30 & 19:30 – 24:00' } } },
+    23 => { name: 'NorthEast (YELG)',
+            bands: { red: { weekdays: '16:00 – 19:30 ' },
+                     amber: { weekdays: '08:00 – 16:00 & 19:30 – 22:00 '  },
+                     green: { weekdays: '00:00 – 08:00 & 22:00 – 24:00 ', weekends: 'all day' } } }
+  }.freeze
   private_constant :DUOS_BY_REGION
 
   private_class_method def self.band_by_region_daytype(region, daytype, half_hour_index)
     @@band ||= {}
     colour_band = @@band.dig(region, daytype, half_hour_index)
     return colour_band unless colour_band.nil?
+
     times = DUOS_BY_REGION[region][daytype]
     cached_band(region, daytype)[half_hour_index] ||= calculate_band(region, times, daytype, half_hour_index)
   end
@@ -161,7 +150,7 @@ class DUOSCharges
     @@band[region][daytype] ||= {}
   end
 
-  private_class_method def self.calculate_band(region, times, daytype, half_hour_index)
+  private_class_method def self.calculate_band(region, _times, daytype, half_hour_index)
     DUOS_BY_REGION[region][:bands].each do |band, band_info|
       return band if band_info.key?(daytype) && in_time_range?(band_info[daytype], half_hour_index)
     end
@@ -180,12 +169,13 @@ class DUOSCharges
   private_class_method def self.time_ranges(times)
     @@time_ranges ||= {}
     return @@time_ranges[times] if @@time_ranges.key?(times)
+
     @@time_ranges[times] = calculate_time_ranges(times)
   end
 
   private_class_method def self.calculate_time_ranges(times)
     if times == 'all day'
-      [ TimeOfDay.new(0, 0)..TimeOfDay.new(23, 30) ]
+      [TimeOfDay.new(0, 0)..TimeOfDay.new(23, 30)]
     else
       breakdown_time_list(times)
     end

--- a/app/models/tariffs/generic_accounting_tariff.rb
+++ b/app/models/tariffs/generic_accounting_tariff.rb
@@ -305,9 +305,10 @@ class GenericAccountingTariff
 
     costs.map do |colour_key, kwh_x48|
       duos_key = "duos_#{colour_key.to_s}".to_sym
+      # fallback to 0.0 if can't find key in the rates, e.g. if using DuoS fallback
       [
         duos_key,
-        AMRData.fast_multiply_x48_x_scalar(kwh_x48, tariff[:rates][duos_key])
+        AMRData.fast_multiply_x48_x_scalar(kwh_x48, tariff[:rates][duos_key] || 0.0)
       ]
     end.to_h
   end

--- a/spec/app/models/tariffs/generic_accounting_tariff_spec.rb
+++ b/spec/app/models/tariffs/generic_accounting_tariff_spec.rb
@@ -236,10 +236,6 @@ describe GenericAccountingTariff, :aggregate_failures do
         context 'when the DuoS region is unknown' do
           let(:mpxn)  { 2_712_345_678_900 }
 
-          before do
-            allow(meter).to receive(:mpxn).and_return(2_712_345_678_900)
-          end
-
           it 'includes the zero charges as a fallback' do
             # confirm that we've omitted these costs
             expect(accounting_cost.all_costs_x48[:duos_red]).to be_nil

--- a/spec/app/models/tariffs/generic_accounting_tariff_spec.rb
+++ b/spec/app/models/tariffs/generic_accounting_tariff_spec.rb
@@ -8,6 +8,7 @@ describe GenericAccountingTariff, :aggregate_failures do
   let(:tariff_type)       { :flat }
   let(:rates)             { create_flat_rate }
   let(:kwh_data_x48)      { Array.new(48, 0.01) }
+  let(:mpxn)              { 1_512_345_678_900 }
 
   let(:tariff_attribute) do
     create_accounting_tariff_generic(start_date: start_date, end_date: end_date, type: tariff_type, rates: rates)
@@ -18,7 +19,7 @@ describe GenericAccountingTariff, :aggregate_failures do
   let(:accounting_tariff)      { described_class.new(meter, tariff_attribute) }
 
   before do
-    expect(meter).to receive(:mpxn).and_return(1_512_345_678_900)
+    expect(meter).to receive(:mpxn).and_return(mpxn)
     expect(meter).to receive(:amr_data).and_return(nil)
     expect(meter).to receive(:fuel_type).and_return(:electricity)
   end
@@ -230,6 +231,21 @@ describe GenericAccountingTariff, :aggregate_failures do
           expect(accounting_cost.all_costs_x48[:duos_red].sum).not_to be 0.0
           expect(accounting_cost.all_costs_x48[:duos_amber].sum).not_to be 0.0
           expect(accounting_cost.all_costs_x48[:duos_green].sum).not_to be 0.0
+        end
+
+        context 'when the DuoS region is unknown' do
+          let(:mpxn)  { 2_712_345_678_900 }
+
+          before do
+            allow(meter).to receive(:mpxn).and_return(2_712_345_678_900)
+          end
+
+          it 'includes the zero charges as a fallback' do
+            # confirm that we've omitted these costs
+            expect(accounting_cost.all_costs_x48[:duos_red]).to be_nil
+            expect(accounting_cost.all_costs_x48[:duos_amber]).to be_nil
+            expect(accounting_cost.all_costs_x48[:duos_green]).to be_nil
+          end
         end
       end
 


### PR DESCRIPTION
Non-domestic tariffs include additional time of use charges that vary by time of day and by Distribution Network Operator.

Our current code assumes there are only the existing geographic operators (10-23) but there are now a number of IDNOs which operate across the UK. See [list](https://www.energynetworks.org/customers/find-my-network-operator).

It looks like IDNOs may end up charging the same costs as the local DNO but this isn't 100% clear yet. We're also relying on a set of hard-codes times of day which may not longer be 100% accurate.

As we now have meters that are using an IDNO prefix we need a better fallback than just throwing an exception if we can't find a configuration. Better to omit charges on the tariffs page rather than fail to regenerate the whole school.

So this PR provides a simplistic fallback for meters associated with IDNOS. A better longer term solution will be to:

- find another way to map schools to (I)DNO, e.g. based on postcode prefix
- provide a better way to configure times of use for DUOS charges

