### PR TITLE
Rework creation of aggregate meter to apply alternate baseload calculation

### DIFF
--- a/app/models/dashboard/aggregate_meter.rb
+++ b/app/models/dashboard/aggregate_meter.rb
@@ -5,7 +5,6 @@ module Dashboard
     def initialize(meter_collection:, amr_data:, type:, identifier:, name:,
                    floor_area: nil, number_of_pupils: nil,
                    solar_pv_installation: nil,
-                   storage_heater_config: nil, # now redundant PH 20Mar2019
                    external_meter_id: nil,
                    dcc_meter: false,
                    constituent_meters: [],
@@ -18,7 +17,6 @@ module Dashboard
             floor_area:,
             number_of_pupils:,
             solar_pv_installation:,
-            storage_heater_config:,
             external_meter_id:,
             dcc_meter:,
             meter_attributes:)

--- a/app/models/dashboard/aggregate_meter.rb
+++ b/app/models/dashboard/aggregate_meter.rb
@@ -21,7 +21,7 @@ module Dashboard
             storage_heater_config:,
             external_meter_id:,
             dcc_meter:,
-            meter_attributes: {})
+            meter_attributes:)
       @constituent_meters = constituent_meters
       @has_sheffield_solar_pv = constituent_meters.any?(&:sheffield_simulated_solar_pv_panels?)
       @has_metered_solar = constituent_meters.any?(&:solar_pv_real_metering?)

--- a/app/models/dashboard/aggregate_meter.rb
+++ b/app/models/dashboard/aggregate_meter.rb
@@ -1,0 +1,48 @@
+require_rel './meter.rb'
+
+module Dashboard
+  class AggregateMeter < Meter
+    def initialize(meter_collection:, amr_data:, type:, identifier:, name:,
+                   floor_area: nil, number_of_pupils: nil,
+                   solar_pv_installation: nil,
+                   storage_heater_config: nil, # now redundant PH 20Mar2019
+                   external_meter_id: nil,
+                   dcc_meter: false,
+                   constituent_meters: [],
+                   meter_attributes: {})
+      super(meter_collection:,
+            amr_data:,
+            type:,
+            identifier:,
+            name:,
+            floor_area:,
+            number_of_pupils:,
+            solar_pv_installation:,
+            storage_heater_config:,
+            external_meter_id:,
+            dcc_meter:,
+            meter_attributes: {})
+      @constituent_meters = constituent_meters
+      @has_sheffield_solar_pv = constituent_meters.any?(&:sheffield_simulated_solar_pv_panels?)
+      @has_metered_solar = constituent_meters.any?(&:solar_pv_real_metering?)
+      add_aggregate_partial_meter_coverage_component(list_of_meters.map(&:partial_meter_coverage))
+    end
+
+    def sheffield_simulated_solar_pv_panels?
+      @has_sheffield_solar_pv || super
+    end
+
+    def solar_pv_real_metering?
+      @has_metered_solar || super
+    end
+
+    # must be called immediately after construction
+    def set_constituent_meters(list_of_meters)
+      @constituent_meters = list_of_meters
+    end
+
+    def aggregate_meter?
+      true
+    end
+  end
+end

--- a/app/models/dashboard/aggregate_meter.rb
+++ b/app/models/dashboard/aggregate_meter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_rel './meter.rb'
 
 module Dashboard
@@ -21,17 +23,15 @@ module Dashboard
             dcc_meter:,
             meter_attributes:)
       @constituent_meters = constituent_meters
-      @has_sheffield_solar_pv = constituent_meters.any?(&:sheffield_simulated_solar_pv_panels?)
-      @has_metered_solar = constituent_meters.any?(&:solar_pv_real_metering?)
       @partial_meter_coverage = partial_meter_coverage_from_meters
     end
 
     def sheffield_simulated_solar_pv_panels?
-      @has_sheffield_solar_pv
+      @sheffield_simulated_solar_pv_panels ||= constituent_meters.any?(&:sheffield_simulated_solar_pv_panels?)
     end
 
     def solar_pv_real_metering?
-      @has_metered_solar
+      @solar_pv_real_metering ||= constituent_meters.any?(&:solar_pv_real_metering?)
     end
 
     def aggregate_meter?
@@ -50,6 +50,5 @@ module Dashboard
         partial_meter_coverage_list
       end
     end
-
   end
 end

--- a/app/models/dashboard/aggregate_meter.rb
+++ b/app/models/dashboard/aggregate_meter.rb
@@ -25,24 +25,33 @@ module Dashboard
       @constituent_meters = constituent_meters
       @has_sheffield_solar_pv = constituent_meters.any?(&:sheffield_simulated_solar_pv_panels?)
       @has_metered_solar = constituent_meters.any?(&:solar_pv_real_metering?)
-      add_aggregate_partial_meter_coverage_component(list_of_meters.map(&:partial_meter_coverage))
+      @partial_meter_coverage = partial_meter_coverage_from_meters
     end
 
     def sheffield_simulated_solar_pv_panels?
-      @has_sheffield_solar_pv || super
+      @has_sheffield_solar_pv
     end
 
     def solar_pv_real_metering?
-      @has_metered_solar || super
-    end
-
-    # must be called immediately after construction
-    def set_constituent_meters(list_of_meters)
-      @constituent_meters = list_of_meters
+      @has_metered_solar
     end
 
     def aggregate_meter?
       true
     end
+
+    private
+
+    # aggregate @partial_meter_coverage meter attribute component is an array
+    # of its component meters' partial_meter_coverages
+    def partial_meter_coverage_from_meters
+      partial_meter_coverage_list = @constituent_meters.map(&:partial_meter_coverage)
+      if partial_meter_coverage_list.empty?
+        nil
+      else
+        partial_meter_coverage_list
+      end
+    end
+
   end
 end

--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -6,27 +6,21 @@ module Dashboard
 
     # Extra fields - potentially a concern or mix-in
     attr_reader :fuel_type, :meter_collection, :meter_attributes
-    attr_reader :storage_heater_setup, :sub_meters
-    attr_reader :meter_correction_rules, :model_cache
-    attr_reader :partial_meter_coverage
-    attr_reader :meter_tariffs
-    attr_reader :community_opening_times
-    attr_accessor :amr_data, :floor_area, :number_of_pupils, :solar_pv_setup, :solar_pv_overrides
-    attr_reader :constituent_meters
+    attr_reader :storage_heater_setup, :sub_meters, :meter_correction_rules, :model_cache, :partial_meter_coverage, :meter_tariffs, :community_opening_times, :constituent_meters
+    attr_accessor :amr_data, :floor_area, :number_of_pupils, :solar_pv_setup, :solar_pv_overrides, :id, :name, :external_meter_id
 
     # Energy Sparks activerecord fields:
     attr_reader :active, :created_at, :meter_type, :school, :updated_at, :mpan_mprn, :dcc_meter
-    attr_accessor :id, :name, :external_meter_id
+
     # enum meter_type: [:electricity, :gas]
 
     def initialize(meter_collection:, amr_data:, type:, identifier:, name:,
-                    floor_area: nil, number_of_pupils: nil,
-                    solar_pv_installation: nil,
-                    storage_heater_config: nil, # now redundant PH 20Mar2019
-                    external_meter_id: nil,
-                    dcc_meter: false,
-                    has_sheffield_solar_pv: false, # set for aggregate if component meters have sheffield data, for baseload calcs
-                    meter_attributes: {})
+                   floor_area: nil, number_of_pupils: nil,
+                   solar_pv_installation: nil,
+                   storage_heater_config: nil, # now redundant PH 20Mar2019
+                   external_meter_id: nil,
+                   dcc_meter: false,
+                   meter_attributes: {})
       @amr_data = amr_data
       @meter_collection = meter_collection
       @meter_type = type # think Energy Sparks variable naming is a minomer (PH,31May2018)
@@ -41,7 +35,6 @@ module Dashboard
       @sub_meters = Dashboard::SubMeters.new
       @external_meter_id = external_meter_id
       @dcc_meter = dcc_meter
-      @has_sheffield_solar_pv = has_sheffield_solar_pv
       set_meter_attributes(meter_attributes)
       @model_cache = AnalyseHeatingAndHotWater::ModelCache.new(self)
       @constituent_meters = [self]
@@ -88,6 +81,7 @@ module Dashboard
       # are against the pseudo meter, rather than the legacy individual meters
       kwh_attr = combined_meter_and_aggregate_attributes(:estimated_period_consumption).uniq
       return Float::NAN if kwh_attr.nil? || kwh_attr.empty?
+
       kwh_estimate = EstimatePeriodConsumption.new(kwh_attr)
       kwh_estimate.annual_kwh
     end
@@ -169,27 +163,27 @@ module Dashboard
     # if only one meter of that fuel type - in which case the meter is copied
     # and not aggregated - so it shouldn't get here!
     def add_aggregate_partial_meter_coverage_component(partial_meter_coverage_components)
-      if partial_meter_coverage_components.empty?
-        @partial_meter_coverage = nil
-      else
-        @partial_meter_coverage = partial_meter_coverage_components
-      end
+      @partial_meter_coverage = if partial_meter_coverage_components.empty?
+                                  nil
+                                else
+                                  partial_meter_coverage_components
+                                end
     end
 
     # Centrica
     def has_community_use?
-      # TODO check real attribute
-      mpxn.to_i % 2 == 1
+      # TODO: check real attribute
+      mpxn.to_i.odd?
     end
 
     # Centrica
     def has_exclusive_community_use?
-      # TODO check real attribute
-      mpxn.to_i % 2 == 1
+      # TODO: check real attribute
+      mpxn.to_i.odd?
     end
 
     def inspect
-      "object_id: #{"0x00%x" % (object_id << 1)}, #{self.class.name}, mpan: #{@mpan_mprn.to_s}, fuel_type: #{@fuel_type.to_s}"
+      "object_id: #{format('0x00%x', (object_id << 1))}, #{self.class.name}, mpan: #{@mpan_mprn}, fuel_type: #{@fuel_type}"
     end
 
     def to_s
@@ -208,6 +202,7 @@ module Dashboard
     def original_meter
       if solar_pv_panels? || storage_heater?
         raise MissingOriginalMainsMeter, "Missing original mains meter for #{mpxn} only got #{sub_meters&.keys}" unless sub_meters.key?(:mains_consume) && !sub_meters[:mains_consume].nil?
+
         sub_meters[:mains_consume]
       else
         self
@@ -228,8 +223,8 @@ module Dashboard
 
     def solar_pv_panels?
       sheffield_simulated_solar_pv_panels? ||
-      solar_pv_real_metering? ||
-      solar_pv_sub_meters_to_be_aggregated > 0
+        solar_pv_real_metering? ||
+        solar_pv_sub_meters_to_be_aggregated > 0
     end
 
     def first_solar_pv_panel_installation_date
@@ -237,13 +232,11 @@ module Dashboard
         @solar_pv_setup.first_installation_date
       elsif solar_pv_real_metering?
         @amr_data.start_date
-      else
-        nil
       end
     end
 
     def sheffield_simulated_solar_pv_panels?
-      @has_sheffield_solar_pv || !@solar_pv_setup.nil? && @solar_pv_setup.instance_of?(SolarPVPanels)
+      !@solar_pv_setup.nil? && @solar_pv_setup.instance_of?(SolarPVPanels)
     end
 
     def solar_pv_real_metering?
@@ -254,6 +247,7 @@ module Dashboard
     # extra meters - so this method is only valid prior to aggregation
     def solar_pv_sub_meters_to_be_aggregated
       return 0 if attributes(:solar_pv_mpan_meter_mapping).nil?
+
       attributes(:solar_pv_mpan_meter_mapping).length
     end
 
@@ -292,11 +286,11 @@ module Dashboard
     end
 
     def heat_meter?
-      [:gas, :storage_heater, :aggregated_heat].include?(fuel_type)
+      %i[gas storage_heater aggregated_heat].include?(fuel_type)
     end
 
     def electricity_meter?
-      [:electricity, :solar_pv, :aggregated_electricity].include?(fuel_type)
+      %i[electricity solar_pv aggregated_electricity].include?(fuel_type)
     end
 
     def insert_correction_rules_first(rules)
@@ -312,13 +306,13 @@ module Dashboard
       name.present? ? name : mpan_mprn.to_s
     end
 
-    #Default series name for this meter when displayed on a chart
+    # Default series name for this meter when displayed on a chart
     def series_name
       name.present? ? name : mpan_mprn.to_s
     end
 
-    #Used to create a qualified series name for charts, when 2 meters for
-    #this school have the same name.
+    # Used to create a qualified series name for charts, when 2 meters for
+    # this school have the same name.
     def qualified_series_name
       name.present? ? "#{name} (#{mpan_mprn})" : mpan_mprn.to_s
     end
@@ -331,28 +325,29 @@ module Dashboard
     end
 
     def synthetic_mpan_mprn?
-      mpan_mprn > 60000000000000
+      mpan_mprn > 60_000_000_000_000
     end
 
     def aggregate_meter?
       # TODO(PH, 14Sep2019) - Make 90000000000000 etc. masks constants
-      aggregate = 90000000000000 & mpan_mprn > 0 || 80000000000000 & mpan_mprn > 0
+      aggregate = 90_000_000_000_000 & mpan_mprn > 0 || 80_000_000_000_000 & mpan_mprn > 0
       # TODO(PH, 10Aug2021) deprecate in favour of aggregate_meter2? if continues to work
-      raise StandardError, "Unexpected inconsistency in aggregate meter logic see aggregate_meter2?" if aggregate != aggregate_meter2?
+      raise StandardError, 'Unexpected inconsistency in aggregate meter logic see aggregate_meter2?' if aggregate != aggregate_meter2?
+
       aggregate
     end
 
     def self.synthetic_combined_meter_mpan_mprn_from_urn(urn, fuel_type, group_number = 0)
-      if fuel_type == :electricity || fuel_type == :aggregated_electricity
-        90000000000000 + urn.to_i
-      elsif fuel_type == :gas || fuel_type == :aggregated_heat
-        80000000000000 + urn.to_i
+      if %i[electricity aggregated_electricity].include?(fuel_type)
+        90_000_000_000_000 + urn.to_i
+      elsif %i[gas aggregated_heat].include?(fuel_type)
+        80_000_000_000_000 + urn.to_i
       elsif fuel_type == :storage_heater # suspect as same number as solar_pv; TODO(PH, 14Sep2019)
-        70000000000000 + urn.to_i
+        70_000_000_000_000 + urn.to_i
       elsif fuel_type == :solar_pv
-        70000000000000 + urn.to_i + 1000000000000 * group_number
+        70_000_000_000_000 + urn.to_i + 1_000_000_000_000 * group_number
       elsif fuel_type == :exported_solar_pv
-        60000000000000 + urn.to_i + 1000000000000 * group_number
+        60_000_000_000_000 + urn.to_i + 1_000_000_000_000 * group_number
       else
         raise EnergySparksUnexpectedStateException.new, "Unexpected fuel_type #{fuel_type}"
       end
@@ -360,26 +355,25 @@ module Dashboard
 
     def self.synthetic_aggregate_generation_meter(base_mpan)
       mpan = base_mpan.to_i
-      prefix = (mpan / 10000000000000) * 10000000000000
-      new_mpan = 20000000000000 + (mpan - prefix)
-      new_mpan
+      prefix = (mpan / 10_000_000_000_000) * 10_000_000_000_000
+      20_000_000_000_000 + (mpan - prefix)
     end
 
     def self.synthetic_mpan_mprn(mpan_mprn, type)
       mpan_mprn = mpan_mprn.to_i
       case type
       when :storage_heater_only, :storage_heater_disaggregated_storage_heater
-        70000000000000 + mpan_mprn
+        70_000_000_000_000 + mpan_mprn
       when :electricity_minus_storage_heater, :storage_heater_disaggregated_electricity
-        75000000000000 + mpan_mprn
+        75_000_000_000_000 + mpan_mprn
       when :solar_pv
-        80000000000000 + mpan_mprn
+        80_000_000_000_000 + mpan_mprn
       else
         raise EnergySparksUnexpectedStateException.new("Unexpected type #{type} for modified mpan/mprn")
       end
     end
 
-    #Sets the default cost schedules for this meter, allowing calculation of £/co2 values
+    # Sets the default cost schedules for this meter, allowing calculation of £/co2 values
     def set_tariffs
       set_economic_tariff
       set_current_economic_tariff
@@ -420,24 +414,12 @@ module Dashboard
     end
 
     def check_fuel_type(fuel_type)
-      raise EnergySparksUnexpectedStateException.new("Unexpected fuel type #{fuel_type}") if [:electricity, :gas].include?(fuel_type)
+      raise EnergySparksUnexpectedStateException.new("Unexpected fuel type #{fuel_type}") if %i[electricity gas].include?(fuel_type)
     end
 
     def function_includes?(*function_list)
       function = attributes(:function)
       !function.nil? && !(function_list & function).empty?
-    end
-
-  end
-
-  class AggregateMeter < Meter
-    # must be called immediately after construction
-    def set_constituent_meters(list_of_meters)
-      @constituent_meters = list_of_meters
-    end
-
-    def aggregate_meter?
-      true
     end
   end
 end

--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -156,18 +156,6 @@ module Dashboard
       )
     end
 
-    # Centrica
-    def has_community_use?
-      # TODO: check real attribute
-      mpxn.to_i.odd?
-    end
-
-    # Centrica
-    def has_exclusive_community_use?
-      # TODO: check real attribute
-      mpxn.to_i.odd?
-    end
-
     def inspect
       "object_id: #{format('0x00%x', (object_id << 1))}, #{self.class.name}, mpan: #{@mpan_mprn}, fuel_type: #{@fuel_type}"
     end

--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -158,18 +158,6 @@ module Dashboard
       )
     end
 
-    # aggregate @partial_meter_coverage meter attribute component is an array
-    # of its component meters' partial_meter_coverages, or just the component
-    # if only one meter of that fuel type - in which case the meter is copied
-    # and not aggregated - so it shouldn't get here!
-    def add_aggregate_partial_meter_coverage_component(partial_meter_coverage_components)
-      @partial_meter_coverage = if partial_meter_coverage_components.empty?
-                                  nil
-                                else
-                                  partial_meter_coverage_components
-                                end
-    end
-
     # Centrica
     def has_community_use?
       # TODO: check real attribute

--- a/app/models/dashboard/meter.rb
+++ b/app/models/dashboard/meter.rb
@@ -17,7 +17,6 @@ module Dashboard
     def initialize(meter_collection:, amr_data:, type:, identifier:, name:,
                    floor_area: nil, number_of_pupils: nil,
                    solar_pv_installation: nil,
-                   storage_heater_config: nil, # now redundant PH 20Mar2019
                    external_meter_id: nil,
                    dcc_meter: false,
                    meter_attributes: {})
@@ -153,7 +152,6 @@ module Dashboard
         floor_area: meter_to_clone.floor_area,
         number_of_pupils: meter_to_clone.number_of_pupils,
         solar_pv_installation: meter_to_clone.solar_pv_setup,
-        storage_heater_config: meter_to_clone.storage_heater_setup,
         meter_attributes: meter_to_clone.meter_attributes
       )
     end

--- a/app/models/meter_collection.rb
+++ b/app/models/meter_collection.rb
@@ -106,7 +106,6 @@ class MeterCollection
       floor_area: original.floor_area,
       number_of_pupils: original.number_of_pupils,
       solar_pv_installation: original.solar_pv_setup,
-      storage_heater_config: original.storage_heater_setup,
       meter_attributes: original.meter_attributes.merge(pseudo_meter_attributes(pseudo_meter_key))
     )
   end

--- a/app/models/meter_collection.rb
+++ b/app/models/meter_collection.rb
@@ -85,6 +85,32 @@ class MeterCollection
     false
   end
 
+  # Factory method to create a new meter in this meter collection,
+  # copying values and data from an existing meter.
+  #
+  # @param Dashboard::Meter original the meter to copy
+  # @param AmrData amr_data the amr data to populate the new meter
+  # @param Symbol meter_type the type for the new meter
+  # @param String identifier the identifier for the new meter
+  # @param String name the name of the new meter
+  # @param Symbol pseudo_meter_key a symbol indicates the name of pseudo meter attributes to copy into the new meter
+  #
+  # @return Dashboard::Meter the new meter
+  def create_modified_copy_of_meter(original:, amr_data:, meter_type:, identifier:, name:, pseudo_meter_key: {})
+    Dashboard::Meter.new(
+      meter_collection: self,
+      amr_data: amr_data,
+      type: meter_type,
+      identifier: identifier,
+      name: name,
+      floor_area: original.floor_area,
+      number_of_pupils: original.number_of_pupils,
+      solar_pv_installation: original.solar_pv_setup,
+      storage_heater_config: original.storage_heater_setup,
+      meter_attributes: original.meter_attributes.merge(pseudo_meter_attributes(pseudo_meter_key))
+    )
+  end
+
   def aggregate_meter(fuel_type)
     case fuel_type
     when :electricity

--- a/app/services/aggregate_data_service.rb
+++ b/app/services/aggregate_data_service.rb
@@ -270,7 +270,6 @@ class AggregateDataService
   #
   # Otherwise (the common case) creates a new +Dashboard::AggregateMeter+.
   #
-  #
   # @param Dashboard::Meter combined_meter the existing aggregate meter, if there is one
   # @param Array list_of_meters the meters to combine
   # @param Symbol fuel_type the fuel type of the meters being aggregated
@@ -292,8 +291,6 @@ class AggregateDataService
     # Will apply rules that define how the time series are combined
     combined_amr_data = aggregate_amr_data(list_of_meters, fuel_type)
 
-    has_sheffield_solar_pv = list_of_meters.any?(&:sheffield_simulated_solar_pv_panels?)
-
     # Concatenate meter names ids and sum floor area and number of pupils
     combined_name, _, combined_floor_area, combined_pupils = combine_meter_meta_data(list_of_meters)
 
@@ -309,13 +306,9 @@ class AggregateDataService
         name: combined_name,
         floor_area: combined_floor_area,
         number_of_pupils: combined_pupils,
-        has_sheffield_solar_pv: has_sheffield_solar_pv,
+        constituent_meters: list_of_meters,
         meter_attributes: @meter_collection.pseudo_meter_attributes(Dashboard::Meter.aggregate_pseudo_meter_attribute_key(fuel_type))
       )
-
-      combined_meter.set_constituent_meters(list_of_meters)
-
-      combined_meter.add_aggregate_partial_meter_coverage_component(list_of_meters.map(&:partial_meter_coverage))
     else
       log "Combined meter #{combined_meter.mpan_mprn} already created"
       combined_meter.floor_area = combined_floor_area if combined_meter.floor_area.nil? || combined_meter.floor_area.zero?

--- a/app/services/aggregation_mixin.rb
+++ b/app/services/aggregation_mixin.rb
@@ -93,58 +93,6 @@ module AggregationMixin
 
   private
 
-  # Factory method to create a new meter, copying values and data from an existing
-  # meter. By default it instantiates a new +Dashboard::Meter+ but other classes
-  # can be provided as a parameter.
-  #
-  # Note: relies on +meter_collection+ method being available
-  #
-  # @param Dashboard::Meter meter the meter to copy
-  # @param AmrData amr_data the amr data to populate the new meter
-  # @param Symbol type the type for the new meter
-  # @param String identifier the identifier for the new meter
-  # @param String name the name of the new meter
-  # @param Symbol pseudo_meter_name a symbol indicates the name of pseudo meter attributes to copy into the new meter
-  # @param Class meter_type the class to use to instantiate the new meter
-  #
-  # @return Dashboard::Meter the new meter
-  def create_modified_meter_copy(meter, amr_data, type, identifier, name, pseudo_meter_name, meter_type = Dashboard::Meter)
-    meter_type.new(
-      meter_collection: meter_collection,
-      amr_data: amr_data,
-      type: type,
-      identifier: identifier,
-      name: name,
-      floor_area: meter.floor_area,
-      number_of_pupils: meter.number_of_pupils,
-      solar_pv_installation: meter.solar_pv_setup,
-      storage_heater_config: meter.storage_heater_setup,
-      meter_attributes: meter.meter_attributes.merge(meter_collection.pseudo_meter_attributes(pseudo_meter_name))
-    )
-  end
-
-  # Creates a new aggregate meter, by coping values from an existing meter
-  #
-  # Note: only used in +DisaggregateCommunityUsage+?
-  #
-  # @param Dashboard::Meter aggregate_meter the existing meter to copy from
-  # @param Array meters the list of meters to add to the new aggregate
-  # @param Symbol fuel_type the fuel type of the meter
-  # @param String identifier the identifier for the new meter
-  # @param String name the name of the new meter
-  # @param Symbol pseudo_meter_name a symbol indicates the name of pseudo meter attributes to copy into the new meter
-  def create_aggregate_meter(aggregate_meter, meters, fuel_type, identifier, name, pseudo_meter_name)
-    aggregate_amr_data = aggregate_amr_data_between_dates(meters, fuel_type, aggregate_meter.amr_data.start_date, aggregate_meter.amr_data.end_date, aggregate_meter.mpxn)
-
-    new_aggregate_meter = create_modified_meter_copy(aggregate_meter, aggregate_amr_data, fuel_type, identifier, name, pseudo_meter_name, Dashboard::AggregateMeter)
-
-    new_aggregate_meter.set_constituent_meters(meters)
-
-    calculate_meter_carbon_emissions_and_costs(new_aggregate_meter, fuel_type)
-
-    new_aggregate_meter
-  end
-
   # Aggregate the data associated with a list of meters, optionally ignoring any aggregation rules
   #
   # @param Array meter an array of +Dashboard::Meter+

--- a/app/services/aggregation_service_solar_pv.rb
+++ b/app/services/aggregation_service_solar_pv.rb
@@ -205,13 +205,13 @@ class AggregateDataServiceSolar
     date_range = pv_meter_map[:mains_consume].amr_data.date_range
     logger.debug { "Creating empty export meter between #{date_range.first} and #{date_range.last}" }
     amr_data = AMRData.create_empty_dataset(:exported_solar_pv, date_range.first, date_range.last, 'SOLE')
-    create_modified_meter_copy(
-      pv_meter_map[:mains_consume],
-      amr_data,
-      :exported_solar_pv,
-      Dashboard::Meter.synthetic_combined_meter_mpan_mprn_from_urn(@meter_collection.urn, :exported_solar_pv),
-      SolarPVPanels::SOLAR_PV_EXPORTED_ELECTRIC_METER_NAME,
-      :solar_pv_exported_sub_meter
+    @meter_collection.create_modified_copy_of_meter(
+      original: pv_meter_map[:mains_consume],
+      amr_data: amr_data,
+      meter_type: :exported_solar_pv,
+      identifier: Dashboard::Meter.synthetic_combined_meter_mpan_mprn_from_urn(@meter_collection.urn, :exported_solar_pv),
+      name: SolarPVPanels::SOLAR_PV_EXPORTED_ELECTRIC_METER_NAME,
+      pseudo_meter_key: :solar_pv_exported_sub_meter
     )
   end
 
@@ -234,13 +234,13 @@ class AggregateDataServiceSolar
       ignore_rules: true,
       zero_negative: true
     )
-    pv_meter_map[:self_consume] = create_modified_meter_copy(
-      pv_meter_map[:mains_consume],
-      onsite_consumpton_amr_data,
-      :solar_pv,
-      Dashboard::Meter.synthetic_combined_meter_mpan_mprn_from_urn(@meter_collection.urn, :solar_pv),
-      SolarPVPanels::SOLAR_PV_ONSITE_ELECTRIC_CONSUMPTION_METER_NAME,
-      :solar_pv_consumed_sub_meter
+    pv_meter_map[:self_consume] = @meter_collection.create_modified_copy_of_meter(
+      original: pv_meter_map[:mains_consume],
+      amr_data: onsite_consumpton_amr_data,
+      meter_type: :solar_pv,
+      identifier: Dashboard::Meter.synthetic_combined_meter_mpan_mprn_from_urn(@meter_collection.urn, :solar_pv),
+      name: SolarPVPanels::SOLAR_PV_ONSITE_ELECTRIC_CONSUMPTION_METER_NAME,
+      pseudo_meter_key: :solar_pv_consumed_sub_meter
     )
   end
 
@@ -255,13 +255,12 @@ class AggregateDataServiceSolar
       ignore_rules: true
     )
 
-    pv_meter_map[:mains_plus_self_consume] = create_modified_meter_copy(
-      pv_meter_map[:mains_consume],
-      consumpton_amr_data,
-      :electricity,
-      pv_meter_map[:mains_consume].mpan_mprn,
-      pv_meter_map[:mains_consume].name,
-      {}
+    pv_meter_map[:mains_plus_self_consume] = @meter_collection.create_modified_copy_of_meter(
+      original: pv_meter_map[:mains_consume],
+      amr_data: consumpton_amr_data,
+      meter_type: :electricity,
+      identifier: pv_meter_map[:mains_consume].mpan_mprn,
+      name: pv_meter_map[:mains_consume].name
     )
   end
 
@@ -282,13 +281,12 @@ class AggregateDataServiceSolar
       mpan
     )
 
-    generation_meter = create_modified_meter_copy(
-      pv_meter_map[:generation],
-      generation_amr_data,
-      :solar_pv,
-      mpan,
-      pv_meter_map[:generation].name,
-      {}
+    generation_meter = @meter_collection.create_modified_copy_of_meter(
+      original: pv_meter_map[:generation],
+      amr_data: generation_amr_data,
+      meter_type: :solar_pv,
+      identifier: mpan,
+      name: pv_meter_map[:generation].name
     )
 
     logger.debug { "Created aggregate generation meter #{generation_meter} #{generation_meter.amr_data.total.round(0)}" }

--- a/lib/dashboard/charting_and_reports/virtual_schools/synthetic_meter.rb
+++ b/lib/dashboard/charting_and_reports/virtual_schools/synthetic_meter.rb
@@ -11,7 +11,6 @@ class SyntheticMeter < Dashboard::Meter
       floor_area: meter_to_clone.floor_area,
       number_of_pupils: meter_to_clone.number_of_pupils,
       solar_pv_installation: meter_to_clone.solar_pv_setup,
-      storage_heater_config: meter_to_clone.storage_heater_setup,
       meter_attributes: meter_to_clone.meter_attributes
     )
   end

--- a/lib/dashboard/modelling/solar/solar_pv_panels.rb
+++ b/lib/dashboard/modelling/solar/solar_pv_panels.rb
@@ -402,7 +402,6 @@ class SolarPVPanels
       floor_area: meter_to_clone.floor_area,
       number_of_pupils: meter_to_clone.number_of_pupils,
       solar_pv_installation: meter_to_clone.solar_pv_setup,
-      storage_heater_config: meter_to_clone.storage_heater_setup,
       meter_attributes: meter_to_clone.meter_attributes.merge(meter_to_clone.meter_collection.pseudo_meter_attributes(pseudo_meter_type))
     )
   end

--- a/lib/dashboard/modelling/targeting and tracking/target_meter.rb
+++ b/lib/dashboard/modelling/targeting and tracking/target_meter.rb
@@ -20,7 +20,6 @@ class TargetMeter < Dashboard::Meter
       floor_area: meter_to_clone.floor_area,
       number_of_pupils: meter_to_clone.number_of_pupils,
       solar_pv_installation: meter_to_clone.solar_pv_setup,
-      storage_heater_config: meter_to_clone.storage_heater_setup,
       meter_attributes: meter_to_clone.meter_attributes
     )
 

--- a/script/standard/test_alerts.rb
+++ b/script/standard/test_alerts.rb
@@ -8,8 +8,8 @@ require_rel '../../test_support'
 # end
 
 # Romilly, gas
-asof_date = Date.new(2024, 3, 25)
-schools = ['r*']
+asof_date = Date.new(2025, 4, 4)
+schools = ['l*']
 
 # Mallaig, storage/electricity
 #asof_date = Date.new(2024, 4, 8)
@@ -24,7 +24,7 @@ overrides = {
   cache_school: false,
   alerts:   { alerts: nil, control: { asof_date: asof_date} },
   alerts:   { alerts: [
-#    AlertElectricityBaseloadVersusBenchmark
+    AlertElectricityBaseloadVersusBenchmark
 #    AlertThermostaticControl
 #    AlertEnergyAnnualVersusBenchmark,
 #    AlertSchoolWeekComparisonGas,
@@ -58,7 +58,7 @@ overrides = {
     #AlertEnergyAnnualVersusBenchmark,
     #AlertAdditionalPrioritisationData,
     #AlertHotWaterEfficiency
-    AlertGasHeatingHotWaterOnDuringHoliday,
+#    AlertGasHeatingHotWaterOnDuringHoliday,
 #    AlertStorageHeaterHeatingOnDuringHoliday,
 #    AlertElectricityUsageDuringCurrentHoliday
     ],

--- a/script/standard/test_charts.rb
+++ b/script/standard/test_charts.rb
@@ -8,7 +8,7 @@ module Logging
 end
 
 charts = {
-  adhoc: %i[benchmark]
+  adhoc: %i[baseload_lastyear]
 }
 
 no_charts = RunCharts.standard_charts_for_school
@@ -24,7 +24,7 @@ control = {
 }
 
 overrides = {
-  schools:  ['acc*'],
+  schools:  ['l*'],
   cache_school: false,
   charts:   { charts: charts, control: control }
 }

--- a/spec/app/models/dashboard/meter_spec.rb
+++ b/spec/app/models/dashboard/meter_spec.rb
@@ -17,7 +17,6 @@ describe Dashboard::Meter do
         floor_area: nil,
         number_of_pupils: nil,
         solar_pv_installation: nil,
-        storage_heater_config: nil,
         external_meter_id: nil,
         dcc_meter: true,
         meter_attributes: {}

--- a/spec/app/services/aggregation_service_spec.rb
+++ b/spec/app/services/aggregation_service_spec.rb
@@ -37,4 +37,96 @@ describe AggregateDataService, type: :service do
       end
     end
   end
+
+  describe '#aggregate_heat_and_electricity_meters' do
+    subject(:result) { described_class.new(meter_collection).validate_and_aggregate_meter_data }
+
+    let(:meter_collection) do
+      build(:meter_collection)
+    end
+
+    before do
+      electricity_meters.each { |meter| meter_collection.add_electricity_meter(meter) }
+    end
+
+    context 'with single electricity meter' do
+      let(:electricity_meters) do
+        [build(:meter, meter_collection: meter_collection, type: :electricity)]
+      end
+
+      it 'uses that meter as the aggregate' do
+        expect(result.aggregated_electricity_meters).to eq(electricity_meters.first)
+      end
+    end
+
+    context 'with multiple electricity meters' do
+      subject(:aggregate_meter) { result.aggregated_electricity_meters }
+
+      let(:electricity_meters) do
+        [
+          build(:meter, meter_collection: meter_collection, type: :electricity),
+          build(:meter, meter_collection: meter_collection, type: :electricity)
+        ]
+      end
+
+      it 'creates an AggregateMeter' do
+        expect(aggregate_meter).to be_a Dashboard::AggregateMeter
+        expect(aggregate_meter.constituent_meters).to eq(electricity_meters)
+        expect(aggregate_meter.mpan_mprn).to eq(Dashboard::Meter.synthetic_combined_meter_mpan_mprn_from_urn(meter_collection.urn, :electricity))
+      end
+
+      it 'correctly identifies presence of solar' do
+        expect(aggregate_meter.sheffield_simulated_solar_pv_panels?).to be(false)
+        expect(aggregate_meter.solar_pv_real_metering?).to be(false)
+      end
+
+      context 'when there is sheffield solar' do
+        let(:electricity_meters) do
+          solar_attributes = { solar_pv: [{ start_date: Date.new(2023, 1, 1), kwp: 10.0 }] }
+          [
+            build(:meter, meter_collection: meter_collection, type: :electricity, meter_attributes: solar_attributes),
+            build(:meter, meter_collection: meter_collection, type: :electricity)
+          ]
+        end
+
+        it 'correctly identifies presence of solar' do
+          expect(aggregate_meter.sheffield_simulated_solar_pv_panels?).to be(true)
+          expect(aggregate_meter.solar_pv_real_metering?).to be(false)
+        end
+      end
+
+      context 'when there is metered solar' do
+        let(:solar_production_meter) { build(:meter, meter_collection: meter_collection, type: :solar_pv) }
+        let(:solar_pv_mpan_meter_mapping) do
+          {
+            start_date: Date.new(2023, 1, 1),
+            production_mpan: solar_production_meter.mpan_mprn.to_s
+          }
+        end
+
+        let(:electricity_meters) do
+          solar_attributes = { solar_pv_mpan_meter_mapping: [solar_pv_mpan_meter_mapping] }
+          [
+            build(:meter, meter_collection: meter_collection, type: :electricity, meter_attributes: solar_attributes),
+            build(:meter, meter_collection: meter_collection, type: :electricity),
+            solar_production_meter
+          ]
+        end
+
+        it 'correctly identifies presence of solar' do
+          expect(aggregate_meter.sheffield_simulated_solar_pv_panels?).to be(false)
+          expect(aggregate_meter.solar_pv_real_metering?).to be(true)
+        end
+
+        it 'creates an AggregateMeter' do
+          expect(aggregate_meter).to be_a Dashboard::AggregateMeter
+          expect(aggregate_meter.mpan_mprn).to eq(Dashboard::Meter.synthetic_combined_meter_mpan_mprn_from_urn(meter_collection.urn, :electricity))
+        end
+
+        it 'has updated the list of electricity meters' do
+          expect(result.electricity_meters.count).to eq(2)
+        end
+      end
+    end
+  end
 end

--- a/spec/factories/meter_factory.rb
+++ b/spec/factories/meter_factory.rb
@@ -13,7 +13,6 @@ FactoryBot.define do
       floor_area              { 0 }
       number_of_pupils        { 1 }
       solar_pv_installation   { nil }
-      storage_heater_config   { nil }
       external_meter_id       { nil }
       dcc_meter               { false }
       meter_attributes        { {} }
@@ -24,7 +23,6 @@ FactoryBot.define do
           amr_data: amr_data, type: type, identifier: identifier,
           name: name, floor_area: floor_area, number_of_pupils: number_of_pupils,
           solar_pv_installation: solar_pv_installation,
-          storage_heater_config: storage_heater_config,
           external_meter_id: external_meter_id,
           dcc_meter: dcc_meter,
           meter_attributes: meter_attributes)
@@ -47,7 +45,6 @@ FactoryBot.define do
             amr_data: amr_data, type: type, identifier: identifier,
             name: name, floor_area: floor_area, number_of_pupils: number_of_pupils,
             solar_pv_installation: solar_pv_installation,
-            storage_heater_config: storage_heater_config,
             external_meter_id: external_meter_id,
             dcc_meter: dcc_meter,
             meter_attributes: { accounting_tariff_generic: [accounting_tariff] }.merge(meter_attributes))
@@ -69,7 +66,6 @@ FactoryBot.define do
             amr_data: amr_data, type: type, identifier: identifier,
             name: name, floor_area: floor_area, number_of_pupils: number_of_pupils,
             solar_pv_installation: solar_pv_installation,
-            storage_heater_config: storage_heater_config,
             external_meter_id: external_meter_id,
             dcc_meter: dcc_meter,
             meter_attributes: meter_attributes)


### PR DESCRIPTION
Aggregated electricity meters currently use the default baseload calculation, unless there's sheffield simulated data. A constructor parameter indicates the presence of simulated solar which then triggers a change in behaviour.

But we want the calculation method to change if there's either real metered OR synthetic solar, in line with the changes applied to individual meters. The functional change in this PR is to ensure that this is done correctly.

To implement that the code for creating aggregate meters has been refactored slightly to push more into the AggregateMeter subclass. Some of the code has also been simplified, removing unused methods and constructor parameters.